### PR TITLE
Fix clang warnings on etl::unordered_map, etl::unordered_multimap, and etl::unordered_set

### DIFF
--- a/include/etl/unordered_map.h
+++ b/include/etl/unordered_map.h
@@ -841,7 +841,7 @@ namespace etl
     ///\param position The position to insert at.
     ///\param value    The value to insert.
     //*********************************************************************
-    iterator insert(const_iterator position, const value_type& key_value_pair)
+    iterator insert(const_iterator, const value_type& key_value_pair)
     {
       return insert(key_value_pair).first;
     }

--- a/include/etl/unordered_map.h
+++ b/include/etl/unordered_map.h
@@ -781,8 +781,6 @@ namespace etl
       bucket_t* pbucket = pbuckets + index;
       bucket_t& bucket = *pbucket;
 
-      size_t s = pbuckets->size();
-
       // The first one in the bucket?
       if (bucket.empty())
       {

--- a/include/etl/unordered_multimap.h
+++ b/include/etl/unordered_multimap.h
@@ -726,7 +726,7 @@ namespace etl
     ///\param position The position to insert at.
     ///\param value    The value to insert.
     //*********************************************************************
-    iterator insert(const_iterator position, const value_type& key_value_pair)
+    iterator insert(const_iterator, const value_type& key_value_pair)
     {
       return insert(key_value_pair);
     }

--- a/include/etl/unordered_set.h
+++ b/include/etl/unordered_set.h
@@ -725,7 +725,7 @@ namespace etl
     ///\param position The position to insert at.
     ///\param value    The value to insert.
     //*********************************************************************
-    iterator insert(const_iterator position, const value_type& key)
+    iterator insert(const_iterator, const value_type& key)
     {
       return insert(key).first;
     }


### PR DESCRIPTION
1. Fixes extra semicolon warnings
2. Suppresses unused parameter warnings
3. Fixes unused variable warnings