### PR TITLE
Add semicolon to DEBUG_COUNT definitions to fix clang extra semicolon warnings

### DIFF
--- a/include/etl/debug_count.h
+++ b/include/etl/debug_count.h
@@ -41,12 +41,12 @@ SOFTWARE.
 
 #if defined(ETL_DEBUG_COUNT)
 
-#define ETL_DECLARE_DEBUG_COUNT     etl::debug_count etl_debug_count
-#define ETL_INCREMENT_DEBUG_COUNT   ++etl_debug_count
-#define ETL_DECREMENT_DEBUG_COUNT   --etl_debug_count
-#define ETL_ADD_DEBUG_COUNT(n)      etl_debug_count += (n)
-#define ETL_SUBTRACT_DEBUG_COUNT(n) etl_debug_count -= (n)
-#define ETL_RESET_DEBUG_COUNT       etl_debug_count.clear()
+#define ETL_DECLARE_DEBUG_COUNT     etl::debug_count etl_debug_count;
+#define ETL_INCREMENT_DEBUG_COUNT   ++etl_debug_count;
+#define ETL_DECREMENT_DEBUG_COUNT   --etl_debug_count;
+#define ETL_ADD_DEBUG_COUNT(n)      etl_debug_count += (n);
+#define ETL_SUBTRACT_DEBUG_COUNT(n) etl_debug_count -= (n);
+#define ETL_RESET_DEBUG_COUNT       etl_debug_count.clear();
 
 namespace etl
 {
@@ -125,4 +125,3 @@ namespace etl
 #endif // ETL_DEBUG_COUNT
 
 #endif
-

--- a/include/etl/deque.h
+++ b/include/etl/deque.h
@@ -214,7 +214,7 @@ namespace etl
     size_type       current_size; ///< The current number of elements in the deque.
     const size_type CAPACITY;     ///< The maximum number of elements in the deque.
     const size_type BUFFER_SIZE;  ///< The number of elements in the buffer.
-    ETL_DECLARE_DEBUG_COUNT;      ///< Internal debugging.
+    ETL_DECLARE_DEBUG_COUNT       ///< Internal debugging.
   };
 
   //***************************************************************************
@@ -935,7 +935,7 @@ namespace etl
         --_begin;
         p = etl::addressof(*_begin);
         ++current_size;
-        ETL_INCREMENT_DEBUG_COUNT;
+        ETL_INCREMENT_DEBUG_COUNT
         position = _begin;
       }
       else if (insert_position == end())
@@ -943,7 +943,7 @@ namespace etl
         p = etl::addressof(*_end);
         ++_end;
         ++current_size;
-        ETL_INCREMENT_DEBUG_COUNT;
+        ETL_INCREMENT_DEBUG_COUNT
         position = _end - 1;
       }
       else
@@ -1000,7 +1000,7 @@ namespace etl
         --_begin;
         p = etl::addressof(*_begin);
         ++current_size;
-        ETL_INCREMENT_DEBUG_COUNT;
+        ETL_INCREMENT_DEBUG_COUNT
         position = _begin;
       }
       else if (insert_position == end())
@@ -1008,7 +1008,7 @@ namespace etl
         p = etl::addressof(*_end);
         ++_end;
         ++current_size;
-        ETL_INCREMENT_DEBUG_COUNT;
+        ETL_INCREMENT_DEBUG_COUNT
         position = _end - 1;
       }
       else
@@ -1065,7 +1065,7 @@ namespace etl
         --_begin;
         p = etl::addressof(*_begin);
         ++current_size;
-        ETL_INCREMENT_DEBUG_COUNT;
+        ETL_INCREMENT_DEBUG_COUNT
         position = _begin;
       }
       else if (insert_position == end())
@@ -1073,7 +1073,7 @@ namespace etl
         p = etl::addressof(*_end);
         ++_end;
         ++current_size;
-        ETL_INCREMENT_DEBUG_COUNT;
+        ETL_INCREMENT_DEBUG_COUNT
         position = _end - 1;
       }
       else
@@ -1130,7 +1130,7 @@ namespace etl
         --_begin;
         p = etl::addressof(*_begin);
         ++current_size;
-        ETL_INCREMENT_DEBUG_COUNT;
+        ETL_INCREMENT_DEBUG_COUNT
         position = _begin;
       }
       else if (insert_position == end())
@@ -1138,7 +1138,7 @@ namespace etl
         p = etl::addressof(*_end);
         ++_end;
         ++current_size;
-        ETL_INCREMENT_DEBUG_COUNT;
+        ETL_INCREMENT_DEBUG_COUNT
         position = _end - 1;
       }
       else
@@ -1538,7 +1538,7 @@ namespace etl
       ::new (&(*_end)) T(value1);
       ++_end;
       ++current_size;
-      ETL_INCREMENT_DEBUG_COUNT;
+      ETL_INCREMENT_DEBUG_COUNT
     }
 
     //*************************************************************************
@@ -1555,7 +1555,7 @@ namespace etl
       ::new (&(*_end)) T(value1, value2);
       ++_end;
       ++current_size;
-      ETL_INCREMENT_DEBUG_COUNT;
+      ETL_INCREMENT_DEBUG_COUNT
     }
 
     //*************************************************************************
@@ -1572,7 +1572,7 @@ namespace etl
       ::new (&(*_end)) T(value1, value2, value3);
       ++_end;
       ++current_size;
-      ETL_INCREMENT_DEBUG_COUNT;
+      ETL_INCREMENT_DEBUG_COUNT
     }
 
     //*************************************************************************
@@ -1589,7 +1589,7 @@ namespace etl
       ::new (&(*_end)) T(value1, value2, value3, value4);
       ++_end;
       ++current_size;
-      ETL_INCREMENT_DEBUG_COUNT;
+      ETL_INCREMENT_DEBUG_COUNT
     }
 
     //*************************************************************************
@@ -1645,7 +1645,7 @@ namespace etl
       --_begin;
       ::new (&(*_begin)) T(value1);
       ++current_size;
-      ETL_INCREMENT_DEBUG_COUNT;
+      ETL_INCREMENT_DEBUG_COUNT
     }
 
     //*************************************************************************
@@ -1662,7 +1662,7 @@ namespace etl
       --_begin;
       ::new (&(*_begin)) T(value1, value2);
       ++current_size;
-      ETL_INCREMENT_DEBUG_COUNT;
+      ETL_INCREMENT_DEBUG_COUNT
     }
 
     //*************************************************************************
@@ -1679,7 +1679,7 @@ namespace etl
       --_begin;
       ::new (&(*_begin)) T(value1, value2, value3);
       ++current_size;
-      ETL_INCREMENT_DEBUG_COUNT;
+      ETL_INCREMENT_DEBUG_COUNT
     }
 
     //*************************************************************************
@@ -1696,7 +1696,7 @@ namespace etl
       --_begin;
       ::new (&(*_begin)) T(value1, value2, value3, value4);
       ++current_size;
-      ETL_INCREMENT_DEBUG_COUNT;
+      ETL_INCREMENT_DEBUG_COUNT
     }
 
     //*************************************************************************
@@ -1811,7 +1811,7 @@ namespace etl
       if ETL_IF_CONSTEXPR(etl::is_trivially_destructible<T>::value)
       {
         current_size    = 0;
-        ETL_RESET_DEBUG_COUNT;
+        ETL_RESET_DEBUG_COUNT
       }
       else
       {
@@ -1850,7 +1850,7 @@ namespace etl
       --_begin;
       ::new (&(*_begin)) T();
       ++current_size;
-      ETL_INCREMENT_DEBUG_COUNT;
+      ETL_INCREMENT_DEBUG_COUNT
     }
 
     //*********************************************************************
@@ -1882,7 +1882,7 @@ namespace etl
         ::new (&(*item++)) T(*from);
         ++from;
         ++current_size;
-        ETL_INCREMENT_DEBUG_COUNT;
+        ETL_INCREMENT_DEBUG_COUNT
       } while (n-- != 0);
     }
 
@@ -1894,7 +1894,7 @@ namespace etl
       ::new (&(*_end)) T();
       ++_end;
       ++current_size;
-      ETL_INCREMENT_DEBUG_COUNT;
+      ETL_INCREMENT_DEBUG_COUNT
     }
 
     //*********************************************************************
@@ -1905,7 +1905,7 @@ namespace etl
       --_begin;
       ::new (&(*_begin)) T(value);
       ++current_size;
-      ETL_INCREMENT_DEBUG_COUNT;
+      ETL_INCREMENT_DEBUG_COUNT
     }
 
     //*********************************************************************
@@ -1916,7 +1916,7 @@ namespace etl
       ::new (&(*_end)) T(value);
       ++_end;
       ++current_size;
-      ETL_INCREMENT_DEBUG_COUNT;
+      ETL_INCREMENT_DEBUG_COUNT
     }
 
     //*********************************************************************
@@ -1926,7 +1926,7 @@ namespace etl
     {
       (*_begin).~T();
       --current_size;
-      ETL_DECREMENT_DEBUG_COUNT;
+      ETL_DECREMENT_DEBUG_COUNT
       ++_begin;
     }
 
@@ -1938,7 +1938,7 @@ namespace etl
       --_end;
       (*_end).~T();
       --current_size;
-      ETL_DECREMENT_DEBUG_COUNT;
+      ETL_DECREMENT_DEBUG_COUNT
     }
 
     //*************************************************************************

--- a/include/etl/flat_map.h
+++ b/include/etl/flat_map.h
@@ -236,7 +236,7 @@ namespace etl
       {
         value_type* pvalue = storage.allocate<value_type>();
         ::new (pvalue) value_type();
-        ETL_INCREMENT_DEBUG_COUNT;
+        ETL_INCREMENT_DEBUG_COUNT
 
         std::pair<iterator, bool> result = refmap_t::insert_at(i_element, *pvalue);
         i_element->second = result.first->second;
@@ -308,7 +308,7 @@ namespace etl
 
         value_type* pvalue = storage.allocate<value_type>();
         ::new (pvalue) value_type(value);
-        ETL_INCREMENT_DEBUG_COUNT;
+        ETL_INCREMENT_DEBUG_COUNT
         result = refmap_t::insert_at(i_element, *pvalue);
       }
 
@@ -369,7 +369,7 @@ namespace etl
       // Doesn't already exist?
       if ((i_element == end() || (i_element->first != key)))
       {
-        ETL_INCREMENT_DEBUG_COUNT;
+        ETL_INCREMENT_DEBUG_COUNT
         result = refmap_t::insert_at(i_element, *pvalue);
       }
       else
@@ -401,7 +401,7 @@ namespace etl
       // Doesn't already exist?
       if ((i_element == end() || (i_element->first != key)))
       {
-        ETL_INCREMENT_DEBUG_COUNT;
+        ETL_INCREMENT_DEBUG_COUNT
         result = refmap_t::insert_at(i_element, *pvalue);
       }
       else
@@ -433,7 +433,7 @@ namespace etl
       // Doesn't already exist?
       if ((i_element == end() || (i_element->first != key)))
       {
-        ETL_INCREMENT_DEBUG_COUNT;
+        ETL_INCREMENT_DEBUG_COUNT
         result = refmap_t::insert_at(i_element, *pvalue);
       }
       else
@@ -465,7 +465,7 @@ namespace etl
       // Doesn't already exist?
       if ((i_element == end() || (i_element->first != key)))
       {
-        ETL_INCREMENT_DEBUG_COUNT;
+        ETL_INCREMENT_DEBUG_COUNT
         result = refmap_t::insert_at(i_element, *pvalue);
       }
       else
@@ -497,7 +497,7 @@ namespace etl
       // Doesn't already exist?
       if ((i_element == end() || (i_element->first != key)))
       {
-        ETL_INCREMENT_DEBUG_COUNT;
+        ETL_INCREMENT_DEBUG_COUNT
         result = refmap_t::insert_at(i_element, *pvalue);
       }
       else
@@ -527,7 +527,7 @@ namespace etl
         i_element->~value_type();
         storage.release(etl::addressof(*i_element));
         refmap_t::erase(i_element);
-        ETL_DECREMENT_DEBUG_COUNT;
+        ETL_DECREMENT_DEBUG_COUNT
         return 1;
       }
     }
@@ -541,7 +541,7 @@ namespace etl
       i_element->~value_type();
       storage.release(etl::addressof(*i_element));
       refmap_t::erase(i_element);
-      ETL_DECREMENT_DEBUG_COUNT;
+      ETL_DECREMENT_DEBUG_COUNT
     }
 
     //*********************************************************************
@@ -560,7 +560,7 @@ namespace etl
         itr->~value_type();
         storage.release(etl::addressof(*itr));
         ++itr;
-        ETL_DECREMENT_DEBUG_COUNT;
+        ETL_DECREMENT_DEBUG_COUNT
       }
 
       refmap_t::erase(first, last);
@@ -587,7 +587,7 @@ namespace etl
         }
       }
 
-      ETL_RESET_DEBUG_COUNT;
+      ETL_RESET_DEBUG_COUNT
       refmap_t::clear();
     }
 
@@ -769,7 +769,7 @@ namespace etl
     TKeyCompare compare;
 
     /// Internal debugging.
-    ETL_DECLARE_DEBUG_COUNT;
+    ETL_DECLARE_DEBUG_COUNT
 
     //*************************************************************************
     /// Destructor.

--- a/include/etl/flat_multimap.h
+++ b/include/etl/flat_multimap.h
@@ -262,7 +262,7 @@ namespace etl
 
       value_type* pvalue = storage.allocate<value_type>();
       ::new (pvalue) value_type(value);
-      ETL_INCREMENT_DEBUG_COUNT;
+      ETL_INCREMENT_DEBUG_COUNT
       result = refmap_t::insert_at(i_element, *pvalue);
 
       return result;
@@ -315,7 +315,7 @@ namespace etl
       ::new ((void*)etl::addressof(pvalue->first)) key_type(key);
       ::new ((void*)etl::addressof(pvalue->second)) mapped_type(value);
       iterator i_element = lower_bound(key);
-      ETL_INCREMENT_DEBUG_COUNT;
+      ETL_INCREMENT_DEBUG_COUNT
 
       return refmap_t::insert_at(i_element, *pvalue);
     }
@@ -333,7 +333,7 @@ namespace etl
       ::new ((void*)etl::addressof(pvalue->first)) key_type(key);
       ::new ((void*)etl::addressof(pvalue->second)) mapped_type(value1);
       iterator i_element = lower_bound(key);
-      ETL_INCREMENT_DEBUG_COUNT;
+      ETL_INCREMENT_DEBUG_COUNT
 
       return refmap_t::insert_at(i_element, *pvalue);
     }
@@ -351,7 +351,7 @@ namespace etl
       ::new ((void*)etl::addressof(pvalue->first)) key_type(key);
       ::new ((void*)etl::addressof(pvalue->second)) mapped_type(value1, value2);
       iterator i_element = lower_bound(key);
-      ETL_INCREMENT_DEBUG_COUNT;
+      ETL_INCREMENT_DEBUG_COUNT
 
       return refmap_t::insert_at(i_element, *pvalue);
     }
@@ -369,7 +369,7 @@ namespace etl
       ::new ((void*)etl::addressof(pvalue->first)) key_type(key);
       ::new ((void*)etl::addressof(pvalue->second)) mapped_type(value1, value2, value3);
       iterator i_element = lower_bound(key);
-      ETL_INCREMENT_DEBUG_COUNT;
+      ETL_INCREMENT_DEBUG_COUNT
 
       return refmap_t::insert_at(i_element, *pvalue);
     }
@@ -387,7 +387,7 @@ namespace etl
       ::new ((void*)etl::addressof(pvalue->first)) key_type(key);
       ::new ((void*)etl::addressof(pvalue->second)) mapped_type(value1, value2, value3, value4);
       iterator i_element = lower_bound(key);
-      ETL_INCREMENT_DEBUG_COUNT;
+      ETL_INCREMENT_DEBUG_COUNT
 
       return refmap_t::insert_at(i_element, *pvalue);
     }
@@ -422,7 +422,7 @@ namespace etl
       i_element->~value_type();
       storage.release(etl::addressof(*i_element));
       refmap_t::erase(i_element);
-      ETL_DECREMENT_DEBUG_COUNT;
+      ETL_DECREMENT_DEBUG_COUNT
     }
 
     //*********************************************************************
@@ -441,7 +441,7 @@ namespace etl
         itr->~value_type();
         storage.release(etl::addressof(*itr));
         ++itr;
-        ETL_DECREMENT_DEBUG_COUNT;
+        ETL_DECREMENT_DEBUG_COUNT
       }
 
       refmap_t::erase(first, last);
@@ -468,7 +468,7 @@ namespace etl
         }
       }
 
-      ETL_RESET_DEBUG_COUNT;
+      ETL_RESET_DEBUG_COUNT
       refmap_t::clear();
     }
 
@@ -648,7 +648,7 @@ namespace etl
     storage_t& storage;
 
     /// Internal debugging.
-    ETL_DECLARE_DEBUG_COUNT;
+    ETL_DECLARE_DEBUG_COUNT
 
     //*************************************************************************
     /// Destructor.

--- a/include/etl/flat_multiset.h
+++ b/include/etl/flat_multiset.h
@@ -236,7 +236,7 @@ namespace etl
 
       value_type* pvalue = storage.allocate<value_type>();
       ::new (pvalue) value_type(value);
-      ETL_INCREMENT_DEBUG_COUNT;
+      ETL_INCREMENT_DEBUG_COUNT
       result = refset_t::insert_at(i_element, *pvalue);
 
       return result;
@@ -292,7 +292,7 @@ namespace etl
 
       iterator i_element = lower_bound(*pvalue);
 
-      ETL_INCREMENT_DEBUG_COUNT;
+      ETL_INCREMENT_DEBUG_COUNT
       return std::pair<iterator, bool>(refset_t::insert_at(i_element, *pvalue));
     }
 
@@ -310,7 +310,7 @@ namespace etl
 
       iterator i_element = lower_bound(*pvalue);
 
-      ETL_INCREMENT_DEBUG_COUNT;
+      ETL_INCREMENT_DEBUG_COUNT
       return std::pair<iterator, bool>(refset_t::insert_at(i_element, *pvalue));
     }
 
@@ -328,7 +328,7 @@ namespace etl
 
       iterator i_element = lower_bound(*pvalue);
 
-      ETL_INCREMENT_DEBUG_COUNT;
+      ETL_INCREMENT_DEBUG_COUNT
       return std::pair<iterator, bool>(refset_t::insert_at(i_element, *pvalue));
     }
 
@@ -346,7 +346,7 @@ namespace etl
 
       iterator i_element = lower_bound(*pvalue);
 
-      ETL_INCREMENT_DEBUG_COUNT;
+      ETL_INCREMENT_DEBUG_COUNT
       return std::pair<iterator, bool>(refset_t::insert_at(i_element, *pvalue));
     }
 
@@ -380,7 +380,7 @@ namespace etl
       etl::destroy_at(etl::addressof(*i_element));
       storage.release(etl::addressof(*i_element));
       refset_t::erase(i_element);
-      ETL_DECREMENT_DEBUG_COUNT;
+      ETL_DECREMENT_DEBUG_COUNT
     }
 
     //*********************************************************************
@@ -399,7 +399,7 @@ namespace etl
         etl::destroy_at(etl::addressof(*itr));
         storage.release(etl::addressof(*itr));
         ++itr;
-        ETL_DECREMENT_DEBUG_COUNT;
+        ETL_DECREMENT_DEBUG_COUNT
       }
 
       refset_t::erase(first, last);
@@ -426,7 +426,7 @@ namespace etl
         }
       }
 
-      ETL_RESET_DEBUG_COUNT;
+      ETL_RESET_DEBUG_COUNT
       refset_t::clear();
     }
 
@@ -608,7 +608,7 @@ namespace etl
     TKeyCompare compare;
 
     /// Internal debugging.
-    ETL_DECLARE_DEBUG_COUNT;
+    ETL_DECLARE_DEBUG_COUNT
 
     //*************************************************************************
     /// Destructor.

--- a/include/etl/flat_set.h
+++ b/include/etl/flat_set.h
@@ -239,7 +239,7 @@ namespace etl
 
         value_type* pvalue = storage.allocate<value_type>();
         ::new (pvalue) value_type(value);
-        ETL_INCREMENT_DEBUG_COUNT;
+        ETL_INCREMENT_DEBUG_COUNT
         result = refset_t::insert_at(i_element, *pvalue);
       }
 
@@ -300,7 +300,7 @@ namespace etl
       // Doesn't already exist?
       if ((i_element == end() || (*i_element != *pvalue)))
       {
-        ETL_INCREMENT_DEBUG_COUNT;
+        ETL_INCREMENT_DEBUG_COUNT
         result = refset_t::insert_at(i_element, *pvalue);
       }
       else
@@ -333,7 +333,7 @@ namespace etl
       // Doesn't already exist?
       if ((i_element == end() || (*i_element != *pvalue)))
       {
-        ETL_INCREMENT_DEBUG_COUNT;
+        ETL_INCREMENT_DEBUG_COUNT
         result = refset_t::insert_at(i_element, *pvalue);
       }
       else
@@ -366,7 +366,7 @@ namespace etl
       // Doesn't already exist?
       if ((i_element == end() || (*i_element != *pvalue)))
       {
-        ETL_INCREMENT_DEBUG_COUNT;
+        ETL_INCREMENT_DEBUG_COUNT
         result = refset_t::insert_at(i_element, *pvalue);
       }
       else
@@ -399,7 +399,7 @@ namespace etl
       // Doesn't already exist?
       if ((i_element == end() || (*i_element != *pvalue)))
       {
-        ETL_INCREMENT_DEBUG_COUNT;
+        ETL_INCREMENT_DEBUG_COUNT
         result = refset_t::insert_at(i_element, *pvalue);
       }
       else
@@ -431,7 +431,7 @@ namespace etl
         etl::destroy_at(etl::addressof(*i_element));
         storage.release(etl::addressof(*i_element));
         refset_t::erase(i_element);
-        ETL_DECREMENT_DEBUG_COUNT;
+        ETL_DECREMENT_DEBUG_COUNT
         return 1;
       }
     }
@@ -445,7 +445,7 @@ namespace etl
       etl::destroy_at(etl::addressof(*i_element));
       storage.release(etl::addressof(*i_element));
       refset_t::erase(i_element);
-      ETL_DECREMENT_DEBUG_COUNT;
+      ETL_DECREMENT_DEBUG_COUNT
     }
 
     //*********************************************************************
@@ -464,7 +464,7 @@ namespace etl
         etl::destroy_at(etl::addressof(*itr));
         storage.release(etl::addressof(*itr));
         ++itr;
-        ETL_DECREMENT_DEBUG_COUNT;
+        ETL_DECREMENT_DEBUG_COUNT
       }
 
       refset_t::erase(first, last);
@@ -488,11 +488,11 @@ namespace etl
           etl::destroy_at(etl::addressof(*itr));
           storage.release(etl::addressof(*itr));
           ++itr;
-          ETL_DECREMENT_DEBUG_COUNT;
+          ETL_DECREMENT_DEBUG_COUNT
         }
       }
 
-      ETL_RESET_DEBUG_COUNT;
+      ETL_RESET_DEBUG_COUNT
       refset_t::clear();
     }
 
@@ -674,7 +674,7 @@ namespace etl
     TKeyCompare compare;
 
     /// Internal debugging.
-    ETL_DECLARE_DEBUG_COUNT;
+    ETL_DECLARE_DEBUG_COUNT
 
     //*************************************************************************
     /// Destructor.

--- a/include/etl/forward_list.h
+++ b/include/etl/forward_list.h
@@ -278,7 +278,7 @@ namespace etl
     node_t           start_node;  ///< The node that acts as the forward_list start.
     etl::ipool*      p_node_pool; ///< The pool of data nodes used in the list.
     const size_type  MAX_SIZE;    ///< The maximum size of the forward_list.
-    ETL_DECLARE_DEBUG_COUNT;      ///< Internal debugging.
+    ETL_DECLARE_DEBUG_COUNT       ///< Internal debugging.
   };
 
   //***************************************************************************
@@ -658,7 +658,7 @@ namespace etl
 #endif
       data_node_t* p_data_node = p_node_pool->allocate<data_node_t>();
       ::new (&(p_data_node->value)) T(value1);
-      ETL_INCREMENT_DEBUG_COUNT;
+      ETL_INCREMENT_DEBUG_COUNT
       insert_node_after(start_node, *p_data_node);
     }
 
@@ -673,7 +673,7 @@ namespace etl
 #endif
       data_node_t* p_data_node = p_node_pool->allocate<data_node_t>();
       ::new (&(p_data_node->value)) T(value1, value2);
-      ETL_INCREMENT_DEBUG_COUNT;
+      ETL_INCREMENT_DEBUG_COUNT
       insert_node_after(start_node, *p_data_node);
     }
 
@@ -688,7 +688,7 @@ namespace etl
 #endif
       data_node_t* p_data_node = p_node_pool->allocate<data_node_t>();
       ::new (&(p_data_node->value)) T(value1, value2, value3);
-      ETL_INCREMENT_DEBUG_COUNT;
+      ETL_INCREMENT_DEBUG_COUNT
       insert_node_after(start_node, *p_data_node);
     }
 
@@ -703,7 +703,7 @@ namespace etl
 #endif
       data_node_t* p_data_node = p_node_pool->allocate<data_node_t>();
       ::new (&(p_data_node->value)) T(value1, value2, value3, value4);
-      ETL_INCREMENT_DEBUG_COUNT;
+      ETL_INCREMENT_DEBUG_COUNT
       insert_node_after(start_node, *p_data_node);
     }
 
@@ -793,7 +793,7 @@ namespace etl
 
       data_node_t* p_data_node = p_node_pool->allocate<data_node_t>();
       ::new (&(p_data_node->value)) T(value1);
-      ETL_INCREMENT_DEBUG_COUNT;
+      ETL_INCREMENT_DEBUG_COUNT
       insert_node_after(*position.p_node, *p_data_node);
 
       return iterator(p_data_node);
@@ -809,7 +809,7 @@ namespace etl
 
       data_node_t* p_data_node = p_node_pool->allocate<data_node_t>();
       ::new (&(p_data_node->value)) T(value1, value2);
-      ETL_INCREMENT_DEBUG_COUNT;
+      ETL_INCREMENT_DEBUG_COUNT
       insert_node_after(*position.p_node, *p_data_node);
 
       return iterator(p_data_node);
@@ -825,7 +825,7 @@ namespace etl
 
       data_node_t* p_data_node = p_node_pool->allocate<data_node_t>();
       ::new (&(p_data_node->value)) T(value1, value2, value3);
-      ETL_INCREMENT_DEBUG_COUNT;
+      ETL_INCREMENT_DEBUG_COUNT
       insert_node_after(*position.p_node, *p_data_node);
 
       return iterator(p_data_node);
@@ -841,7 +841,7 @@ namespace etl
 
       data_node_t* p_data_node = p_node_pool->allocate<data_node_t>();
       ::new (&(p_data_node->value)) T(value1, value2, value3, value4);
-      ETL_INCREMENT_DEBUG_COUNT;
+      ETL_INCREMENT_DEBUG_COUNT
       insert_node_after(*position.p_node, *p_data_node);
 
       return iterator(p_data_node);
@@ -1247,7 +1247,7 @@ namespace etl
         if ETL_IF_CONSTEXPR(etl::is_trivially_destructible<T>::value)
         {
           p_node_pool->release_all();
-          ETL_RESET_DEBUG_COUNT;
+          ETL_RESET_DEBUG_COUNT
         }
         else
         {
@@ -1326,7 +1326,7 @@ namespace etl
     {
       data_node_t* p_node = p_node_pool->allocate<data_node_t>();
       ::new (&(p_node->value)) T(value);
-      ETL_INCREMENT_DEBUG_COUNT;
+      ETL_INCREMENT_DEBUG_COUNT
 
       return *p_node;
     }
@@ -1338,7 +1338,7 @@ namespace etl
     {
       node.value.~T();
       p_node_pool->release(&node);
-      ETL_DECREMENT_DEBUG_COUNT;
+      ETL_DECREMENT_DEBUG_COUNT
     }
 
     // Disable copy construction.

--- a/include/etl/list.h
+++ b/include/etl/list.h
@@ -320,7 +320,7 @@ namespace etl
     etl::ipool*      p_node_pool;   ///< The pool of data nodes used in the list.
     node_t           terminal_node; ///< The node that acts as the list start and end.
     const size_type  MAX_SIZE;      ///< The maximum size of the list.
-    ETL_DECLARE_DEBUG_COUNT;        ///< Internal debugging.
+    ETL_DECLARE_DEBUG_COUNT         ///< Internal debugging.
   };
 
   //***************************************************************************
@@ -789,7 +789,7 @@ namespace etl
 #endif
       data_node_t* p_data_node = p_node_pool->allocate<data_node_t>();
       ::new (&(p_data_node->value)) T(value1);
-      ETL_INCREMENT_DEBUG_COUNT;
+      ETL_INCREMENT_DEBUG_COUNT
       insert_node(get_head(), *p_data_node);
     }
 
@@ -804,7 +804,7 @@ namespace etl
 #endif
       data_node_t* p_data_node = p_node_pool->allocate<data_node_t>();
       ::new (&(p_data_node->value)) T(value1, value2);
-      ETL_INCREMENT_DEBUG_COUNT;
+      ETL_INCREMENT_DEBUG_COUNT
       insert_node(get_head(), *p_data_node);
     }
 
@@ -819,7 +819,7 @@ namespace etl
 #endif
       data_node_t* p_data_node = p_node_pool->allocate<data_node_t>();
       ::new (&(p_data_node->value)) T(value1, value2, value3);
-      ETL_INCREMENT_DEBUG_COUNT;
+      ETL_INCREMENT_DEBUG_COUNT
       insert_node(get_head(), *p_data_node);
     }
 
@@ -834,7 +834,7 @@ namespace etl
 #endif
       data_node_t* p_data_node = p_node_pool->allocate<data_node_t>();
       ::new (&(p_data_node->value)) T(value1, value2, value3, value4);
-      ETL_INCREMENT_DEBUG_COUNT;
+      ETL_INCREMENT_DEBUG_COUNT
       insert_node(get_head(), *p_data_node);
     }
 
@@ -880,7 +880,7 @@ namespace etl
 #endif
       data_node_t* p_data_node = p_node_pool->allocate<data_node_t>();
       ::new (&(p_data_node->value)) T(value1);
-      ETL_INCREMENT_DEBUG_COUNT;
+      ETL_INCREMENT_DEBUG_COUNT
       insert_node(terminal_node, *p_data_node);
     }
 
@@ -895,7 +895,7 @@ namespace etl
 #endif
       data_node_t* p_data_node = p_node_pool->allocate<data_node_t>();
       ::new (&(p_data_node->value)) T(value1, value2);
-      ETL_INCREMENT_DEBUG_COUNT;
+      ETL_INCREMENT_DEBUG_COUNT
       insert_node(terminal_node, *p_data_node);
     }
 
@@ -910,7 +910,7 @@ namespace etl
 #endif
       data_node_t* p_data_node = p_node_pool->allocate<data_node_t>();
       ::new (&(p_data_node->value)) T(value1, value2, value3);
-      ETL_INCREMENT_DEBUG_COUNT;
+      ETL_INCREMENT_DEBUG_COUNT
       insert_node(terminal_node, *p_data_node);
     }
 
@@ -925,7 +925,7 @@ namespace etl
 #endif
       data_node_t* p_data_node = p_node_pool->allocate<data_node_t>();
       ::new (&(p_data_node->value)) T(value1, value2, value3, value4);
-      ETL_INCREMENT_DEBUG_COUNT;
+      ETL_INCREMENT_DEBUG_COUNT
       insert_node(terminal_node, *p_data_node);
     }
 
@@ -964,7 +964,7 @@ namespace etl
 
       data_node_t* p_data_node = p_node_pool->allocate<data_node_t>();
       ::new (&(p_data_node->value)) T(value1);
-      ETL_INCREMENT_DEBUG_COUNT;
+      ETL_INCREMENT_DEBUG_COUNT
       insert_node(*position.p_node, *p_data_node);
 
       return iterator(*p_data_node);
@@ -980,7 +980,7 @@ namespace etl
 
       data_node_t* p_data_node = p_node_pool->allocate<data_node_t>();
       ::new (&(p_data_node->value)) T(value1, value2);
-      ETL_INCREMENT_DEBUG_COUNT;
+      ETL_INCREMENT_DEBUG_COUNT
       insert_node(*position.p_node, *p_data_node);
 
       return iterator(*p_data_node);
@@ -996,7 +996,7 @@ namespace etl
 
       data_node_t* p_data_node = p_node_pool->allocate<data_node_t>();
       ::new (&(p_data_node->value)) T(value1, value2, value3);
-      ETL_INCREMENT_DEBUG_COUNT;
+      ETL_INCREMENT_DEBUG_COUNT
       insert_node(*position.p_node, *p_data_node);
 
       return iterator(*p_data_node);
@@ -1012,7 +1012,7 @@ namespace etl
 
       data_node_t* p_data_node = p_node_pool->allocate<data_node_t>();
       ::new (&(p_data_node->value)) T(value1, value2, value3, value4);
-      ETL_INCREMENT_DEBUG_COUNT;
+      ETL_INCREMENT_DEBUG_COUNT
       insert_node(*position.p_node, *p_data_node);
 
       return iterator(*p_data_node);
@@ -1456,7 +1456,7 @@ namespace etl
         if ETL_IF_CONSTEXPR(etl::is_trivially_destructible<T>::value)
         {
           p_node_pool->release_all();
-          ETL_RESET_DEBUG_COUNT;
+          ETL_RESET_DEBUG_COUNT
         }
         else
         {
@@ -1549,7 +1549,7 @@ namespace etl
     {
       data_node_t* p_data_node = p_node_pool->allocate<data_node_t>();
       ::new (&(p_data_node->value)) T(value);
-      ETL_INCREMENT_DEBUG_COUNT;
+      ETL_INCREMENT_DEBUG_COUNT
 
       return *p_data_node;
     }
@@ -1561,7 +1561,7 @@ namespace etl
     {
       node.value.~T();
       p_node_pool->release(&node);
-      ETL_DECREMENT_DEBUG_COUNT;
+      ETL_DECREMENT_DEBUG_COUNT
     }
 
     // Disable copy construction.

--- a/include/etl/map.h
+++ b/include/etl/map.h
@@ -452,7 +452,7 @@ namespace etl
     size_type current_size;   ///< The number of the used nodes.
     const size_type CAPACITY; ///< The maximum size of the map.
     Node* root_node;          ///< The node that acts as the map root.
-    ETL_DECLARE_DEBUG_COUNT;
+    ETL_DECLARE_DEBUG_COUNT
   };
 
   //***************************************************************************
@@ -1264,7 +1264,7 @@ namespace etl
     {
       Data_Node& node = *p_node_pool->allocate<Data_Node>();
       ::new (&node.value) const value_type(value);
-      ETL_INCREMENT_DEBUG_COUNT;
+      ETL_INCREMENT_DEBUG_COUNT
       return node;
     }
 
@@ -1275,7 +1275,7 @@ namespace etl
     {
       node.value.~value_type();
       p_node_pool->release(&node);
-      ETL_DECREMENT_DEBUG_COUNT;
+      ETL_DECREMENT_DEBUG_COUNT
     }
 
     //*************************************************************************

--- a/include/etl/multimap.h
+++ b/include/etl/multimap.h
@@ -609,7 +609,7 @@ namespace etl
     size_type current_size;   ///< The number of the used nodes.
     const size_type CAPACITY; ///< The maximum size of the map.
     Node* root_node;          ///< The node that acts as the multimap root.
-    ETL_DECLARE_DEBUG_COUNT;
+    ETL_DECLARE_DEBUG_COUNT
   };
 
   //***************************************************************************
@@ -1358,7 +1358,7 @@ namespace etl
     {
       Data_Node& node = *p_node_pool->allocate<Data_Node>();
       ::new (&node.value) const value_type(value);
-      ETL_INCREMENT_DEBUG_COUNT;
+      ETL_INCREMENT_DEBUG_COUNT
       return node;
     }
 
@@ -1369,7 +1369,7 @@ namespace etl
     {
       node.value.~value_type();
       p_node_pool->release(&node);
-      ETL_DECREMENT_DEBUG_COUNT;
+      ETL_DECREMENT_DEBUG_COUNT
     }
 
     //*************************************************************************

--- a/include/etl/multiset.h
+++ b/include/etl/multiset.h
@@ -609,7 +609,7 @@ namespace etl
     size_type current_size;   ///< The number of the used nodes.
     const size_type CAPACITY; ///< The maximum size of the set.
     Node* root_node;          ///< The node that acts as the multiset root.
-    ETL_DECLARE_DEBUG_COUNT;
+    ETL_DECLARE_DEBUG_COUNT
   };
 
   //***************************************************************************
@@ -1339,7 +1339,7 @@ namespace etl
     {
       Data_Node& node = *p_node_pool->allocate<Data_Node>();
       ::new ((void*)&node.value) value_type(value);
-      ETL_INCREMENT_DEBUG_COUNT;
+      ETL_INCREMENT_DEBUG_COUNT
       return node;
     }
 
@@ -1350,7 +1350,7 @@ namespace etl
     {
       node.value.~value_type();
       p_node_pool->release(&node);
-      ETL_DECREMENT_DEBUG_COUNT;
+      ETL_DECREMENT_DEBUG_COUNT
     }
 
     //*************************************************************************

--- a/include/etl/private/vector_base.h
+++ b/include/etl/private/vector_base.h
@@ -162,7 +162,7 @@ namespace etl
     }
 
     const size_type CAPACITY; ///<The maximum number of elements in the vector.
-    ETL_DECLARE_DEBUG_COUNT;  ///< Internal debugging.
+    ETL_DECLARE_DEBUG_COUNT   ///< Internal debugging.
   };
 }
 

--- a/include/etl/queue.h
+++ b/include/etl/queue.h
@@ -194,7 +194,7 @@ namespace etl
       }
 
       ++current_size;
-      ETL_INCREMENT_DEBUG_COUNT;
+      ETL_INCREMENT_DEBUG_COUNT
     }
 
     //*************************************************************************
@@ -207,7 +207,7 @@ namespace etl
         out = 0;
       }
       --current_size;
-      ETL_DECREMENT_DEBUG_COUNT;
+      ETL_DECREMENT_DEBUG_COUNT
     }
 
     //*************************************************************************
@@ -218,14 +218,14 @@ namespace etl
       in = 0;
       out = 0;
       current_size = 0;
-      ETL_RESET_DEBUG_COUNT;
+      ETL_RESET_DEBUG_COUNT
     }
 
     size_type in;            ///< Where to input new data.
     size_type out;           ///< Where to get the oldest data.
     size_type current_size;   ///< The number of items in the queue.
     const size_type CAPACITY; ///< The maximum number of items in the queue.
-    ETL_DECLARE_DEBUG_COUNT;  ///< For internal debugging purposes.
+    ETL_DECLARE_DEBUG_COUNT  ///< For internal debugging purposes.
 
   };
 

--- a/include/etl/set.h
+++ b/include/etl/set.h
@@ -446,7 +446,7 @@ namespace etl
     size_type current_size;   ///< The number of the used nodes.
     const size_type CAPACITY; ///< The maximum size of the set.
     Node* root_node;          ///< The node that acts as the set root.
-    ETL_DECLARE_DEBUG_COUNT;
+    ETL_DECLARE_DEBUG_COUNT
 
   };
 
@@ -1187,7 +1187,7 @@ namespace etl
     {
       Data_Node& node = *p_node_pool->allocate<Data_Node>();
       ::new ((void*)&node.value) value_type(value);
-      ETL_INCREMENT_DEBUG_COUNT;
+      ETL_INCREMENT_DEBUG_COUNT
       return node;
     }
 
@@ -1198,7 +1198,7 @@ namespace etl
     {
       node.value.~value_type();
       p_node_pool->release(&node);
-      ETL_DECREMENT_DEBUG_COUNT;
+      ETL_DECREMENT_DEBUG_COUNT
     }
 
     //*************************************************************************

--- a/include/etl/stack.h
+++ b/include/etl/stack.h
@@ -180,7 +180,7 @@ namespace etl
     void add_in()
     {
       top_index = current_size++;
-      ETL_INCREMENT_DEBUG_COUNT;
+      ETL_INCREMENT_DEBUG_COUNT
     }
 
     //*************************************************************************
@@ -190,7 +190,7 @@ namespace etl
     {
       --top_index;
       --current_size;
-      ETL_DECREMENT_DEBUG_COUNT;
+      ETL_DECREMENT_DEBUG_COUNT
     }
 
     //*************************************************************************
@@ -200,13 +200,13 @@ namespace etl
     {
       top_index = 0;
       current_size = 0;
-      ETL_RESET_DEBUG_COUNT;
+      ETL_RESET_DEBUG_COUNT
     }
 
     size_type top_index;      ///< The index of the top of the stack.
     size_type current_size;   ///< The number of items in the stack.
     const size_type CAPACITY; ///< The maximum number of items in the stack.
-    ETL_DECLARE_DEBUG_COUNT;  ///< For internal debugging purposes.
+    ETL_DECLARE_DEBUG_COUNT  ///< For internal debugging purposes.
   };
 
   //***************************************************************************

--- a/include/etl/unordered_map.h
+++ b/include/etl/unordered_map.h
@@ -659,7 +659,7 @@ namespace etl
       // Get a new node.
       node_t& node = *pnodepool->allocate<node_t>();
       ::new (&node.key_value_pair) value_type(key, T());
-      ETL_INCREMENT_DEBUG_COUNT;
+      ETL_INCREMENT_DEBUG_COUNT
 
       pbucket->insert_after(pbucket->before_begin(), node);
 
@@ -789,7 +789,7 @@ namespace etl
         // Get a new node.
         node_t& node = *pnodepool->allocate<node_t>();
         ::new (&node.key_value_pair) value_type(key_value_pair);
-        ETL_INCREMENT_DEBUG_COUNT;
+        ETL_INCREMENT_DEBUG_COUNT
 
         // Just add the pointer to the bucket;
         bucket.insert_after(bucket.before_begin(), node);
@@ -823,7 +823,7 @@ namespace etl
           // Get a new node.
           node_t& node = *pnodepool->allocate<node_t>();
           ::new (&node.key_value_pair) value_type(key_value_pair);
-          ETL_INCREMENT_DEBUG_COUNT;
+          ETL_INCREMENT_DEBUG_COUNT
 
           // Add the node to the end of the bucket;
           bucket.insert_after(inode_previous, node);
@@ -893,7 +893,7 @@ namespace etl
         icurrent->key_value_pair.~value_type(); // Destroy the value.
         pnodepool->release(&*icurrent);         // Release it back to the pool.
         n = 1;
-        ETL_DECREMENT_DEBUG_COUNT;
+        ETL_DECREMENT_DEBUG_COUNT
       }
 
       return n;
@@ -922,7 +922,7 @@ namespace etl
       bucket.erase_after(iprevious);          // Unlink from the bucket.
       icurrent->key_value_pair.~value_type(); // Destroy the value.
       pnodepool->release(&*icurrent);         // Release it back to the pool.
-      ETL_DECREMENT_DEBUG_COUNT;
+      ETL_DECREMENT_DEBUG_COUNT
 
       return inext;
     }
@@ -957,7 +957,7 @@ namespace etl
         local_iterator inext = pbucket->erase_after(iprevious); // Unlink from the bucket.
         icurrent->key_value_pair.~value_type(); // Destroy the value.
         pnodepool->release(&*icurrent);         // Release it back to the pool.
-        ETL_DECREMENT_DEBUG_COUNT;
+        ETL_DECREMENT_DEBUG_COUNT
 
         icurrent = inext;
 
@@ -1225,7 +1225,7 @@ namespace etl
             {
               // Destroy the value contents.
               it->key_value_pair.~value_type();
-              ETL_DECREMENT_DEBUG_COUNT;
+              ETL_DECREMENT_DEBUG_COUNT
 
               ++it;
             }
@@ -1283,7 +1283,7 @@ namespace etl
     key_equal key_equal_function;
 
     /// For library debugging purposes only.
-    ETL_DECLARE_DEBUG_COUNT;
+    ETL_DECLARE_DEBUG_COUNT
 
     //*************************************************************************
     /// Destructor.

--- a/include/etl/unordered_multimap.h
+++ b/include/etl/unordered_multimap.h
@@ -678,7 +678,7 @@ namespace etl
         // Get a new node.
         node_t& node = *pnodepool->allocate<node_t>();
         ::new (&node.key_value_pair) value_type(key_value_pair);
-        ETL_INCREMENT_DEBUG_COUNT;
+        ETL_INCREMENT_DEBUG_COUNT
 
         // Just add the pointer to the bucket;
         bucket.insert_after(bucket.before_begin(), node);
@@ -708,7 +708,7 @@ namespace etl
         // Get a new node.
         node_t& node = *pnodepool->allocate<node_t>();
         ::new (&node.key_value_pair) value_type(key_value_pair);
-        ETL_INCREMENT_DEBUG_COUNT;
+        ETL_INCREMENT_DEBUG_COUNT
 
         // Add the node to the end of the bucket;
         bucket.insert_after(inode_previous, node);
@@ -771,7 +771,7 @@ namespace etl
           pnodepool->release(&*icurrent);         // Release it back to the pool.
           ++n;
           icurrent = iprevious;
-          ETL_DECREMENT_DEBUG_COUNT;
+          ETL_DECREMENT_DEBUG_COUNT
         }
         else
         {
@@ -807,7 +807,7 @@ namespace etl
       bucket.erase_after(iprevious);          // Unlink from the bucket.
       icurrent->key_value_pair.~value_type(); // Destroy the value.
       pnodepool->release(&*icurrent);         // Release it back to the pool.
-      ETL_DECREMENT_DEBUG_COUNT;
+      ETL_DECREMENT_DEBUG_COUNT
 
       return inext;
     }
@@ -842,7 +842,7 @@ namespace etl
         local_iterator inext = pbucket->erase_after(iprevious); // Unlink from the bucket.
         icurrent->key_value_pair.~value_type(); // Destroy the value.
         pnodepool->release(&*icurrent);         // Release it back to the pool.
-        ETL_DECREMENT_DEBUG_COUNT;
+        ETL_DECREMENT_DEBUG_COUNT
 
         icurrent = inext;
 
@@ -1137,7 +1137,7 @@ namespace etl
               // Destroy the value contents.
               it->key_value_pair.~value_type();
               ++it;
-              ETL_DECREMENT_DEBUG_COUNT;
+              ETL_DECREMENT_DEBUG_COUNT
             }
 
             // Now it's safe to clear the bucket.
@@ -1193,7 +1193,7 @@ namespace etl
     key_equal key_equal_function;
 
     /// For library debugging purposes only.
-    ETL_DECLARE_DEBUG_COUNT;
+    ETL_DECLARE_DEBUG_COUNT
 
     //*************************************************************************
     /// Destructor.

--- a/include/etl/unordered_multiset.h
+++ b/include/etl/unordered_multiset.h
@@ -670,7 +670,7 @@ namespace etl
         // Get a new node.
         node_t& node = *pnodepool->allocate<node_t>();
         ::new (&node.key) value_type(key);
-        ETL_INCREMENT_DEBUG_COUNT;
+        ETL_INCREMENT_DEBUG_COUNT
 
         // Just add the pointer to the bucket;
         bucket.insert_after(bucket.before_begin(), node);
@@ -701,7 +701,7 @@ namespace etl
         // Get a new node.
         node_t& node = *pnodepool->allocate<node_t>();
         ::new (&node.key) value_type(key);
-        ETL_INCREMENT_DEBUG_COUNT;
+        ETL_INCREMENT_DEBUG_COUNT
 
         // Add the node to the end of the bucket;
         bucket.insert_after(inode_previous, node);
@@ -765,7 +765,7 @@ namespace etl
           pnodepool->release(&*icurrent); // Release it back to the pool.
           ++n;
           icurrent = iprevious;
-          ETL_DECREMENT_DEBUG_COUNT;
+          ETL_DECREMENT_DEBUG_COUNT
         }
         else
         {
@@ -801,7 +801,7 @@ namespace etl
       bucket.erase_after(iprevious);  // Unlink from the bucket.
       icurrent->key.~value_type();    // Destroy the value.
       pnodepool->release(&*icurrent); // Release it back to the pool.
-      ETL_DECREMENT_DEBUG_COUNT;
+      ETL_DECREMENT_DEBUG_COUNT
 
       return inext;
     }
@@ -836,7 +836,7 @@ namespace etl
         local_iterator inext = pbucket->erase_after(iprevious); // Unlink from the bucket.
         icurrent->key.~value_type();    // Destroy the value.
         pnodepool->release(&*icurrent); // Release it back to the pool.
-        ETL_DECREMENT_DEBUG_COUNT;
+        ETL_DECREMENT_DEBUG_COUNT
 
         icurrent = inext;
 
@@ -1131,7 +1131,7 @@ namespace etl
               // Destroy the value contents.
               it->key.~value_type();
               ++it;
-              ETL_DECREMENT_DEBUG_COUNT;
+              ETL_DECREMENT_DEBUG_COUNT
             }
 
             // Now it's safe to clear the bucket.
@@ -1187,7 +1187,7 @@ namespace etl
     key_equal key_equal_function;
 
     /// For library debugging purposes only.
-    ETL_DECLARE_DEBUG_COUNT;
+    ETL_DECLARE_DEBUG_COUNT
 
     //*************************************************************************
     /// Destructor.

--- a/include/etl/unordered_set.h
+++ b/include/etl/unordered_set.h
@@ -671,7 +671,7 @@ namespace etl
         // Get a new node.
         node_t& node = *pnodepool->allocate<node_t>();
         ::new (&node.key) value_type(key);
-        ETL_INCREMENT_DEBUG_COUNT;
+        ETL_INCREMENT_DEBUG_COUNT
 
         // Just add the pointer to the bucket;
         bucket.insert_after(bucket.before_begin(), node);
@@ -705,7 +705,7 @@ namespace etl
           // Get a new node.
           node_t& node = *pnodepool->allocate<node_t>();
           ::new (&node.key) value_type(key);
-          ETL_INCREMENT_DEBUG_COUNT;
+          ETL_INCREMENT_DEBUG_COUNT
 
           // Add the node to the end of the bucket;
           bucket.insert_after(inode_previous, node);
@@ -775,7 +775,7 @@ namespace etl
         icurrent->key.~value_type();    // Destroy the value.
         pnodepool->release(&*icurrent); // Release it back to the pool.
         n = 1;
-        ETL_DECREMENT_DEBUG_COUNT;
+        ETL_DECREMENT_DEBUG_COUNT
       }
 
       return n;
@@ -804,7 +804,7 @@ namespace etl
       bucket.erase_after(iprevious);  // Unlink from the bucket.
       icurrent->key.~value_type();    // Destroy the value.
       pnodepool->release(&*icurrent); // Release it back to the pool.
-      ETL_DECREMENT_DEBUG_COUNT;
+      ETL_DECREMENT_DEBUG_COUNT
 
       return inext;
     }
@@ -839,7 +839,7 @@ namespace etl
         local_iterator inext = pbucket->erase_after(iprevious); // Unlink from the bucket.
         icurrent->key.~value_type();    // Destroy the value.
         pnodepool->release(&*icurrent); // Release it back to the pool.
-        ETL_DECREMENT_DEBUG_COUNT;
+        ETL_DECREMENT_DEBUG_COUNT
 
         icurrent = inext;
 
@@ -1108,7 +1108,7 @@ namespace etl
               // Destroy the value contents.
               it->key.~value_type();
               ++it;
-              ETL_DECREMENT_DEBUG_COUNT;
+              ETL_DECREMENT_DEBUG_COUNT
             }
 
             // Now it's safe to clear the bucket.
@@ -1164,7 +1164,7 @@ namespace etl
     key_equal key_equal_function;
 
     /// For library debugging purposes only.
-    ETL_DECLARE_DEBUG_COUNT;
+    ETL_DECLARE_DEBUG_COUNT
 
     //*************************************************************************
     /// Destructor.

--- a/include/etl/vector.h
+++ b/include/etl/vector.h
@@ -234,12 +234,12 @@ namespace etl
       if (current_size < new_size)
       {
         etl::uninitialized_fill_n(p_end, delta, value);
-        ETL_ADD_DEBUG_COUNT(delta);
+        ETL_ADD_DEBUG_COUNT(delta)
       }
       else
       {
         etl::destroy_n(p_end - delta, delta);
-        ETL_SUBTRACT_DEBUG_COUNT(delta);
+        ETL_SUBTRACT_DEBUG_COUNT(delta)
       }
 
       p_end = p_buffer + new_size;
@@ -370,7 +370,7 @@ namespace etl
       initialise();
 
       p_end = etl::uninitialized_copy(first, last, p_buffer);
-      ETL_ADD_DEBUG_COUNT(uint32_t(std::distance(first, last)));
+      ETL_ADD_DEBUG_COUNT(uint32_t(std::distance(first, last)))
     }
 
     //*********************************************************************
@@ -386,7 +386,7 @@ namespace etl
       initialise();
 
       p_end = etl::uninitialized_fill_n(p_buffer, n, value);
-      ETL_ADD_DEBUG_COUNT(uint32_t(n));
+      ETL_ADD_DEBUG_COUNT(uint32_t(n))
     }
 
     //*************************************************************************
@@ -436,7 +436,7 @@ namespace etl
 #endif
       ::new (p_end) T(value1);
       ++p_end;
-      ETL_INCREMENT_DEBUG_COUNT;
+      ETL_INCREMENT_DEBUG_COUNT
     }
 
     //*********************************************************************
@@ -452,7 +452,7 @@ namespace etl
 #endif
       ::new (p_end) T(value1, value2);
       ++p_end;
-      ETL_INCREMENT_DEBUG_COUNT;
+      ETL_INCREMENT_DEBUG_COUNT
     }
 
     //*********************************************************************
@@ -468,7 +468,7 @@ namespace etl
 #endif
       ::new (p_end) T(value1, value2, value3);
       ++p_end;
-      ETL_INCREMENT_DEBUG_COUNT;
+      ETL_INCREMENT_DEBUG_COUNT
     }
 
     //*********************************************************************
@@ -484,7 +484,7 @@ namespace etl
 #endif
       ::new (p_end) T(value1, value2, value3, value4);
       ++p_end;
-      ETL_INCREMENT_DEBUG_COUNT;
+      ETL_INCREMENT_DEBUG_COUNT
     }
 
     //*************************************************************************
@@ -536,7 +536,7 @@ namespace etl
       if (position == end())
       {
         p = p_end++;
-        ETL_INCREMENT_DEBUG_COUNT;
+        ETL_INCREMENT_DEBUG_COUNT
       }
       else
       {
@@ -564,7 +564,7 @@ namespace etl
       if (position == end())
       {
         p = p_end++;
-        ETL_INCREMENT_DEBUG_COUNT;
+        ETL_INCREMENT_DEBUG_COUNT
       }
       else
       {
@@ -592,7 +592,7 @@ namespace etl
       if (position == end())
       {
         p = p_end++;
-        ETL_INCREMENT_DEBUG_COUNT;
+        ETL_INCREMENT_DEBUG_COUNT
       }
       else
       {
@@ -620,7 +620,7 @@ namespace etl
       if (position == end())
       {
         p = p_end++;
-        ETL_INCREMENT_DEBUG_COUNT;
+        ETL_INCREMENT_DEBUG_COUNT
       }
       else
       {
@@ -673,14 +673,14 @@ namespace etl
 
       // Construct old.
       etl::uninitialized_copy_n(p_end - construct_old_n, construct_old_n, p_construct_old);
-      ETL_ADD_DEBUG_COUNT(construct_old_n);
+      ETL_ADD_DEBUG_COUNT(construct_old_n)
 
       // Copy old.
       etl::copy_n(p_buffer + insert_begin, copy_old_n, p_buffer + insert_end);
 
       // Construct new.
       etl::uninitialized_fill_n(p_end, construct_new_n, value);
-      ETL_ADD_DEBUG_COUNT(construct_new_n);
+      ETL_ADD_DEBUG_COUNT(construct_new_n)
 
       // Copy new.
       std::fill_n(p_buffer + insert_begin, copy_new_n, value);
@@ -730,14 +730,14 @@ namespace etl
 
       // Construct old.
       etl::uninitialized_copy_n(p_end - construct_old_n, construct_old_n, p_construct_old);
-      ETL_ADD_DEBUG_COUNT(construct_old_n);
+      ETL_ADD_DEBUG_COUNT(construct_old_n)
 
       // Copy old.
       etl::copy_n(p_buffer + insert_begin, copy_old_n, p_buffer + insert_end);
 
       // Construct new.
       etl::uninitialized_copy_n(first + copy_new_n, construct_new_n, p_end);
-      ETL_ADD_DEBUG_COUNT(construct_new_n);
+      ETL_ADD_DEBUG_COUNT(construct_new_n)
 
       // Copy new.
       etl::copy_n(first, copy_new_n, p_buffer + insert_begin);
@@ -779,7 +779,7 @@ namespace etl
 
         // Destroy the elements left over at the end.
         etl::destroy(p_end - n_delete, p_end);
-        ETL_SUBTRACT_DEBUG_COUNT(n_delete);
+        ETL_SUBTRACT_DEBUG_COUNT(n_delete)
         p_end -= n_delete;
       }
 
@@ -860,7 +860,7 @@ namespace etl
     void initialise()
     {
       etl::destroy(p_buffer, p_end);
-      ETL_SUBTRACT_DEBUG_COUNT(int32_t(std::distance(p_buffer, p_end)));
+      ETL_SUBTRACT_DEBUG_COUNT(int32_t(std::distance(p_buffer, p_end)))
 
       p_end = p_buffer;
     }
@@ -886,7 +886,7 @@ namespace etl
     inline void create_back()
     {
       etl::create_value_at(p_end);
-      ETL_INCREMENT_DEBUG_COUNT;
+      ETL_INCREMENT_DEBUG_COUNT
 
       ++p_end;
     }
@@ -897,7 +897,7 @@ namespace etl
     inline void create_back(parameter_t value)
     {
       etl::create_copy_at(p_end, value);
-      ETL_INCREMENT_DEBUG_COUNT;
+      ETL_INCREMENT_DEBUG_COUNT
 
       ++p_end;
     }
@@ -910,7 +910,7 @@ namespace etl
       --p_end;
 
       etl::destroy_at(p_end);
-      ETL_DECREMENT_DEBUG_COUNT;
+      ETL_DECREMENT_DEBUG_COUNT
     }
 
     // Disable copy construction.


### PR DESCRIPTION
clang++ emits `-Wextra-semi` warnings if *DEBUG_COUNT is undefined. 