### PR TITLE
Add template deduction guides for array and array_view

### DIFF
--- a/include/etl/array.h
+++ b/include/etl/array.h
@@ -553,6 +553,15 @@ namespace etl
   };
 
   //*************************************************************************
+  /// Template deduction guides.
+  //*************************************************************************
+#ifdef ETL_CPP17_SUPPORTED
+  template <typename T, typename... Ts>
+  array(T, Ts...)
+      -> array<etl::enable_if_t<(etl::is_same_v<T, Ts> && ...), T>, 1 + sizeof...(Ts)>;
+#endif  
+
+  //*************************************************************************
   /// Overloaded swap for etl::array<T, SIZE>
   ///\param lhs The first array.
   ///\param rhs The second array.
@@ -670,4 +679,3 @@ namespace etl
 }
 
 #endif
-

--- a/include/etl/array_view.h
+++ b/include/etl/array_view.h
@@ -40,6 +40,7 @@ SOFTWARE.
 #include "hash.h"
 #include "algorithm.h"
 #include "memory.h"
+#include "type_traits.h"
 
 ///\defgroup array array
 /// A wrapper for arrays
@@ -506,6 +507,24 @@ namespace etl
   };
 
   //*************************************************************************
+  /// Template deduction guides.
+  //*************************************************************************
+#ifdef ETL_CPP17_SUPPORTED
+  template <typename TArray>
+  array_view(TArray& a) 
+    -> array_view<typename TArray::value_type>;
+
+  template <typename TIterator>
+  array_view(const TIterator begin_, const TIterator end_)
+    -> array_view<etl::remove_pointer_t<TIterator>>;
+
+  template <typename TIterator,
+            typename TSize>
+  array_view(const TIterator begin_, const TSize size_)
+    -> array_view<etl::remove_pointer_t<TIterator>>;
+#endif  
+
+  //*************************************************************************
   /// Hash function.
   //*************************************************************************
 #if ETL_8BIT_SUPPORT
@@ -533,4 +552,3 @@ void swap(etl::array_view<T>& lhs, etl::array_view<T>& rhs)
 #undef ETL_FILE
 
 #endif
-


### PR DESCRIPTION
Add template deduction guides (C++17) for array and array_view. This will allow something like this to compile:

```
etl::array arr{0, 1, 2, 3, 4, 5);

etl::array_view arr_view1{arr};
etl::array_view arr_view2{arr.begin(), arr.end()};
etl::array_view arr_view3{arr.begin(), 2};
etl::array_view arr_view4{arr_view1};

uint8_t c_array[5] = {0};
etl::array_view arr_view5{c_array};
```
