### PR TITLE
etl::list<int, 0>::full() asserts

### DIFF
--- a/include/etl/error_handler.h
+++ b/include/etl/error_handler.h
@@ -43,6 +43,7 @@ SOFTWARE.
 #include "function.h"
 #include "nullptr.h"
 
+#if defined(ETL_LOG_ERRORS) || defined(ETL_IN_UNIT_TEST)
 namespace etl
 {
   //***************************************************************************
@@ -254,6 +255,7 @@ namespace etl
     }
   };
 }
+#endif
 
 //***************************************************************************
 /// Asserts a condition.

--- a/include/etl/list.h
+++ b/include/etl/list.h
@@ -281,8 +281,15 @@ namespace etl
     //*************************************************************************
     bool full() const
     {
-      ETL_ASSERT(p_node_pool != ETL_NULLPTR, ETL_ERROR(list_no_pool));
-      return p_node_pool->size() == MAX_SIZE;
+      if (has_shared_pool())
+      {
+        return size() == MAX_SIZE;
+      }
+      else
+      {
+        ETL_ASSERT(p_node_pool != ETL_NULLPTR, ETL_ERROR(list_no_pool));
+        return p_node_pool->size() == MAX_SIZE;
+      }
     }
 
     //*************************************************************************

--- a/test/codeblocks/ETL.cbp
+++ b/test/codeblocks/ETL.cbp
@@ -546,6 +546,7 @@
 		<Unit filename="../test_maths.cpp" />
 		<Unit filename="../test_memory.cpp" />
 		<Unit filename="../test_message_bus.cpp" />
+		<Unit filename="../test_message_packet.cpp" />
 		<Unit filename="../test_message_router.cpp" />
 		<Unit filename="../test_message_timer.cpp" />
 		<Unit filename="../test_multi_array.cpp" />
@@ -580,15 +581,19 @@
 		<Unit filename="../test_scaled_rounding.cpp" />
 		<Unit filename="../test_set.cpp" />
 		<Unit filename="../test_smallest.cpp" />
+		<Unit filename="../test_span.cpp" />
 		<Unit filename="../test_stack.cpp" />
 		<Unit filename="../test_state_chart.cpp" />
 		<Unit filename="../test_string_char.cpp" />
+		<Unit filename="../test_string_char_external_buffer.cpp" />
 		<Unit filename="../test_string_stream.cpp" />
 		<Unit filename="../test_string_stream_u16.cpp" />
 		<Unit filename="../test_string_stream_u32.cpp" />
 		<Unit filename="../test_string_stream_wchar_t.cpp" />
 		<Unit filename="../test_string_u16.cpp" />
+		<Unit filename="../test_string_u16_external_buffer.cpp" />
 		<Unit filename="../test_string_u32.cpp" />
+		<Unit filename="../test_string_u32_external_buffer.cpp" />
 		<Unit filename="../test_string_utilities.cpp" />
 		<Unit filename="../test_string_utilities_std.cpp" />
 		<Unit filename="../test_string_utilities_std_u16.cpp" />
@@ -599,6 +604,7 @@
 		<Unit filename="../test_string_utilities_wchar_t.cpp" />
 		<Unit filename="../test_string_view.cpp" />
 		<Unit filename="../test_string_wchar_t.cpp" />
+		<Unit filename="../test_string_wchar_t_external_buffer.cpp" />
 		<Unit filename="../test_task_scheduler.cpp" />
 		<Unit filename="../test_to_string.cpp" />
 		<Unit filename="../test_to_u16string.cpp" />


### PR DESCRIPTION
The list::full method asserts for lists with max size equal to zero.