### PR TITLE
Use etl/ prefixed includes in sources and tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,11 +34,8 @@ add_library(etl
   )
 target_include_directories(etl
   PUBLIC
-  include/etl
-  include/etl/atomic
+  include
   include/etl/profiles
-  PRIVATE
-  include/etl/private
   )
 
 if (${ETL_PROFILE} STREQUAL DEFAULT)

--- a/include/etl/factory.h
+++ b/include/etl/factory.h
@@ -40,7 +40,7 @@ SOFTWARE.
 #include "alignment.h"
 #include "static_assert.h"
 #include "type_lookup.h"
-#include <pool.h>
+#include "pool.h"
 
 #if defined(ETL_COMPILER_GCC)
   #warning THIS CLASS IS DEPRECATED!USE VARIANT_POOL INSTEAD.

--- a/include/etl/variant_pool.h
+++ b/include/etl/variant_pool.h
@@ -64,7 +64,7 @@ SOFTWARE.
 #include "alignment.h"
 #include "static_assert.h"
 #include "type_lookup.h"
-#include <pool.h>
+#include "pool.h"
 
 #undef ETL_FILE
 #define ETL_FILE "40"

--- a/src/binary.cpp
+++ b/src/binary.cpp
@@ -28,8 +28,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 ******************************************************************************/
 
-#include "platform.h"
-#include "binary.h"
+#include "etl/platform.h"
+#include "etl/binary.h"
 
 namespace etl
 {

--- a/src/crc16.cpp
+++ b/src/crc16.cpp
@@ -30,7 +30,7 @@ SOFTWARE.
 
 #include <stdint.h>
 
-#include "platform.h"
+#include "etl/platform.h"
 
 namespace etl
 {

--- a/src/crc16_ccitt.cpp
+++ b/src/crc16_ccitt.cpp
@@ -30,7 +30,7 @@ SOFTWARE.
 
 #include <stdint.h>
 
-#include "platform.h"
+#include "etl/platform.h"
 
 namespace etl
 {

--- a/src/crc16_kermit.cpp
+++ b/src/crc16_kermit.cpp
@@ -30,7 +30,7 @@ SOFTWARE.
 
 #include <stdint.h>
 
-#include "platform.h"
+#include "etl/platform.h"
 
 namespace etl
 {

--- a/src/crc32.cpp
+++ b/src/crc32.cpp
@@ -30,7 +30,7 @@ SOFTWARE.
 
 #include <stdint.h>
 
-#include "platform.h"
+#include "etl/platform.h"
 
 namespace etl
 {

--- a/src/crc32_c.cpp
+++ b/src/crc32_c.cpp
@@ -30,7 +30,7 @@ SOFTWARE.
 
 #include <stdint.h>
 
-#include "platform.h"
+#include "etl/platform.h"
 
 namespace etl
 {

--- a/src/crc64_ecma.cpp
+++ b/src/crc64_ecma.cpp
@@ -30,7 +30,7 @@ SOFTWARE.
 
 #include <stdint.h>
 
-#include "platform.h"
+#include "etl/platform.h"
 
 namespace etl
 {

--- a/src/crc8_ccitt.cpp
+++ b/src/crc8_ccitt.cpp
@@ -30,8 +30,8 @@ SOFTWARE.
 
 #include <stdint.h>
 
-#include "platform.h"
-#include "static_assert.h"
+#include "etl/platform.h"
+#include "etl/static_assert.h"
 
 ETL_STATIC_ASSERT(ETL_8BIT_SUPPORT, "This file does not currently support targets with no 8bit type");
 

--- a/src/error_handler.cpp
+++ b/src/error_handler.cpp
@@ -28,9 +28,9 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 ******************************************************************************/
 
-#include "platform.h"
-#include "error_handler.h"
-#include "nullptr.h"
+#include "etl/platform.h"
+#include "etl/error_handler.h"
+#include "etl/nullptr.h"
 
 //*****************************************************************************
 /// The error function callback pointer.

--- a/src/pearson.cpp
+++ b/src/pearson.cpp
@@ -30,8 +30,8 @@ SOFTWARE.
 
 #include <stdint.h>
 
-#include "platform.h"
-#include "static_assert.h"
+#include "etl/platform.h"
+#include "etl/static_assert.h"
 
 ETL_STATIC_ASSERT(ETL_8BIT_SUPPORT, "This file does not currently support targets with no 8bit type");
 

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -28,8 +28,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 ******************************************************************************/
 
-#include "platform.h"
-#include "random.h"
+#include "etl/platform.h"
+#include "etl/random.h"
 
 namespace etl
 {

--- a/test/data.h
+++ b/test/data.h
@@ -31,7 +31,7 @@ SOFTWARE.
 
 #include <ostream>
 
-#include "instance_count.h"
+#include "etl/instance_count.h"
 
 //*****************************************************************************
 // Default constructor.

--- a/test/etl_profile.h
+++ b/test/etl_profile.h
@@ -77,9 +77,9 @@ SOFTWARE.
 //#define ETL_NO_STL
 
 #ifdef _MSC_VER
-  #include "profiles/msvc_x86.h"
+  #include "etl/profiles/msvc_x86.h"
 #else
-  #include "profiles/gcc_windows_x86.h"
+  #include "etl/profiles/gcc_windows_x86.h"
 #endif
 
 #endif

--- a/test/murmurhash3.cpp
+++ b/test/murmurhash3.cpp
@@ -7,7 +7,7 @@
 // compile and run any of them on any platform, but your performance with the
 // non-native version will be less than optimal.
 
-#include "platform.h"
+#include "etl/platform.h"
 
 #ifdef ETL_COMPILER_GCC
   #pragma GCC diagnostic ignored "-Wimplicit-fallthrough"

--- a/test/murmurhash3.h
+++ b/test/murmurhash3.h
@@ -10,7 +10,7 @@
 
 // Microsoft Visual Studio
 
-#include "platform.h"
+#include "etl/platform.h"
 
 #if defined(ETL_COMPILER_MICROSOFT) && (_MSC_VER < 1600)
 

--- a/test/test_algorithm.cpp
+++ b/test/test_algorithm.cpp
@@ -28,8 +28,8 @@ SOFTWARE.
 
 #include "UnitTest++.h"
 
-#include "algorithm.h"
-#include "container.h"
+#include "etl/algorithm.h"
+#include "etl/container.h"
 
 #include <vector>
 #include <list>

--- a/test/test_alignment.cpp
+++ b/test/test_alignment.cpp
@@ -28,8 +28,8 @@ SOFTWARE.
 
 #include "UnitTest++.h"
 
-#include "alignment.h"
-#include "type_traits.h"
+#include "etl/alignment.h"
+#include "etl/type_traits.h"
 
 #include <type_traits>
 #include <utility>

--- a/test/test_array.cpp
+++ b/test/test_array.cpp
@@ -28,13 +28,13 @@ SOFTWARE.
 
 #include "UnitTest++.h"
 
-#include "array.h"
+#include "etl/array.h"
 
 #include <array>
 #include <algorithm>
 #include <iterator>
 
-#include "integral_limits.h"
+#include "etl/integral_limits.h"
 
 namespace
 {

--- a/test/test_array_view.cpp
+++ b/test/test_array_view.cpp
@@ -28,8 +28,8 @@ SOFTWARE.
 
 #include "UnitTest++.h"
 
-#include "array_view.h"
-#include "array.h"
+#include "etl/array_view.h"
+#include "etl/array.h"
 
 #include <array>
 #include <vector>

--- a/test/test_array_wrapper.cpp
+++ b/test/test_array_wrapper.cpp
@@ -28,7 +28,7 @@ SOFTWARE.
 
 #include "UnitTest++.h"
 
-#include "array_wrapper.h"
+#include "etl/array_wrapper.h"
 
 namespace
 {

--- a/test/test_atomic_gcc_sync.cpp
+++ b/test/test_atomic_gcc_sync.cpp
@@ -28,8 +28,8 @@ SOFTWARE.
 
 #include "UnitTest++.h"
 
-#include "platform.h"
-#include "atomic/atomic_std.h"
+#include "etl/platform.h"
+#include "etl/atomic/atomic_std.h"
 
 #include <atomic>
 

--- a/test/test_atomic_std.cpp
+++ b/test/test_atomic_std.cpp
@@ -28,7 +28,7 @@ SOFTWARE.
 
 #include "UnitTest++.h"
 
-#include "platform.h"
+#include "etl/platform.h"
 #include "atomic/atomic_std.h"
 
 #include <atomic>

--- a/test/test_binary.cpp
+++ b/test/test_binary.cpp
@@ -31,10 +31,10 @@ SOFTWARE.
 #include <cstdint>
 #include <type_traits>
 
-#include "binary.h"
-#include "bitset.h"
-#include "fnv_1.h"
-#include "integral_limits.h"
+#include "etl/binary.h"
+#include "etl/bitset.h"
+#include "etl/fnv_1.h"
+#include "etl/integral_limits.h"
 
 // Count bits the easy way.
 template <typename T>

--- a/test/test_bitset.cpp
+++ b/test/test_bitset.cpp
@@ -32,7 +32,7 @@ SOFTWARE.
 #include <type_traits>
 #include <bitset>
 
-#include "bitset.h"
+#include "etl/bitset.h"
 
 namespace
 {

--- a/test/test_bloom_filter.cpp
+++ b/test/test_bloom_filter.cpp
@@ -31,14 +31,14 @@ SOFTWARE.
 #include <vector>
 #include <string.h>
 
-#include "bloom_filter.h"
+#include "etl/bloom_filter.h"
 
-#include "fnv_1.h"
-#include "crc16.h"
-#include "crc16_ccitt.h"
-#include "crc32.h"
+#include "etl/fnv_1.h"
+#include "etl/crc16.h"
+#include "etl/crc16_ccitt.h"
+#include "etl/crc32.h"
 
-#include "char_traits.h"
+#include "etl/char_traits.h"
 
 struct hash1_t
 {

--- a/test/test_bsd_checksum.cpp
+++ b/test/test_bsd_checksum.cpp
@@ -33,7 +33,7 @@ SOFTWARE.
 #include <vector>
 #include <stdint.h>
 
-#include "checksum.h"
+#include "etl/checksum.h"
 
 namespace
 {

--- a/test/test_c_timer_framework.cpp
+++ b/test/test_c_timer_framework.cpp
@@ -29,7 +29,7 @@ SOFTWARE.
 #include "UnitTest++.h"
 #include "ExtraCheckMacros.h"
 
-#include "platform.h"
+#include "etl/platform.h"
 
 extern "C"
 {

--- a/test/test_callback_timer.cpp
+++ b/test/test_callback_timer.cpp
@@ -29,8 +29,8 @@ SOFTWARE.
 #include "UnitTest++.h"
 #include "ExtraCheckMacros.h"
 
-#include "callback_timer.h"
-#include "function.h"
+#include "etl/callback_timer.h"
+#include "etl/function.h"
 
 #include <iostream>
 #include <vector>

--- a/test/test_checksum.cpp
+++ b/test/test_checksum.cpp
@@ -33,7 +33,7 @@ SOFTWARE.
 #include <vector>
 #include <stdint.h>
 
-#include "checksum.h"
+#include "etl/checksum.h"
 
 namespace
 {		

--- a/test/test_compare.cpp
+++ b/test/test_compare.cpp
@@ -28,7 +28,7 @@ SOFTWARE.
 
 #include "UnitTest++.h"
 
-#include "compare.h"
+#include "etl/compare.h"
 
 namespace
 {

--- a/test/test_constant.cpp
+++ b/test/test_constant.cpp
@@ -28,8 +28,8 @@ SOFTWARE.
 
 #include "UnitTest++.h"
 
-#include "constant.h"
-#include "integral_limits.h"
+#include "etl/constant.h"
+#include "etl/integral_limits.h"
 
 #include <stdint.h>
 #include <type_traits>

--- a/test/test_container.cpp
+++ b/test/test_container.cpp
@@ -28,7 +28,7 @@ SOFTWARE.
 
 #include "UnitTest++.h"
 
-#include "container.h"
+#include "etl/container.h"
 
 #include <list>
 

--- a/test/test_crc.cpp
+++ b/test/test_crc.cpp
@@ -33,12 +33,12 @@ SOFTWARE.
 #include <vector>
 #include <stdint.h>
 
-#include "crc8_ccitt.h"
-#include "crc16.h"
-#include "crc16_ccitt.h"
-#include "crc16_kermit.h"
-#include "crc32.h"
-#include "crc64_ecma.h"
+#include "etl/crc8_ccitt.h"
+#include "etl/crc16.h"
+#include "etl/crc16_ccitt.h"
+#include "etl/crc16_kermit.h"
+#include "etl/crc32.h"
+#include "etl/crc64_ecma.h"
 
 namespace
 {

--- a/test/test_cyclic_value.cpp
+++ b/test/test_cyclic_value.cpp
@@ -30,7 +30,7 @@ SOFTWARE.
 
 #include "UnitTest++.h"
 
-#include "cyclic_value.h"
+#include "etl/cyclic_value.h"
 
 namespace
 {

--- a/test/test_debounce.cpp
+++ b/test/test_debounce.cpp
@@ -28,7 +28,7 @@ SOFTWARE.
 
 #include "UnitTest++.h"
 
-#include "debounce.h"
+#include "etl/debounce.h"
 
 namespace
 {

--- a/test/test_deque.cpp
+++ b/test/test_deque.cpp
@@ -29,7 +29,7 @@ SOFTWARE.
 #include "UnitTest++.h"
 #include "ExtraCheckMacros.h"
 
-#include "deque.h"
+#include "etl/deque.h"
 
 #include "data.h"
 

--- a/test/test_embedded_compile.cpp
+++ b/test/test_embedded_compile.cpp
@@ -1,30 +1,30 @@
 
 
-#include "algorithm.h"
-#include "alignment.h"
-#include "array.h"
-#include "bitset.h"
-#include "container.h"
-#include "crc8_ccitt.h"
-#include "crc16.h"
-#include "crc16_ccitt.h"
-#include "crc16_kermit.h"
-#include "crc32.h"
-#include "crc64_ecma.h"
-#include "cyclic_value.h"
-#include "deque.h"
-#include "io_port.h"
-#include "vector.h"
-#include "variant.h"
-#include "list.h"
-#include "map.h"
-#include "integral_limits.h"
-#include "constant.h"
+#include "etl/algorithm.h"
+#include "etl/alignment.h"
+#include "etl/array.h"
+#include "etl/bitset.h"
+#include "etl/container.h"
+#include "etl/crc8_ccitt.h"
+#include "etl/crc16.h"
+#include "etl/crc16_ccitt.h"
+#include "etl/crc16_kermit.h"
+#include "etl/crc32.h"
+#include "etl/crc64_ecma.h"
+#include "etl/cyclic_value.h"
+#include "etl/deque.h"
+#include "etl/io_port.h"
+#include "etl/vector.h"
+#include "etl/variant.h"
+#include "etl/list.h"
+#include "etl/map.h"
+#include "etl/integral_limits.h"
+#include "etl/constant.h"
 
 #include <algorithm>
 
 #if !defined(ETL_COMPILER_IAR) & !defined(ETL_COMPILER_TI)
-#include "stm32f4xx.h"
+#include "etl/stm32f4xx.h"
 #endif
 
 #if defined(COMPILER_KEIL)

--- a/test/test_endian.cpp
+++ b/test/test_endian.cpp
@@ -29,7 +29,7 @@ SOFTWARE.
 #include "UnitTest++.h"
 #include <string>
 
-#include "endianness.h"
+#include "etl/endianness.h"
 
 namespace 
 {		

--- a/test/test_enum_type.cpp
+++ b/test/test_enum_type.cpp
@@ -29,7 +29,7 @@ SOFTWARE.
 #include "UnitTest++.h"
 #include <string>
 
-#include "enum_type.h"
+#include "etl/enum_type.h"
 
 struct enum_test
 {

--- a/test/test_error_handler.cpp
+++ b/test/test_error_handler.cpp
@@ -33,8 +33,8 @@ SOFTWARE.
 #include <sstream>
 #include <string>
 
-#include "error_handler.h"
-#include "exception.h"
+#include "etl/error_handler.h"
+#include "etl/exception.h"
 
 bool error_received;
 

--- a/test/test_exception.cpp
+++ b/test/test_exception.cpp
@@ -29,7 +29,7 @@ SOFTWARE.
 #include "UnitTest++.h"
 #include <string>
 
-#include "exception.h"
+#include "etl/exception.h"
 
 namespace 
 {		

--- a/test/test_factory.cpp
+++ b/test/test_factory.cpp
@@ -29,7 +29,7 @@ SOFTWARE.
 #include "UnitTest++.h"
 #include "ExtraCheckMacros.h"
 
-#include "factory.h"
+#include "etl/factory.h"
 
 #include <string>
 #include <type_traits>

--- a/test/test_fixed_iterator.cpp
+++ b/test/test_fixed_iterator.cpp
@@ -30,7 +30,7 @@ SOFTWARE.
 #include <vector>
 #include <ostream>
 
-#include "fixed_iterator.h"
+#include "etl/fixed_iterator.h"
 
 template <typename TIterator>
 std::ostream& operator << (std::ostream& os, const etl::fixed_iterator<TIterator>& fi)

--- a/test/test_flat_map.cpp
+++ b/test/test_flat_map.cpp
@@ -40,7 +40,7 @@ SOFTWARE.
 
 #include "data.h"
 
-#include "flat_map.h"
+#include "etl/flat_map.h"
 
 namespace
 {

--- a/test/test_flat_multimap.cpp
+++ b/test/test_flat_multimap.cpp
@@ -38,7 +38,7 @@ SOFTWARE.
 
 #include "data.h"
 
-#include "flat_multimap.h"
+#include "etl/flat_multimap.h"
 
 namespace
 {

--- a/test/test_flat_multiset.cpp
+++ b/test/test_flat_multiset.cpp
@@ -38,7 +38,7 @@ SOFTWARE.
 
 #include "data.h"
 
-#include "flat_multiset.h"
+#include "etl/flat_multiset.h"
 
 namespace
 {

--- a/test/test_flat_set.cpp
+++ b/test/test_flat_set.cpp
@@ -38,7 +38,7 @@ SOFTWARE.
 
 #include "data.h"
 
-#include "flat_set.h"
+#include "etl/flat_set.h"
 
 namespace
 {

--- a/test/test_fnv_1.cpp
+++ b/test/test_fnv_1.cpp
@@ -33,7 +33,7 @@ SOFTWARE.
 #include <vector>
 #include <stdint.h>
 
-#include "fnv_1.h"
+#include "etl/fnv_1.h"
 
 namespace
 {		

--- a/test/test_forward_list.cpp
+++ b/test/test_forward_list.cpp
@@ -31,7 +31,7 @@ SOFTWARE.
 
 #include "data.h"
 
-#include "forward_list.h"
+#include "etl/forward_list.h"
 
 #include <algorithm>
 #include <array>

--- a/test/test_fsm.cpp
+++ b/test/test_fsm.cpp
@@ -28,11 +28,11 @@ SOFTWARE.
 
 #include "UnitTest++.h"
 
-#include "fsm.h"
-#include "enum_type.h"
-#include "container.h"
-#include "packet.h"
-#include "queue.h"
+#include "etl/fsm.h"
+#include "etl/enum_type.h"
+#include "etl/container.h"
+#include "etl/packet.h"
+#include "etl/queue.h"
 
 #include <iostream>
 

--- a/test/test_function.cpp
+++ b/test/test_function.cpp
@@ -28,7 +28,7 @@ SOFTWARE.
 
 #include "UnitTest++.h"
 
-#include "function.h"
+#include "etl/function.h"
 
 //*****************************************************************************
 const int VALUE = 1;

--- a/test/test_functional.cpp
+++ b/test/test_functional.cpp
@@ -28,7 +28,7 @@ SOFTWARE.
 
 #include "UnitTest++.h"
 
-#include "functional.h"
+#include "etl/functional.h"
 
 #include <list>
 #include <vector>

--- a/test/test_hash.cpp
+++ b/test/test_hash.cpp
@@ -33,7 +33,7 @@ SOFTWARE.
 #include <vector>
 #include <stdint.h>
 
-#include "hash.h"
+#include "etl/hash.h"
 
 namespace
 {

--- a/test/test_instance_count.cpp
+++ b/test/test_instance_count.cpp
@@ -28,7 +28,7 @@ SOFTWARE.
 
 #include "UnitTest++.h"
 
-#include "instance_count.h"
+#include "etl/instance_count.h"
 
 #include <list>
 #include <vector>

--- a/test/test_integral_limits.cpp
+++ b/test/test_integral_limits.cpp
@@ -32,7 +32,7 @@ SOFTWARE.
 #include <type_traits>
 #include <bitset>
 
-#include "integral_limits.h"
+#include "etl/integral_limits.h"
 
 namespace
 {

--- a/test/test_intrusive_forward_list.cpp
+++ b/test/test_intrusive_forward_list.cpp
@@ -31,7 +31,7 @@ SOFTWARE.
 
 #include "data.h"
 
-#include "intrusive_forward_list.h"
+#include "etl/intrusive_forward_list.h"
 
 #include <algorithm>
 #include <array>

--- a/test/test_intrusive_links.cpp
+++ b/test/test_intrusive_links.cpp
@@ -31,7 +31,7 @@ SOFTWARE.
 
 #include "data.h"
 
-#include "intrusive_links.h"
+#include "etl/intrusive_links.h"
 
 namespace
 {

--- a/test/test_intrusive_list.cpp
+++ b/test/test_intrusive_list.cpp
@@ -31,7 +31,7 @@ SOFTWARE.
 
 #include "data.h"
 
-#include "intrusive_list.h"
+#include "etl/intrusive_list.h"
 
 #include <algorithm>
 #include <array>

--- a/test/test_intrusive_queue.cpp
+++ b/test/test_intrusive_queue.cpp
@@ -28,8 +28,8 @@ SOFTWARE.
 
 #include "UnitTest++.h"
 
-#include "intrusive_queue.h"
-#include "intrusive_links.h"
+#include "etl/intrusive_queue.h"
+#include "etl/intrusive_links.h"
 
 #include <vector>
 

--- a/test/test_intrusive_stack.cpp
+++ b/test/test_intrusive_stack.cpp
@@ -28,8 +28,8 @@ SOFTWARE.
 
 #include "UnitTest++.h"
 
-#include "intrusive_stack.h"
-#include "intrusive_links.h"
+#include "etl/intrusive_stack.h"
+#include "etl/intrusive_links.h"
 
 #include <vector>
 

--- a/test/test_io_port.cpp
+++ b/test/test_io_port.cpp
@@ -28,7 +28,7 @@ SOFTWARE.
 
 #include "UnitTest++.h"
 
-#include "io_port.h"
+#include "etl/io_port.h"
 
 #include <stdint.h>
 #include <array>

--- a/test/test_iterator.cpp
+++ b/test/test_iterator.cpp
@@ -28,7 +28,7 @@ SOFTWARE.
 
 #include "UnitTest++.h"
 
-#include "iterator.h"
+#include "etl/iterator.h"
 
 //#include <iterator>
 

--- a/test/test_jenkins.cpp
+++ b/test/test_jenkins.cpp
@@ -33,7 +33,7 @@ SOFTWARE.
 #include <vector>
 #include <stdint.h>
 
-#include "jenkins.h"
+#include "etl/jenkins.h"
 
 template <typename TIterator>
 uint32_t jenkins(TIterator begin, TIterator end)

--- a/test/test_largest.cpp
+++ b/test/test_largest.cpp
@@ -28,7 +28,7 @@ SOFTWARE.
 
 #include "UnitTest++.h"
 
-#include "largest.h"
+#include "etl/largest.h"
 
 #include <type_traits>
 

--- a/test/test_list.cpp
+++ b/test/test_list.cpp
@@ -29,7 +29,7 @@ SOFTWARE.
 #include "UnitTest++.h"
 #include "ExtraCheckMacros.h"
 
-#include "list.h"
+#include "etl/list.h"
 
 #include "data.h"
 

--- a/test/test_map.cpp
+++ b/test/test_map.cpp
@@ -36,7 +36,7 @@ SOFTWARE.
 #include <string>
 #include <vector>
 
-#include "map.h"
+#include "etl/map.h"
 
 static const size_t MAX_SIZE = 10;
 

--- a/test/test_maths.cpp
+++ b/test/test_maths.cpp
@@ -28,13 +28,13 @@ SOFTWARE.
 
 #include "UnitTest++.h"
 
-#include "log.h"
-#include "power.h"
-#include "fibonacci.h"
-#include "factorial.h"
-#include "sqrt.h"
-#include "permutations.h"
-#include "combinations.h"
+#include "etl/log.h"
+#include "etl/power.h"
+#include "etl/fibonacci.h"
+#include "etl/factorial.h"
+#include "etl/sqrt.h"
+#include "etl/permutations.h"
+#include "etl/combinations.h"
 
 namespace
 {

--- a/test/test_memory.cpp
+++ b/test/test_memory.cpp
@@ -28,8 +28,8 @@ SOFTWARE.
 
 #include "UnitTest++.h"
 
-#include "memory.h"
-#include "debug_count.h"
+#include "etl/memory.h"
+#include "etl/debug_count.h"
 
 #include <string>
 #include <array>

--- a/test/test_message_bus.cpp
+++ b/test/test_message_bus.cpp
@@ -29,11 +29,11 @@ SOFTWARE.
 #include "UnitTest++.h"
 #include "ExtraCheckMacros.h"
 
-#include "message_router.h"
-#include "message_bus.h"
-#include "queue.h"
-#include "largest.h"
-#include "packet.h"
+#include "etl/message_router.h"
+#include "etl/message_bus.h"
+#include "etl/queue.h"
+#include "etl/largest.h"
+#include "etl/packet.h"
 
 //***************************************************************************
 // The set of messages.

--- a/test/test_message_router.cpp
+++ b/test/test_message_router.cpp
@@ -29,10 +29,10 @@ SOFTWARE.
 #include "UnitTest++.h"
 #include "ExtraCheckMacros.h"
 
-#include "message_router.h"
-#include "queue.h"
-#include "largest.h"
-#include "packet.h"
+#include "etl/message_router.h"
+#include "etl/queue.h"
+#include "etl/largest.h"
+#include "etl/packet.h"
 
 //***************************************************************************
 // The set of messages.

--- a/test/test_message_timer.cpp
+++ b/test/test_message_timer.cpp
@@ -29,9 +29,9 @@ SOFTWARE.
 #include "UnitTest++.h"
 #include "ExtraCheckMacros.h"
 
-#include "message_router.h"
-#include "message_bus.h"
-#include "message_timer.h"
+#include "etl/message_router.h"
+#include "etl/message_bus.h"
+#include "etl/message_timer.h"
 
 #include <iostream>
 #include <vector>

--- a/test/test_multimap.cpp
+++ b/test/test_multimap.cpp
@@ -35,7 +35,7 @@ SOFTWARE.
 #include <iterator>
 #include <string>
 
-#include "multimap.h"
+#include "etl/multimap.h"
 
 static const size_t MAX_SIZE = 10;
 

--- a/test/test_multiset.cpp
+++ b/test/test_multiset.cpp
@@ -35,7 +35,7 @@ SOFTWARE.
 #include <iterator>
 #include <string>
 
-#include "multiset.h"
+#include "etl/multiset.h"
 
 static const size_t MAX_SIZE = 10;
 

--- a/test/test_murmur3.cpp
+++ b/test/test_murmur3.cpp
@@ -35,7 +35,7 @@ SOFTWARE.
 #include <vector>
 #include <stdint.h>
 
-#include "murmur3.h"
+#include "etl/murmur3.h"
 
 namespace
 {		

--- a/test/test_numeric.cpp
+++ b/test/test_numeric.cpp
@@ -28,7 +28,7 @@ SOFTWARE.
 
 #include "UnitTest++.h"
 
-#include "numeric.h"
+#include "etl/numeric.h"
 
 #include <algorithm>
 #include <numeric>

--- a/test/test_observer.cpp
+++ b/test/test_observer.cpp
@@ -28,7 +28,7 @@ SOFTWARE.
 
 #include "UnitTest++.h"
 
-#include "observer.h"
+#include "etl/observer.h"
 
 //*****************************************************************************
 // Notification1

--- a/test/test_optional.cpp
+++ b/test/test_optional.cpp
@@ -31,8 +31,8 @@ SOFTWARE.
 #include <string>
 #include <ostream>
 
-#include "optional.h"
-#include "vector.h"
+#include "etl/optional.h"
+#include "etl/vector.h"
 #include "data.h"
 
 typedef TestDataNDC<std::string> Data;

--- a/test/test_packet.cpp
+++ b/test/test_packet.cpp
@@ -29,10 +29,10 @@ SOFTWARE.
 #include "UnitTest++.h"
 #include "ExtraCheckMacros.h"
 
-#include "packet.h"
-#include "largest.h"
-#include "queue.h"
-#include "pool.h"
+#include "etl/packet.h"
+#include "etl/largest.h"
+#include "etl/queue.h"
+#include "etl/pool.h"
 
 namespace
 {

--- a/test/test_parameter_type.cpp
+++ b/test/test_parameter_type.cpp
@@ -31,7 +31,7 @@ SOFTWARE.
 #include <string>
 #include <ostream>
 
-#include "parameter_type.h"
+#include "etl/parameter_type.h"
 
 namespace
 {

--- a/test/test_pearson.cpp
+++ b/test/test_pearson.cpp
@@ -34,7 +34,7 @@ SOFTWARE.
 #include <iomanip>
 #include <stdint.h>
 
-#include "pearson.h"
+#include "etl/pearson.h"
 
 const size_t HASH_SIZE = 8;
 typedef etl::pearson<HASH_SIZE>::value_type hash_t;

--- a/test/test_pool.cpp
+++ b/test/test_pool.cpp
@@ -35,8 +35,8 @@ SOFTWARE.
 #include <vector>
 #include <string>
 
-#include "pool.h"
-#include "largest.h"
+#include "etl/pool.h"
+#include "etl/largest.h"
 
 #if defined(ETL_COMPILER_GCC)
   #pragma GCC diagnostic push

--- a/test/test_priority_queue.cpp
+++ b/test/test_priority_queue.cpp
@@ -30,7 +30,7 @@ SOFTWARE.
 
 #include <queue>
 
-#include "priority_queue.h"
+#include "etl/priority_queue.h"
 
 namespace
 {

--- a/test/test_queue.cpp
+++ b/test/test_queue.cpp
@@ -30,7 +30,7 @@ SOFTWARE.
 
 #include <queue>
 
-#include "queue.h"
+#include "etl/queue.h"
 
 namespace
 {

--- a/test/test_queue_mpmc_mutex.cpp
+++ b/test/test_queue_mpmc_mutex.cpp
@@ -35,7 +35,7 @@ SOFTWARE.
 #include <atomic>
 #include <algorithm>
 
-#include "queue_mpmc_mutex.h"
+#include "etl/queue_mpmc_mutex.h"
 
 #if defined(ETL_COMPILER_MICROSOFT)
   #include <Windows.h>

--- a/test/test_queue_spsc_atomic.cpp
+++ b/test/test_queue_spsc_atomic.cpp
@@ -32,7 +32,7 @@ SOFTWARE.
 #include <chrono>
 #include <vector>
 
-#include "queue_spsc_atomic.h"
+#include "etl/queue_spsc_atomic.h"
 
 #if defined(ETL_COMPILER_MICROSOFT)
   #include <Windows.h>

--- a/test/test_queue_spsc_isr.cpp
+++ b/test/test_queue_spsc_isr.cpp
@@ -28,7 +28,7 @@ SOFTWARE.
 
 #include "UnitTest++.h"
 
-#include "queue_spsc_isr.h"
+#include "etl/queue_spsc_isr.h"
 
 #include <thread>
 #include <mutex>

--- a/test/test_random.cpp
+++ b/test/test_random.cpp
@@ -30,7 +30,7 @@ SOFTWARE.
 
 #include <stdint.h>
 
-#include "random.h"
+#include "etl/random.h"
 
 #include <vector>
 #include <algorithm>

--- a/test/test_reference_flat_map.cpp
+++ b/test/test_reference_flat_map.cpp
@@ -40,7 +40,7 @@ SOFTWARE.
 
 #include "data.h"
 
-#include "reference_flat_map.h"
+#include "etl/reference_flat_map.h"
 
 namespace
 {

--- a/test/test_reference_flat_multimap.cpp
+++ b/test/test_reference_flat_multimap.cpp
@@ -38,7 +38,7 @@ SOFTWARE.
 
 #include "data.h"
 
-#include "reference_flat_multimap.h"
+#include "etl/reference_flat_multimap.h"
 
 namespace
 {

--- a/test/test_reference_flat_multiset.cpp
+++ b/test/test_reference_flat_multiset.cpp
@@ -38,7 +38,7 @@ SOFTWARE.
 
 #include "data.h"
 
-#include "reference_flat_multiset.h"
+#include "etl/reference_flat_multiset.h"
 
 namespace
 {

--- a/test/test_reference_flat_set.cpp
+++ b/test/test_reference_flat_set.cpp
@@ -38,7 +38,7 @@ SOFTWARE.
 
 #include "data.h"
 
-#include "reference_flat_set.h"
+#include "etl/reference_flat_set.h"
 
 namespace
 {

--- a/test/test_set.cpp
+++ b/test/test_set.cpp
@@ -36,7 +36,7 @@ SOFTWARE.
 #include <string>
 #include <vector>
 
-#include "set.h"
+#include "etl/set.h"
 
 static const size_t MAX_SIZE = 10;
 

--- a/test/test_smallest.cpp
+++ b/test/test_smallest.cpp
@@ -28,7 +28,7 @@ SOFTWARE.
 
 #include "UnitTest++.h"
 
-#include "smallest.h"
+#include "etl/smallest.h"
 
 #include <type_traits>
 

--- a/test/test_stack.cpp
+++ b/test/test_stack.cpp
@@ -32,7 +32,7 @@ SOFTWARE.
 
 #include "data.h"
 
-#include "stack.h"
+#include "etl/stack.h"
 
 namespace
 {

--- a/test/test_string_char.cpp
+++ b/test/test_string_char.cpp
@@ -32,8 +32,8 @@ SOFTWARE.
 #include <array>
 #include <algorithm>
 
-#include "cstring.h"
-#include "fnv_1.h"
+#include "etl/cstring.h"
+#include "etl/fnv_1.h"
 
 #undef STR
 #define STR(x) x

--- a/test/test_string_u16.cpp
+++ b/test/test_string_u16.cpp
@@ -32,7 +32,7 @@ SOFTWARE.
 #include <array>
 #include <algorithm>
 
-#include "u16string.h"
+#include "etl/u16string.h"
 
 #undef STR
 #define STR(x) u##x

--- a/test/test_string_u32.cpp
+++ b/test/test_string_u32.cpp
@@ -32,7 +32,7 @@ SOFTWARE.
 #include <array>
 #include <algorithm>
 
-#include "u32string.h"
+#include "etl/u32string.h"
 
 #undef STR
 #define STR(x) U##x

--- a/test/test_string_view.cpp
+++ b/test/test_string_view.cpp
@@ -28,12 +28,12 @@ SOFTWARE.
 
 #include "UnitTest++.h"
 
-#include "string_view.h"
-#include "cstring.h"
-#include "wstring.h"
-#include "u16string.h"
-#include "u32string.h"
-#include "hash.h"
+#include "etl/string_view.h"
+#include "etl/cstring.h"
+#include "etl/wstring.h"
+#include "etl/u16string.h"
+#include "etl/u32string.h"
+#include "etl/hash.h"
 
 #include <algorithm>
 #include <iterator>

--- a/test/test_string_wchar_t.cpp
+++ b/test/test_string_wchar_t.cpp
@@ -32,7 +32,7 @@ SOFTWARE.
 #include <array>
 #include <algorithm>
 
-#include "wstring.h"
+#include "etl/wstring.h"
 
 #undef STR
 #define STR(x) L##x

--- a/test/test_task_scheduler.cpp
+++ b/test/test_task_scheduler.cpp
@@ -32,9 +32,9 @@ SOFTWARE.
 #include <string>
 #include <vector>
 
-#include "task.h"
-#include "scheduler.h"
-#include "container.h"
+#include "etl/task.h"
+#include "etl/scheduler.h"
+#include "etl/container.h"
 
 typedef std::vector<std::string> WorkList_t;
 

--- a/test/test_type_def.cpp
+++ b/test/test_type_def.cpp
@@ -30,7 +30,7 @@ SOFTWARE.
 
 #include <stdint.h>
 
-#include "type_def.h"
+#include "etl/type_def.h"
 
 namespace
 {

--- a/test/test_type_lookup.cpp
+++ b/test/test_type_lookup.cpp
@@ -29,7 +29,7 @@ SOFTWARE.
 #include "UnitTest++.h"
 #include "ExtraCheckMacros.h"
 
-#include "type_lookup.h"
+#include "etl/type_lookup.h"
 
 #include <type_traits>
 

--- a/test/test_type_select.cpp
+++ b/test/test_type_select.cpp
@@ -29,8 +29,8 @@ SOFTWARE.
 #include "UnitTest++.h"
 #include "ExtraCheckMacros.h"
 
-#include "type_select.h"
-#include "null_type.h"
+#include "etl/type_select.h"
+#include "etl/null_type.h"
 
 #include <type_traits>
 

--- a/test/test_type_traits.cpp
+++ b/test/test_type_traits.cpp
@@ -38,7 +38,7 @@ namespace std
 }
 #endif
 
-#include "type_traits.h"
+#include "etl/type_traits.h"
 #include <type_traits>
 
 namespace

--- a/test/test_unordered_map.cpp
+++ b/test/test_unordered_map.cpp
@@ -39,7 +39,7 @@ SOFTWARE.
 
 #include "data.h"
 
-#include "unordered_map.h"
+#include "etl/unordered_map.h"
 
 namespace
 {

--- a/test/test_unordered_multimap.cpp
+++ b/test/test_unordered_multimap.cpp
@@ -39,7 +39,7 @@ SOFTWARE.
 
 #include "data.h"
 
-#include "unordered_multimap.h"
+#include "etl/unordered_multimap.h"
 
 namespace
 {

--- a/test/test_unordered_multiset.cpp
+++ b/test/test_unordered_multiset.cpp
@@ -39,8 +39,8 @@ SOFTWARE.
 
 #include "data.h"
 
-#include "unordered_multiset.h"
-#include "checksum.h"
+#include "etl/unordered_multiset.h"
+#include "etl/checksum.h"
 
 namespace
 {

--- a/test/test_unordered_set.cpp
+++ b/test/test_unordered_set.cpp
@@ -38,8 +38,8 @@ SOFTWARE.
 
 #include "data.h"
 
-#include "unordered_set.h"
-#include "checksum.h"
+#include "etl/unordered_set.h"
+#include "etl/checksum.h"
 
 namespace
 {

--- a/test/test_user_type.cpp
+++ b/test/test_user_type.cpp
@@ -29,7 +29,7 @@ SOFTWARE.
 #include "UnitTest++.h"
 #include <string>
 
-#include "user_type.h"
+#include "etl/user_type.h"
 
 ETL_DECLARE_USER_TYPE(CompassDirection, int)
 ETL_USER_TYPE(North, 0)

--- a/test/test_utility.cpp
+++ b/test/test_utility.cpp
@@ -28,7 +28,7 @@ SOFTWARE.
 
 #include "UnitTest++.h"
 
-#include "utility.h"
+#include "etl/utility.h"
 
 namespace
 {

--- a/test/test_variant.cpp
+++ b/test/test_variant.cpp
@@ -29,7 +29,7 @@ SOFTWARE.
 #include "UnitTest++.h"
 #include "ExtraCheckMacros.h"
 
-#include "variant.h"
+#include "etl/variant.h"
 
 #include <array>
 #include <vector>

--- a/test/test_variant_pool.cpp
+++ b/test/test_variant_pool.cpp
@@ -29,7 +29,7 @@ SOFTWARE.
 #include "UnitTest++.h"
 #include "ExtraCheckMacros.h"
 
-#include "variant_pool.h"
+#include "etl/variant_pool.h"
 
 #include <string>
 #include <type_traits>

--- a/test/test_vector.cpp
+++ b/test/test_vector.cpp
@@ -33,7 +33,7 @@ SOFTWARE.
 #include <algorithm>
 #include <cstring>
 
-#include "vector.h"
+#include "etl/vector.h"
 
 namespace
 {

--- a/test/test_vector_non_trivial.cpp
+++ b/test/test_vector_non_trivial.cpp
@@ -32,7 +32,7 @@
 #include <array>
 #include <algorithm>
 
-#include "vector.h"
+#include "etl/vector.h"
 #include "data.h"
 
 namespace

--- a/test/test_vector_pointer.cpp
+++ b/test/test_vector_pointer.cpp
@@ -33,7 +33,7 @@ SOFTWARE.
 #include <algorithm>
 #include <cstring>
 
-#include "vector.h"
+#include "etl/vector.h"
 
 namespace
 {

--- a/test/test_visitor.cpp
+++ b/test/test_visitor.cpp
@@ -28,7 +28,7 @@ SOFTWARE.
 
 #include "UnitTest++.h"
 
-#include "visitor.h"
+#include "etl/visitor.h"
 
 //*****************************************************************************
 // Pre-declare the data types.

--- a/test/test_xor_checksum.cpp
+++ b/test/test_xor_checksum.cpp
@@ -33,7 +33,7 @@ SOFTWARE.
 #include <vector>
 #include <stdint.h>
 
-#include "checksum.h"
+#include "etl/checksum.h"
 
 namespace
 {

--- a/test/test_xor_rotate_checksum.cpp
+++ b/test/test_xor_rotate_checksum.cpp
@@ -33,7 +33,7 @@ SOFTWARE.
 #include <vector>
 #include <stdint.h>
 
-#include "checksum.h"
+#include "etl/checksum.h"
 
 namespace
 {


### PR DESCRIPTION
ETL is supposed to be included using #include <etl/header.h>
according to the changelog entry from Sunday, March 18, 2018.

This change updates the tests and etl source files to use
the same style.

This allows compiling etl as part of a separate project (git submodule)
using the same flags as for user code that includes etl.

Signed-off-by: Martin Sivak <mars@montik.net>

PS: I encountered many errors while compiling the test suite. Is it maintained and supposed to work with GCC 7 on Linux (Fedora 26 to be exact)?