### PR TITLE
Added utility function etl::make_string 

### DIFF
--- a/include/etl/cstring.h
+++ b/include/etl/cstring.h
@@ -251,6 +251,15 @@ namespace etl
     }
   };
 #endif
+
+  //***************************************************************************
+  /// make string from string literal or char array
+  //***************************************************************************
+  template<const size_t MAX_SIZE>
+  etl::string<MAX_SIZE - 1> make_string(const char (&string) [MAX_SIZE])
+  {
+    return etl::string<MAX_SIZE - 1>(string);
+  }
 }
 
 #include "private/minmax_pop.h"

--- a/include/etl/u16string.h
+++ b/include/etl/u16string.h
@@ -251,6 +251,14 @@ namespace etl
     }
   };
 #endif
+  //***************************************************************************
+  /// make u16string from UTF-8 string literal or char16_t array
+  //***************************************************************************
+  template<const size_t MAX_SIZE>
+  etl::u16string<MAX_SIZE - 1> make_u16string(const char16_t (&string) [MAX_SIZE])
+  {
+    return etl::u16string<MAX_SIZE - 1>(string);
+  }
 }
 
 #include "private/minmax_pop.h"

--- a/include/etl/u32string.h
+++ b/include/etl/u32string.h
@@ -251,6 +251,14 @@ namespace etl
     }
   };
 #endif
+  //***************************************************************************
+  /// make u32string from UTF-16 string literal or char32_t array
+  //***************************************************************************
+  template<const size_t MAX_SIZE>
+  etl::u32string<MAX_SIZE - 1> make_u32string(const char32_t (&string) [MAX_SIZE])
+  {
+    return etl::u32string<MAX_SIZE - 1>(string);
+  }
 }
 
 #include "private/minmax_pop.h"

--- a/include/etl/wstring.h
+++ b/include/etl/wstring.h
@@ -252,6 +252,14 @@ namespace etl
     }
   };
 #endif
+  //***************************************************************************
+  /// make wstring from wide string literal or wchar_t array
+  //***************************************************************************
+  template<const size_t MAX_SIZE>
+  etl::wstring<MAX_SIZE - 1> make_wstring(const wchar_t (&string) [MAX_SIZE])
+  {
+    return etl::wstring<MAX_SIZE - 1>(string);
+  }
 }
 
 #include "private/minmax_pop.h"


### PR DESCRIPTION
make_string utility function.
It provides possibility to safely create etl::string from string literal.
Example:
```
auto testString = etl::make_string("test567");

 std::cout << "testString: " << testString.data() << std::endl;
 std::cout << "testString: " << testString.max_size() << std::endl;
 std::cout << "testString: " << testString.size() << std::endl;
```
Output:
```
testString: test567
testString: 7
testString: 7
```