### PR TITLE
Fix license formatting so it will be recognized

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,8 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016 jwellbelove
-https://github.com/ETLCPP/etl
-http://www.etlcpp.com
+Copyright (c) 2016 jwellbelove, https://github.com/ETLCPP/etl, http://www.etlcpp.com
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
GitHub uses the [licensee](https://github.com/benbalter/licensee) ruby gem to detect the license type of the repository. licensee [uses](https://github.com/benbalter/licensee/blob/master/docs/what-we-look-at.md#known-licenses) the license texts from [choosealicense.com](https://choosealicense.com/) so if the text of your license file differs from their license it will not be recognized. GitHub allows [filtering searches by license type](https://blog.github.com/2017-11-03-search-repositories-by-license/) and also shows the license type on the homepage of your repository and when viewing the license page but these features are only available when the license is recognized.