### PR TITLE
string_utilities.h failes to compile with NO_ETL_STL

### DIFF
--- a/include/etl/string_utilities.h
+++ b/include/etl/string_utilities.h
@@ -38,6 +38,7 @@ SOFTWARE.
 #include "char_traits.h"
 #include "optional.h"
 
+#include <ctype.h>
 #include <stdint.h>
 
 namespace etl


### PR DESCRIPTION
Lacks `<ctype.h>` (deprecated in C++98 and forward) or <cctype> (prefered, since `<cctype>` is not part of the STL. This would give reason to use `std::toupper/tolower` instead of `::toupper/tolower`.

If `#include <etl/string_utilities.h>` is included before `<etl/string.h>` then this happens:
```
Then In file included from .../etl/t.m.cpp:1:
.../etl/include/etl/string_utilities.h: In function ‘void etl::to_upper_case(TString&)’:
.../etl/include/etl/string_utilities.h:809:53: error: ‘::toupper’ has not been declared
  809 |     etl::transform(s.begin(), s.end(), s.begin(), ::toupper);
      |                                                     ^~~~~~~
.../etl/include/etl/string_utilities.h: In function ‘void etl::to_lower_case(TString&)’:
.../etl/include/etl/string_utilities.h:818:53: error: ‘::tolower’ has not been declared
  818 |     etl::transform(s.begin(), s.end(), s.begin(), ::tolower);
      |                                                     ^~~~~~~
      |                                                     totalorder
.../etl/include/etl/string_utilities.h: In function ‘void etl::to_sentence_case(TString&)’:
.../etl/include/etl/string_utilities.h:829:43: error: ‘::toupper’ has not been declared
  829 |     *itr = typename TString::value_type(::toupper(*itr));
      |                                           ^~~~~~~
.../etl/include/etl/string_utilities.h:832:41: error: ‘::tolower’ has not been declared
  832 |     etl::transform(itr, s.end(), itr, ::tolower);
      |                                         ^~~~~~~
```