### PR TITLE
Use etl::move instead of std::move

### DIFF
--- a/include/etl/optional.h
+++ b/include/etl/optional.h
@@ -167,7 +167,7 @@ namespace etl
     //***************************************************************************
     optional(T&& value_)
     {
-      ::new (storage.template get_address<T>()) T(std::move(value_));
+      ::new (storage.template get_address<T>()) T(etl::move(value_));
       valid = true;
     }
 #endif

--- a/include/etl/queue.h
+++ b/include/etl/queue.h
@@ -618,7 +618,7 @@ namespace etl
     queue(queue&& rhs)
       : base_t(reinterpret_cast<T*>(&buffer[0]), SIZE)
     {
-      base_t::move_clone(std::move(rhs));
+      base_t::move_clone(etl::move(rhs));
     }
 #endif
 


### PR DESCRIPTION
Both optional and queue used std::move without checking
ETL_NOT_USING_STL. Both usages can simply use etl::move
instead.