### PR TITLE
Fix span dynamic extent

### DIFF
--- a/include/etl/span.h
+++ b/include/etl/span.h
@@ -296,6 +296,10 @@ namespace etl
     //*************************************************************************
     ETL_CONSTEXPR etl::span<element_type, etl::dynamic_extent> subspan(size_t offset, size_t count = etl::dynamic_extent) const
     {
+      if (count == etl::dynamic_extent)
+      {
+        return etl::span<element_type, etl::dynamic_extent>(mbegin + offset, mend);
+      }
       return etl::span<element_type, etl::dynamic_extent>(mbegin + offset, mbegin + offset + count);
     }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -97,6 +97,7 @@ set(TEST_SOURCE_FILES
   test_reference_flat_set.cpp
   test_set.cpp
   test_smallest.cpp
+  test_span.cpp
   test_stack.cpp
   test_string_char.cpp
   test_string_u16.cpp

--- a/test/test_span.cpp
+++ b/test/test_span.cpp
@@ -486,6 +486,31 @@ namespace
       CHECK(isEqual);
       CHECK_EQUAL(etl::dynamic_extent, cspan2.extent);
       CHECK_EQUAL(sub2.size(), cspan2.size());
+
+      auto span3 = view.subspan(2, 4);
+      isEqual = std::equal(span3.begin(), span3.end(), sub1.begin());
+      CHECK(isEqual);
+      CHECK_EQUAL(etl::dynamic_extent, span3.extent);
+      CHECK_EQUAL(sub1.size(), span3.size());
+
+      auto cspan3 = cview.subspan(2, 4);
+      isEqual = std::equal(cspan3.begin(), cspan3.end(), sub1.begin());
+      CHECK(isEqual);
+      CHECK_EQUAL(etl::dynamic_extent, cspan3.extent);
+      CHECK_EQUAL(sub1.size(), cspan3.size());
+
+      auto span4 = view.subspan(2);
+      isEqual = std::equal(span4.begin(), span4.end(), sub2.begin());
+      CHECK(isEqual);
+      CHECK_EQUAL(etl::dynamic_extent, span4.extent);
+      CHECK_EQUAL(sub2.size(), span4.size());
+
+      auto cspan4 = cview.subspan(2);
+      isEqual = std::equal(cspan4.begin(), cspan4.end(), sub2.begin());
+      CHECK(isEqual);
+      CHECK_EQUAL(etl::dynamic_extent, cspan4.extent);
+      CHECK_EQUAL(sub2.size(), cspan4.size());
+
     }
 
     //*************************************************************************


### PR DESCRIPTION
Fixes #234

Correct handling when count equals dynamic_extent,
which would previously cause the end pointer to be set to the
wrong location.