### PR TITLE
Added test_hsm.cpp to CMakeLists.txt

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -58,6 +58,7 @@ set(TEST_SOURCE_FILES
   test_functional.cpp
   test_function.cpp
   test_hash.cpp
+  test_hsm.cpp
   test_instance_count.cpp
   test_integral_limits.cpp
   test_intrusive_forward_list.cpp


### PR DESCRIPTION
I had forgotten to add test_hsm.cpp to CMakeLists.txt so it was not included in the test. That might have caused some problems. Now I have added it and tested with gcc 5.3, 7.4 and 8.3 (latest for release 8 in Ubuntu) and all work fine without compilation errors when running the full test suite.