### PR TITLE
Make span std compliant

### DIFF
--- a/include/etl/span.h
+++ b/include/etl/span.h
@@ -259,12 +259,28 @@ namespace etl
     }
 
     //*************************************************************************
+    /// Obtains a span that is a view over the first count elements of this span.
+    //*************************************************************************
+    ETL_CONSTEXPR etl::span<element_type, etl::dynamic_extent> first(size_t count) const
+    {
+      return etl::span<element_type, etl::dynamic_extent>(mbegin, mbegin + count);
+    }
+
+    //*************************************************************************
     /// Obtains a span that is a view over the last COUNT elements of this span.
     //*************************************************************************
     template <const size_t COUNT>
     ETL_CONSTEXPR etl::span<element_type, COUNT> last() const
     {
       return etl::span<element_type, COUNT>(mend - COUNT, mend);
+    }
+
+    //*************************************************************************
+    /// Obtains a span that is a view over the last count elements of this span.
+    //*************************************************************************
+    ETL_CONSTEXPR etl::span<element_type, etl::dynamic_extent> last(size_t count) const
+    {
+      return etl::span<element_type, etl::dynamic_extent>(mend - count, mend);
     }
 
     //*************************************************************************

--- a/include/etl/span.h
+++ b/include/etl/span.h
@@ -128,7 +128,7 @@ namespace etl
     /// Construct from C array
     //*************************************************************************
     template<const size_t ARRAY_SIZE>
-    ETL_CONSTEXPR explicit span(element_type(&begin_)[ARRAY_SIZE]) ETL_NOEXCEPT
+    ETL_CONSTEXPR span(element_type(&begin_)[ARRAY_SIZE]) ETL_NOEXCEPT
       : mbegin(begin_)
       , mend(begin_ + ARRAY_SIZE)
     {

--- a/include/etl/span.h
+++ b/include/etl/span.h
@@ -87,7 +87,7 @@ namespace etl
     /// data() and size() member functions.
     //*************************************************************************
     template <typename TSpan>
-    ETL_CONSTEXPR explicit span(TSpan& a) ETL_NOEXCEPT
+    ETL_CONSTEXPR span(TSpan& a) ETL_NOEXCEPT
       : mbegin(a.data())
       , mend(a.data() + a.size())
     {
@@ -98,7 +98,7 @@ namespace etl
     /// data() and size() member functions.
     //*************************************************************************
     template <typename TSpan>
-    ETL_CONSTEXPR explicit span(const TSpan& a) ETL_NOEXCEPT
+    ETL_CONSTEXPR span(const TSpan& a) ETL_NOEXCEPT
       : mbegin(a.data())
       , mend(a.data() + a.size())
     {

--- a/test/test_span.cpp
+++ b/test/test_span.cpp
@@ -394,6 +394,19 @@ namespace
     }
 
     //*************************************************************************
+    TEST(test_assignment_operator)
+    {
+      View view(etldata);
+      CView cview = view;
+
+      CHECK_EQUAL(etldata.size(), view.size());
+      CHECK_EQUAL(etldata.max_size(), view.max_size());
+
+      bool isEqual = std::equal(view.begin(), view.end(), etldata.begin());
+      CHECK(isEqual);
+    }
+
+    //*************************************************************************
     TEST(test_empty)
     {
       View view1(etldata.begin(), etldata.begin());

--- a/test/test_span.cpp
+++ b/test/test_span.cpp
@@ -247,6 +247,20 @@ namespace
       CHECK(isEqual);
     }
 
+    //*************************************************************************
+    TEST(test_implicit_constructor_c_array_2)
+    {
+      CView view;
+
+      view = ccdata;
+
+      CHECK_EQUAL(SIZE, view.size());
+      CHECK_EQUAL(SIZE, view.max_size());
+
+      bool isEqual = std::equal(view.begin(), view.end(), ccdata);
+      CHECK(isEqual);
+    }
+
 #if ETL_USING_STL && !defined(ETL_TEMPLATE_DEDUCTION_GUIDE_TESTS_DISABLED)
     //*************************************************************************
     TEST(test_cpp17_deduced_constructor)

--- a/test/test_span.cpp
+++ b/test/test_span.cpp
@@ -463,6 +463,27 @@ namespace
     }
 
     //*************************************************************************
+    TEST(test_first_2)
+    {
+      std::vector<int> original = {1, 2, 3, 4, 5, 6, 7, 8};
+      std::vector<int> first = {1, 2, 3, 4, 5, 6};
+      View view(original);
+      CView cview(original);
+
+      bool isEqual;
+
+      auto result = view.first(6);
+      isEqual = std::equal(result.begin(), result.end(), first.begin());
+      CHECK(isEqual);
+      CHECK_EQUAL(first.size(), result.size());
+
+      auto cresult = cview.first(6);
+      isEqual = std::equal(cresult.begin(), cresult.end(), first.begin());
+      CHECK(isEqual);
+      CHECK_EQUAL(first.size(), cresult.size());
+    }
+
+    //*************************************************************************
     TEST(test_last)
     {
       std::vector<int> original = { 1, 2, 3, 4, 5, 6, 7, 8 };
@@ -482,6 +503,27 @@ namespace
       isEqual = std::equal(cresult.begin(), cresult.end(), last.begin());
       CHECK(isEqual);
       CHECK_EQUAL(last.size(), cresult.extent);
+      CHECK_EQUAL(last.size(), cresult.size());
+    }
+
+    //*************************************************************************
+    TEST(test_last_2)
+    {
+      std::vector<int> original = {1, 2, 3, 4, 5, 6, 7, 8};
+      std::vector<int> last = {3, 4, 5, 6, 7, 8};
+      View view(original);
+      CView cview(original);
+
+      bool isEqual;
+
+      auto result = view.last(6);
+      isEqual = std::equal(result.begin(), result.end(), last.begin());
+      CHECK(isEqual);
+      CHECK_EQUAL(last.size(), result.size());
+
+      auto cresult = cview.last(6);
+      isEqual = std::equal(cresult.begin(), cresult.end(), last.begin());
+      CHECK(isEqual);
       CHECK_EQUAL(last.size(), cresult.size());
     }
 


### PR DESCRIPTION
fix for #316 

make etl implementation of std::span more compliant with the standard implementation:

- add missing overloads for etl::span::first and etl::span::last
- remove explicit from some conversion constructors to allow implict conversion during assignment 