### PR TITLE
Improve initial PlatformIO support

### DIFF
--- a/library.json
+++ b/library.json
@@ -14,8 +14,10 @@
     "url": "https://github.com/ETLCPP/etl.git"
   },
   "platforms": [
+    "atmelavr",
     "espressif8266",
-    "espressif32"
+    "espressif32",
+    "ststm32"
   ],
   "frameworks": "arduino",
   "build": {

--- a/library.json
+++ b/library.json
@@ -20,9 +20,9 @@
       "-I include"
     ],
     "srcFilter": [
-        "-<src/*>",
-        "-<temp/*>",
-        "-<test/*>"
+      "-<src/*>",
+      "-<temp/*>",
+      "-<test/*>"
     ]
-}
+  }
 }

--- a/library.json
+++ b/library.json
@@ -1,13 +1,14 @@
 {
   "name": "Embedded Template Library",
-  "version": "10.21.2",
+  "version": "14.11.2",
   "authors": {
     "name": "John Wellbelove",
-    "email":  "<john.wellbelove@etlcpp.com>"
+    "email": "smartgit@wellbelove.co.uk"
   },
-  "homepage": "https://www.etlcpp.com/",
+  "homepage": "https://github.com/ETLCPP/etl",
   "license": "MIT",
-  "description": "A C++ template library tailored for embedded systems. Requires some support from STL. See http://andybrown.me.uk/2011/01/15/the-standard-template-library-stl-for-avr-with-c-streams/ or https://github.com/mike-matera/ArduinoSTL.git for Arduino.",
+  "description": "A C++ template library for embedded applications",
+  "keywords": "ETL embedded template container",
   "repository": "https://github.com/ETLCPP/etl.git",
   "platforms": [
     "espressif8266",

--- a/library.json
+++ b/library.json
@@ -9,7 +9,10 @@
   "license": "MIT",
   "description": "A C++ template library for embedded applications",
   "keywords": "ETL embedded template container",
-  "repository": "https://github.com/ETLCPP/etl.git",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ETLCPP/etl.git"
+  },
   "platforms": [
     "espressif8266",
     "espressif32"


### PR DESCRIPTION
This updates `library.json` with info I found from `conanfile.py` and adds platforms `atmelavr` and `ststm32`. Arduino cores for both Espressif platforms `espressif8266` and `espressif32` include STL so they were easy to get working. AVR core required adding [ArduinoSTL](https://github.com/mike-matera/ArduinoSTL) as a library dependency and STM32 core (stm32duino) required a (modified fork)[https://github.com/cparata/ArduinoSTL.git] of the same library.

I experimented a with different `etl_profile.h` macros and the main observation was that  `#define ETL_CPP11_SUPPORTED 1` compiled only on the Espressif platforms. All platforms use either `-std=c++11` or `-std=gnu++11` build flag so I don't know what that was about. I pretty much had no idea what I was doing but hopefully this helps push this idea forward.

I have setup a repository of a simple example I used for testing that only uses `etl::unordered_map`. It can be found here: [ristomatti/arduino-etl-example](https://github.com/ristomatti/arduino-etl-example).