### PR TITLE
Add missing `rend() const` to list.h

### DIFF
--- a/include/etl/list.h
+++ b/include/etl/list.h
@@ -757,6 +757,14 @@ namespace etl
     }
 
     //*************************************************************************
+    /// Gets the reverse end of the list.
+    //*************************************************************************
+    const_reverse_iterator rend() const
+    {
+      return const_reverse_iterator(get_head());
+    }
+
+    //*************************************************************************
     /// Gets the reverse beginning of the list.
     //*************************************************************************
     const_reverse_iterator crbegin() const


### PR DESCRIPTION
The `etl::list` class has a missing overload of `rend() const` causing unwarranted compile errors.