### PR TITLE
Fix faulty assert in `list<int,0>::available`

### DIFF
--- a/include/etl/list.h
+++ b/include/etl/list.h
@@ -291,8 +291,15 @@ namespace etl
     //*************************************************************************
     size_t available() const
     {
-      ETL_ASSERT(p_node_pool != ETL_NULLPTR, ETL_ERROR(list_no_pool));
-      return max_size() - p_node_pool->size();
+      if (has_shared_pool())
+      {
+        return max_size() - size();
+      }
+      else
+      {
+        ETL_ASSERT(p_node_pool != ETL_NULLPTR, ETL_ERROR(list_no_pool));
+        return max_size() - p_node_pool->size();
+      }
     }
 
   protected:


### PR DESCRIPTION
Prevent zero sized `list<int, 0> x;` from always asserting.