### PR TITLE
Partial fix to compiling with C++98/03

### DIFF
--- a/include/etl/flags.h
+++ b/include/etl/flags.h
@@ -36,6 +36,7 @@ SOFTWARE.
 #include <stdint.h>
 
 #include "platform.h"
+#include "algorithm.h"
 #include "type_traits.h"
 #include "integral_limits.h"
 #include "static_assert.h"

--- a/include/etl/null_type.h
+++ b/include/etl/null_type.h
@@ -29,6 +29,8 @@ SOFTWARE.
 #ifndef ETL_NULL_TYPE_INCLUDED
 #define ETL_NULL_TYPE_INCLUDED
 
+#include <stddef.h>
+
 #undef ETL_FILE
 #define ETL_FILE "50"
 

--- a/include/etl/queue_spsc_locked.h
+++ b/include/etl/queue_spsc_locked.h
@@ -290,7 +290,7 @@ namespace etl
     template <typename T1>
     bool emplace_from_unlocked(const T1& value1)
     {
-      return emplace_implementation(valie1);
+      return emplace_implementation(value1);
     }
 
     //*************************************************************************
@@ -300,7 +300,7 @@ namespace etl
     template <typename T1, typename T2>
     bool emplace_from_unlocked(const T1& value1, const T2& value2)
     {
-      return emplace_implementation(valie1, value2);
+      return emplace_implementation(value1, value2);
     }
 
     //*************************************************************************
@@ -310,7 +310,7 @@ namespace etl
     template <typename T1, typename T2, typename T3>
     bool emplace_from_unlocked(const T1& value1, const T2& value2, const T3& value3)
     {
-      return emplace_implementation(valie1, value2, value3);
+      return emplace_implementation(value1, value2, value3);
     }
 
     //*************************************************************************
@@ -320,7 +320,7 @@ namespace etl
     template <typename T1, typename T2, typename T3, typename T4>
     bool emplace_from_unlocked(const T1& value1, const T2& value2, const T3& value3, const T4& value4)
     {
-      return emplace_implementation(valie1, value2, value3, value4);
+      return emplace_implementation(value1, value2, value3, value4);
     }
 
     //*************************************************************************

--- a/include/etl/ratio.h
+++ b/include/etl/ratio.h
@@ -31,7 +31,10 @@ SOFTWARE.
 #ifndef ETL_RATIO_INCLUDED
 #define ETL_RATIO_INCLUDED
 
+#include <stddef.h>
 #include <stdint.h>
+
+#include "platform.h"
 
 ///\defgroup ratio ratio
 ///\ingroup maths

--- a/include/etl/reference_counted_message.h
+++ b/include/etl/reference_counted_message.h
@@ -35,6 +35,8 @@ SOFTWARE.
 #include "message.h"
 #include "atomic.h"
 #include "reference_counted_object.h"
+#include "static_assert.h"
+#include "type_traits.h"
 #include "ireference_counted_message_pool.h"
 
 namespace etl

--- a/include/etl/string_utilities.h
+++ b/include/etl/string_utilities.h
@@ -83,6 +83,7 @@ namespace etl
     }
   };
 
+#if ETL_CPP11_SUPPORTED
   template <>
   struct whitespace<char16_t>
   {
@@ -100,6 +101,7 @@ namespace etl
       return U" \t\n\r\f\v";
     }
   };
+#endif
 
 #if ETL_CPP17_SUPPORTED
   template <typename TChar>


### PR DESCRIPTION
Some errors fixed when trying to compile the ETL library in C++98 mode.