### PR TITLE
Mulit Ubuntu build and artifacts archiving (#2)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,10 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-18.04, ubuntu-20.04]
 
     steps:
     - uses: actions/checkout@v2
@@ -20,3 +23,9 @@ jobs:
     
     - name: Run tests
       run: ./test/etl_tests
+    
+    - name: Save artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: Testfile
+        path: test/etl_tests


### PR DESCRIPTION
Multi Ubuntu build and artifacts archiving

Build only on Ubuntu 18.04 and 20.04

Ubuntu 16.04 does not support C++17