### PR TITLE
atomic_std: removed extra ';' semicolon after namespace

### DIFF
--- a/include/etl/atomic/atomic_std.h
+++ b/include/etl/atomic/atomic_std.h
@@ -600,6 +600,6 @@ namespace etl
   typedef std::atomic<ptrdiff_t>           atomic_ptrdiff_t;
   typedef std::atomic<intmax_t>            atomic_intmax_t;
   typedef std::atomic<uintmax_t>           atomic_uintmax_t;
-};
+}
 
 #endif


### PR DESCRIPTION
There is small hotfix removing extra semicolon after namespace etl in atomic_std.h