### PR TITLE
fixed some compiler warnings

### DIFF
--- a/src/error_handler.h
+++ b/src/error_handler.h
@@ -56,8 +56,8 @@ namespace etl
     //*************************************************************************
     struct free_function : public etl::function<void, const etl::exception&>
     {
-      free_function(void (*p_function)(const etl::exception&))
-        : etl::function<void, const etl::exception&>(p_function)
+      free_function(void (*p_function_)(const etl::exception&))
+        : etl::function<void, const etl::exception&>(p_function_)
       {
       }
     };

--- a/src/exception.h
+++ b/src/exception.h
@@ -62,11 +62,11 @@ namespace etl
     //*************************************************************************
     /// Constructor.
     //*************************************************************************
-    exception(string_type reason, string_type file, numeric_type line)
-      : reason(reason),
-        line(line)
+    exception(string_type reason_, string_type file_, numeric_type line_)
+      : reason(reason_),
+        line(line_)
     {
-    (void)file;
+    (void)file_;
     }
 #endif
 

--- a/src/function.h
+++ b/src/function.h
@@ -52,6 +52,8 @@ namespace etl
   {
   public:
 
+    virtual ~ifunction() = 0;
+
     typedef TParameter parameter_type; ///< The type of parameter sent to the function.
 
     //*************************************************************************
@@ -68,6 +70,8 @@ namespace etl
   class ifunction<void>
   {
   public:
+
+    virtual ~ifunction() = 0;
 
     typedef void parameter_type; ///< The type of parameter sent to the function.
 
@@ -96,9 +100,9 @@ namespace etl
     ///\param object    Reference to the object
     ///\param p_function Pointer to the member function
     //*************************************************************************
-    function(TObject& object, void(TObject::* p_function)(TParameter))
+    function(TObject& object, void(TObject::* p_function_)(TParameter))
       : p_object(&object),
-        p_function(p_function)
+        p_function(p_function_)
     {
     }
 
@@ -133,9 +137,9 @@ namespace etl
     ///\param object   Reference to the object
     ///\param p_function Pointer to the member function
     //*************************************************************************
-    function(TObject& object, void(TObject::* p_function)(void))
+    function(TObject& object, void(TObject::* p_function_)(void))
       : p_object(&object),
-        p_function(p_function)
+        p_function(p_function_)
     {
     }
 
@@ -167,8 +171,8 @@ namespace etl
     /// Constructor.
     ///\param p_function Pointer to the function
     //*************************************************************************
-    function(void(*p_function)(TParameter))
-      : p_function(p_function)
+    function(void(*p_function_)(TParameter))
+      : p_function(p_function_)
     {
     }
 
@@ -176,7 +180,7 @@ namespace etl
     /// The function operator that calls the destination function.
     ///\param data The data to pass to the function.
     //*************************************************************************
-    virtual void operator ()(TParameter data)
+    virtual void operator ()(TParameter data) override
     {
       // Call the function with the data.
       (*p_function)(data);
@@ -208,7 +212,7 @@ namespace etl
     //*************************************************************************
     /// The function operator that calls the destination function.
     //*************************************************************************
-    virtual void operator ()()
+    virtual void operator ()() override
     {
       // Call the function.
       (*p_function)();

--- a/src/queue.h
+++ b/src/queue.h
@@ -339,9 +339,9 @@ namespace etl
     //*************************************************************************
     /// The constructor that is called from derived classes.
     //*************************************************************************
-    iqueue(T* p_buffer, size_type max_size)
+    iqueue(T* p_buffer_, size_type max_size)
       : queue_base(max_size),
-      p_buffer(p_buffer)
+      p_buffer(p_buffer_)
     {
     }
 

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -246,8 +246,8 @@ namespace etl
   /// Constructor with seed value.
   ///\param seed The new seed value.
   //***************************************************************************
-  random_lsfr::random_lsfr(uint32_t seed, uint32_t iterations)
-    : iterations(iterations)
+  random_lsfr::random_lsfr(uint32_t seed, uint32_t iterations_)
+    : iterations(iterations_)
   {
     initialise(seed);
   }

--- a/src/random.h
+++ b/src/random.h
@@ -62,9 +62,9 @@ namespace etl
 
       random_xorshift();
       explicit random_xorshift(uint32_t seed);
-      void initialise(uint32_t seed);
-      uint32_t operator()();
-      uint32_t range(uint32_t low, uint32_t high);
+      void initialise(uint32_t seed) override;
+      uint32_t operator()() override;
+      uint32_t range(uint32_t low, uint32_t high) override;
 
     private:
 
@@ -82,9 +82,9 @@ namespace etl
 
     random_lcg();
     explicit random_lcg(uint32_t seed);
-    void initialise(uint32_t seed);
-    uint32_t operator()();
-    uint32_t range(uint32_t low, uint32_t high);
+    void initialise(uint32_t seed) override;
+    uint32_t operator()() override;
+    uint32_t range(uint32_t low, uint32_t high) override;
 
   private:
 
@@ -105,9 +105,9 @@ namespace etl
 
       random_clcg();
       explicit random_clcg(uint32_t seed);
-      void initialise(uint32_t seed);
-      uint32_t operator()();
-      uint32_t range(uint32_t low, uint32_t high);
+      void initialise(uint32_t seed) override;
+      uint32_t operator()() override;
+      uint32_t range(uint32_t low, uint32_t high) override;
 
     private:
 
@@ -134,9 +134,9 @@ namespace etl
 
       explicit random_lsfr(uint32_t iterations);
       random_lsfr(uint32_t seed, uint32_t iterations);
-      void initialise(uint32_t seed);
-      uint32_t operator()();
-      uint32_t range(uint32_t low, uint32_t high);
+      void initialise(uint32_t seed) override;
+      uint32_t operator()() override;
+      uint32_t range(uint32_t low, uint32_t high) override;
 
     private:
 


### PR DESCRIPTION
Hello,
I am starting to use the etl library on an cortex-m4 target with gcc.
There are some compiler warnings that I fixed. There are probably more of them in the whole code but I just fixed what I came across so far. With this pull request I want to find out if you are interested in having those warnings fixed and if you like this style.
Those are the relevant warnings.
 - Wsuggest-override
 - Wshadow
 - Wnon-virtual-dtor

I know that those warnings could be safely ignored for these specific cases but as this is a template library it should build cleanly no matter what warnings are enabled in the application code using it.