### PR TITLE
PlatformIO support (WIP)

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,0 +1,27 @@
+{
+  "name": "Embedded Template Library",
+  "version": "10.21.2",
+  "authors": {
+    "name": "John Wellbelove",
+    "email":  "<john.wellbelove@etlcpp.com>"
+  },
+  "homepage": "https://www.etlcpp.com/",
+  "license": "MIT",
+  "description": "A C++ template library tailored for embedded systems. Requires some support from STL. See http://andybrown.me.uk/2011/01/15/the-standard-template-library-stl-for-avr-with-c-streams/ or https://github.com/mike-matera/ArduinoSTL.git for Arduino.",
+  "repository": "https://github.com/ETLCPP/etl.git",
+  "platforms": [
+    "espressif8266",
+    "espressif32"
+  ],
+  "frameworks": "arduino",
+  "build": {
+    "flags": [
+      "-I include"
+    ],
+    "srcFilter": [
+        "-<src/*>",
+        "-<temp/*>",
+        "-<test/*>"
+    ]
+}
+}


### PR DESCRIPTION
This is a WIP PR related to discussion at #121 and should not be merged as such. If you use labels, please add a "WIP" label on this one.

After some fiddling I managed to create a suitable `library.json` file based on instructions here: https://docs.platformio.org/en/latest/librarymanager/config.html

I mapped the values in `library.properties` to best matching fields. There's bunch of other fields you would likely want to add like `keywords`, `export` (to filter out folders like `temp`), `examples` (to possibly add only some of the examples). Also I know ETL isn't Arduino specific and it'd likely work for other platforms also, I added only the ones I have now confirmed working.

I am able to compile the QueuedMessageRouter example with this `platformio.ini` configuration:
```ini
[env:esp32dev]
board     = esp32dev
platform  = espressif32
framework = arduino
lib_deps  = https://github.com/ristomatti/etl.git#platformio-support
```
And this `include/etl_profile.h`:
```cpp
#ifndef __ETL_PROFILE_H__
#define __ETL_PROFILE_H__

#define ETL_VERBOSE_ERRORS
#define ETL_CHECK_PUSH_POP

#endif
```