### PR TITLE
cmake and make using same env with CC and CXX

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,19 +34,14 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v2
-
-    - name: Setup cmake
+    - name: Build and run
       run: |
-          export CC=clang-9
-          export CXX=clang++-9
-          cmake -D BUILD_TESTS=ON ./
+        export CC=clang-9
+        export CXX=clang++-9
+        cmake -D BUILD_TESTS=ON ./
+        make
+        ./test/etl_tests
 
-    - name: Compile
-      run: make
-    
-    - name: Run tests
-      run: ./test/etl_tests
-    
     - name: Save artifacts
       uses: actions/upload-artifact@v2
       with:


### PR DESCRIPTION
Each "run:" call gets a new environment.

With this, the first "run:" is exporting CC and CXX.
In this "run:" the cmake stuff is created.

The next "run:" to make, is using the default CC and CXX, which is
GCC instead of clang.

And then some of the stuff is build with clang other with gcc

* moved cmake, make and running tests in one "run:" command, so they
are sharing the same environment

* fixed indention

* renamed the name to Build and run

* Build build-clang-9-Linux and build-clang-10-osx are similar now.