### PR TITLE
Fix unittest-cpp submodule link

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "unittest-cpp"]
 	path = unittest-cpp
-	url = C:\\Users\\John\\Programming\\unittest-cpp
+	url = https://github.com/unittest-cpp/unittest-cpp.git


### PR DESCRIPTION
You accidentally used a local path in the git submodule file. I fixed it to point to the proper GitHub repository.