### PR TITLE
error_handler.h: Change C++11 type aliases to typedefs

### DIFF
--- a/include/etl/error_handler.h
+++ b/include/etl/error_handler.h
@@ -51,7 +51,7 @@ namespace etl
     template <typename TDummy>
     struct wrapper
     {
-      using stub_type = void(*)(void* object, const etl::exception&);
+      typedef void(*stub_type)(void* object, const etl::exception&);
 
       //*************************************************************************
       /// The internal invocation object.
@@ -176,7 +176,7 @@ namespace etl
 
   private:
 
-    using stub_type = void(*)(void* object, const etl::exception&);
+    typedef void(*stub_type)(void* object, const etl::exception&);
 
     //*************************************************************************
     /// The internal invocation object.


### PR DESCRIPTION
Fixing C++98/C++03 compatibility issues with error_handler.h by using `typedef` instead of C++11 type aliases.