### PR TITLE
add overload for etl::equal that compares lengths

### DIFF
--- a/include/etl/algorithm.h
+++ b/include/etl/algorithm.h
@@ -800,6 +800,19 @@ namespace etl
   }
 #endif
 
+template <typename TIterator1, typename TIterator2>
+ETL_NODISCARD
+bool equal(TIterator1 first1, TIterator1 last1, TIterator2 first2, TIterator2 last2)
+{
+	if (etl::distance(first1, last1) !=
+		etl::distance(first2, last2))
+	{
+		return false;
+	}
+	return etl::equal(first1, last1, first2);
+}
+
+
 #if ETL_NOT_USING_STL
   //***************************************************************************
   // lexicographical_compare

--- a/test/test_algorithm.cpp
+++ b/test/test_algorithm.cpp
@@ -703,6 +703,10 @@ namespace
     {
       CHECK(etl::equal(std::begin(dataV), std::end(dataV), std::begin(dataL)));
       CHECK(!etl::equal(std::begin(dataSL), std::end(dataSL), std::begin(dataL)));
+
+      int small[] = { dataS[0] };
+      CHECK(etl::equal(std::begin(dataV), std::end(dataV), std::begin(dataL), std::end(dataL)));
+      CHECK(!etl::equal(std::begin(dataS), std::end(dataS), std::begin(small), std::end(small)));
     }
 
     //*************************************************************************


### PR DESCRIPTION
This adds an overload for etl::equal that takes (begin,end,begin,end) 4 parameters just like std::equal does since C++14.