### PR TITLE
Use diagnostic push and pop when suppressing GCC warnings to prevent …

### DIFF
--- a/include/etl/basic_string.h
+++ b/include/etl/basic_string.h
@@ -54,6 +54,7 @@ SOFTWARE.
 #define ETL_FILE "27"
 
 #ifdef ETL_COMPILER_GCC
+#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-variable"
 #endif
 
@@ -2231,6 +2232,10 @@ namespace etl
 }
 
 #include "private/minmax_pop.h"
+
+#ifdef ETL_COMPILER_GCC
+#pragma GCC diagnostic pop
+#endif
 
 #undef ETL_FILE
 

--- a/include/etl/private/pvoidvector.h
+++ b/include/etl/private/pvoidvector.h
@@ -45,6 +45,7 @@ SOFTWARE.
 #include "../stl/iterator.h"
 
 #ifdef ETL_COMPILER_GCC
+#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-variable"
 #endif
 
@@ -203,6 +204,10 @@ namespace etl
 }
 
 #include "minmax_pop.h"
+
+#ifdef ETL_COMPILER_GCC
+#pragma GCC diagnostic pop
+#endif
 
 #undef ETL_IN_PVOIDVECTOR
 

--- a/include/etl/vector.h
+++ b/include/etl/vector.h
@@ -59,7 +59,8 @@ SOFTWARE.
 #endif
 
 #ifdef ETL_COMPILER_GCC
-  #pragma GCC diagnostic ignored "-Wunused-variable"
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-variable"
 #endif
 
 //*****************************************************************************
@@ -1222,5 +1223,9 @@ namespace etl
 }
 
 #include "private/ivectorpointer.h"
+
+#ifdef ETL_COMPILER_GCC
+#pragma GCC diagnostic pop
+#endif
 
 #endif


### PR DESCRIPTION
…suppressions from impacting code outside of ETL