### PR TITLE
copy algorithm overload fo POD types returned wrong iterator. Fix.

### DIFF
--- a/include/etl/stl/alternate/algorithm.h
+++ b/include/etl/stl/alternate/algorithm.h
@@ -73,8 +73,7 @@ namespace ETLSTD
     copy(TIterator1 sb, TIterator1 se, TIterator2 db)
   {
     typedef typename ETLSTD::iterator_traits<TIterator1>::value_type value_t;
-
-    return TIterator2(memcpy(db, sb, sizeof(value_t) * (se - sb)));
+    return TIterator2(memcpy(db, sb, sizeof(value_t) * (se - sb)) + (se - sb));
   }
 
   // Other iterator


### PR DESCRIPTION
This change worked for me on Arduino. See issue 166