### PR TITLE
Without this change the standart GHS was not able to build it as GCC …

### DIFF
--- a/include/etl/deque.h
+++ b/include/etl/deque.h
@@ -635,7 +635,7 @@ namespace etl
       //***************************************************
       void swap(const_iterator& other)
       {
-        swap(index, other.index);
+        ETL_OR_STD::swap(index, other.index);
       }
 
     private:


### PR DESCRIPTION
Without this change the standart GHS was not able to build it as GCC compiler does.

The return error was as follow :
../../external/etl/include/etl/deque.h", line 638 (col. 21): error #140: too many arguments in function call