### PR TITLE
Fix extent type conversion warning

### DIFF
--- a/include/etl/type_traits.h
+++ b/include/etl/type_traits.h
@@ -1223,7 +1223,7 @@ namespace etl
   //***************************************************************************
   /// extent
   ///\ingroup type_traits
-  template <typename T, size_t MAXN = 0U>
+  template <typename T, unsigned MAXN = 0U>
   struct extent : std::extent<T, MAXN> {};
 
 #if ETL_CPP17_SUPPORTED


### PR DESCRIPTION

Stop the compiler warning about type conversion from ```unsigned long``` to ```unsigned int```, and use the same type as std::extent.

https://en.cppreference.com/w/cpp/types/extent