### PR TITLE
Correct use of ETL_NULLPTR instead for keyword nulllptr

### DIFF
--- a/include/etl/buffer_descriptors.h
+++ b/include/etl/buffer_descriptors.h
@@ -96,7 +96,7 @@ namespace etl
       //*********************************
       pointer data() const
       {
-        assert(pdesc_item != nullptr);
+        assert(pdesc_item != ETL_NULLPTR);
         return pdesc_item->pbuffer;
       }
 

--- a/include/etl/multi_range.h
+++ b/include/etl/multi_range.h
@@ -98,7 +98,7 @@ namespace etl
     {
       ETL_ASSERT(is_valid(inner_range), ETL_ERROR(multi_range_circular_reference));
 
-      if (inner != nullptr)
+      if (inner != ETL_NULLPTR)
       {
         inner->append(inner_range);
       }


### PR DESCRIPTION
Gives problem in C++98/03 mode.