### PR TITLE
Fixed missing changes to support strict builds.

### DIFF
--- a/src/exception.h
+++ b/src/exception.h
@@ -65,10 +65,10 @@ namespace etl
     /// Constructor.
     //*************************************************************************
     exception(string_type reason_, string_type file_, numeric_type line_)
-      : reason_text(reason),
+      : reason_text(reason_),
         line(line_)
     {
-    (void)file_text;
+    (void)file_;
     }
 #endif
 


### PR DESCRIPTION
Hi John, seems that there was a missing few changes in the exception.h file after you built support for the strict options in your last commit. 