### PR TITLE
Remove etl/ prefix in state_chart.h

### DIFF
--- a/include/etl/state_chart.h
+++ b/include/etl/state_chart.h
@@ -31,11 +31,11 @@ SOFTWARE.
 
 #include <stdint.h>
 
-#include "etl/platform.h"
-#include "etl/nullptr.h"
-#include "etl/array.h"
-#include "etl/array_view.h"
-#include "etl/utility.h"
+#include "platform.h"
+#include "nullptr.h"
+#include "array.h"
+#include "array_view.h"
+#include "utility.h"
 
 namespace etl
 {


### PR DESCRIPTION
It's the only file to include internal header files with "etl/... .h".