### PR TITLE
replace usages of _DEBUG with ETL_DEBUG

### DIFF
--- a/src/flat_map.h
+++ b/src/flat_map.h
@@ -263,8 +263,8 @@ namespace etl
 
     //*********************************************************************
     /// Assigns values to the flat_map.
-    /// If ETL_THROW_EXCEPTIONS & _DEBUG are defined, emits flat_map_full if the flat_map does not have enough free space.
-    /// If ETL_THROW_EXCEPTIONS & _DEBUG are defined, emits flat_map_iterator if the iterators are reversed.
+    /// If ETL_THROW_EXCEPTIONS & ETL_DEBUG are defined, emits flat_map_full if the flat_map does not have enough free space.
+    /// If ETL_THROW_EXCEPTIONS & ETL_DEBUG are defined, emits flat_map_iterator if the iterators are reversed.
     ///\param first The iterator to the first element.
     ///\param last  The iterator to the last element + 1.
     //*********************************************************************

--- a/src/forward_list.h
+++ b/src/forward_list.h
@@ -568,7 +568,7 @@ namespace etl
     //*************************************************************************
     /// Assigns a range of values to the forward_list.
     /// If asserts or exceptions are enabled throws etl::forward_list_full if the forward_list does not have enough free space.
-    /// If ETL_THROW_EXCEPTIONS & _DEBUG are defined throws forward_list_iterator if the iterators are reversed.
+    /// If ETL_THROW_EXCEPTIONS & ETL_DEBUG are defined throws forward_list_iterator if the iterators are reversed.
     //*************************************************************************
     template <typename TIterator>
     void assign(TIterator first, TIterator last)

--- a/src/intrusive_forward_list.h
+++ b/src/intrusive_forward_list.h
@@ -147,7 +147,7 @@ namespace etl
 
     //*************************************************************************
     /// Assigns a range of values to the intrusive_forward_list.
-    /// If ETL_THROW_EXCEPTIONS & _DEBUG are defined throws forward_list_iterator if the iterators are reversed.
+    /// If ETL_THROW_EXCEPTIONS & ETL_DEBUG are defined throws forward_list_iterator if the iterators are reversed.
     //*************************************************************************
     template <typename TIterator>
     void assign(TIterator first, TIterator last)
@@ -971,7 +971,7 @@ namespace etl
     {
       if (!other.empty())
       {
-#if _DEBUG
+#if defined(ETL_DEBUG)
         ETL_ASSERT(etl::is_sorted(other.begin(), other.end(), compare), ETL_ERROR(intrusive_forward_list_unsorted));
         ETL_ASSERT(etl::is_sorted(begin(), end(), compare), ETL_ERROR(intrusive_forward_list_unsorted));
 #endif

--- a/src/intrusive_list.h
+++ b/src/intrusive_list.h
@@ -126,7 +126,7 @@ namespace etl
 
     //*************************************************************************
     /// Assigns a range of values to the intrusive_list.
-    /// If ETL_THROW_EXCEPTIONS & _DEBUG are defined emits a
+    /// If ETL_THROW_EXCEPTIONS & ETL_DEBUG are defined emits a
     /// intrusive_list_iterator_exception if the iterators are reversed.
     //*************************************************************************
     template <typename TIterator>
@@ -1020,7 +1020,7 @@ namespace etl
     {
       if (!other.empty())
       {
-#if _DEBUG
+#if defined(ETL_DEBUG)
         ETL_ASSERT(etl::is_sorted(other.begin(), other.end(), compare), ETL_ERROR(intrusive_list_unsorted));
         ETL_ASSERT(etl::is_sorted(begin(), end(), compare), ETL_ERROR(intrusive_list_unsorted));
 #endif

--- a/src/list.h
+++ b/src/list.h
@@ -706,7 +706,7 @@ namespace etl
     //*************************************************************************
     /// Assigns a range of values to the list.
     /// If asserts or exceptions are enabled throws etl::list_full if the list does not have enough free space.
-    /// If ETL_THROW_EXCEPTIONS & _DEBUG are defined throws list_iterator if the iterators are reversed.
+    /// If ETL_THROW_EXCEPTIONS & ETL_DEBUG are defined throws list_iterator if the iterators are reversed.
     //*************************************************************************
     template <typename TIterator>
     void assign(TIterator first, TIterator last)
@@ -1250,7 +1250,7 @@ namespace etl
     {
       if (!other.empty())
       {
-#if _DEBUG
+#if defined(ETL_DEBUG)
         ETL_ASSERT(etl::is_sorted(other.begin(), other.end(), compare), ETL_ERROR(list_unsorted));
         ETL_ASSERT(etl::is_sorted(begin(), end(), compare), ETL_ERROR(list_unsorted));
 #endif

--- a/src/reference_flat_map.h
+++ b/src/reference_flat_map.h
@@ -514,8 +514,8 @@ namespace etl
 
     //*********************************************************************
     /// Assigns values to the reference_flat_map.
-    /// If ETL_THROW_EXCEPTIONS & _DEBUG are defined, emits flat_map_full if the reference_flat_map does not have enough free space.
-    /// If ETL_THROW_EXCEPTIONS & _DEBUG are defined, emits flat_map_iterator if the iterators are reversed.
+    /// If ETL_THROW_EXCEPTIONS & ETL_DEBUG are defined, emits flat_map_full if the reference_flat_map does not have enough free space.
+    /// If ETL_THROW_EXCEPTIONS & ETL_DEBUG are defined, emits flat_map_iterator if the iterators are reversed.
     ///\param first The iterator to the first element.
     ///\param last  The iterator to the last element + 1.
     //*********************************************************************


### PR DESCRIPTION
fixes some -Wundef errors when _DEBUG was not defined