### PR TITLE
Add moveable parameter support to delegate

### DIFF
--- a/include/etl/delegate.h
+++ b/include/etl/delegate.h
@@ -52,6 +52,7 @@ Original publication: https://www.codeproject.com/Articles/1170503/The-Impossibl
 #include "error_handler.h"
 #include "exception.h"
 #include "type_traits.h"
+#include "utility.h"
 
 #if ETL_CPP11_NOT_SUPPORTED
   #if !defined(ETL_IN_UNIT_TEST)
@@ -198,7 +199,7 @@ namespace etl
     {
       ETL_ASSERT(is_valid(), ETL_ERROR(delegate_uninitialised));
 
-      return (*invocation.stub)(invocation.object, std::forward<TParams>(args)...);
+      return (*invocation.stub)(invocation.object, etl::forward<TParams>(args)...);
     }
 
     //*************************************************************************
@@ -315,7 +316,7 @@ namespace etl
     static TReturn method_stub(void* object, TParams... params)
     {
       T* p = static_cast<T*>(object);
-      return (p->*Method)(std::forward<TParams>(params)...);
+      return (p->*Method)(etl::forward<TParams>(params)...);
     }
 
     //*************************************************************************
@@ -325,7 +326,7 @@ namespace etl
     static TReturn const_method_stub(void* object, TParams... params)
     {
       T* const p = static_cast<T*>(object);
-      return (p->*Method)(std::forward<TParams>(params)...);
+      return (p->*Method)(etl::forward<TParams>(params)...);
     }
 
     //*************************************************************************
@@ -334,7 +335,7 @@ namespace etl
     template <typename T, T& Instance, TReturn(T::*Method)(TParams...)>
     static TReturn method_instance_stub(void*, TParams... params)
     {
-      return (Instance.*Method)(std::forward<TParams>(params)...);
+      return (Instance.*Method)(etl::forward<TParams>(params)...);
     }
 
     //*************************************************************************
@@ -343,7 +344,7 @@ namespace etl
     template <typename T, const T& Instance, TReturn(T::*Method)(TParams...) const>
     static TReturn const_method_instance_stub(void*, TParams... params)
     {
-      return (Instance.*Method)(std::forward<TParams>(params)...);
+      return (Instance.*Method)(etl::forward<TParams>(params)...);
     }
 
 #if !defined(ETL_COMPILER_GCC)
@@ -353,7 +354,7 @@ namespace etl
     template <typename T, T& Instance>
     static TReturn operator_instance_stub(void*, TParams... params)
     {
-      return Instance.operator()(std::forward<TParams>(params)...);
+      return Instance.operator()(etl::forward<TParams>(params)...);
     }
 #endif
 
@@ -363,7 +364,7 @@ namespace etl
     template <TReturn(*Method)(TParams...)>
     static TReturn function_stub(void*, TParams... params)
     {
-      return (Method)(std::forward<TParams>(params)...);
+      return (Method)(etl::forward<TParams>(params)...);
     }
 
     //*************************************************************************
@@ -373,7 +374,7 @@ namespace etl
     static TReturn lambda_stub(void* object, TParams... arg)
     {
       TLambda* p = static_cast<TLambda*>(object);
-      return (p->operator())(std::forward<TParams>(arg)...);
+      return (p->operator())(etl::forward<TParams>(arg)...);
     }
 
     //*************************************************************************

--- a/include/etl/delegate.h
+++ b/include/etl/delegate.h
@@ -198,7 +198,7 @@ namespace etl
     {
       ETL_ASSERT(is_valid(), ETL_ERROR(delegate_uninitialised));
 
-      return (*invocation.stub)(invocation.object, args...);
+      return (*invocation.stub)(invocation.object, std::forward<TParams>(args)...);
     }
 
     //*************************************************************************
@@ -315,7 +315,7 @@ namespace etl
     static TReturn method_stub(void* object, TParams... params)
     {
       T* p = static_cast<T*>(object);
-      return (p->*Method)(params...);
+      return (p->*Method)(std::forward<TParams>(params)...);
     }
 
     //*************************************************************************
@@ -325,7 +325,7 @@ namespace etl
     static TReturn const_method_stub(void* object, TParams... params)
     {
       T* const p = static_cast<T*>(object);
-      return (p->*Method)(params...);
+      return (p->*Method)(std::forward<TParams>(params)...);
     }
 
     //*************************************************************************
@@ -334,7 +334,7 @@ namespace etl
     template <typename T, T& Instance, TReturn(T::*Method)(TParams...)>
     static TReturn method_instance_stub(void*, TParams... params)
     {
-      return (Instance.*Method)(params...);
+      return (Instance.*Method)(std::forward<TParams>(params)...);
     }
 
     //*************************************************************************
@@ -343,7 +343,7 @@ namespace etl
     template <typename T, const T& Instance, TReturn(T::*Method)(TParams...) const>
     static TReturn const_method_instance_stub(void*, TParams... params)
     {
-      return (Instance.*Method)(params...);
+      return (Instance.*Method)(std::forward<TParams>(params)...);
     }
 
 #if !defined(ETL_COMPILER_GCC)
@@ -353,7 +353,7 @@ namespace etl
     template <typename T, T& Instance>
     static TReturn operator_instance_stub(void*, TParams... params)
     {
-      return Instance.operator()(params...);
+      return Instance.operator()(std::forward<TParams>(params)...);
     }
 #endif
 
@@ -363,7 +363,7 @@ namespace etl
     template <TReturn(*Method)(TParams...)>
     static TReturn function_stub(void*, TParams... params)
     {
-      return (Method)(params...);
+      return (Method)(std::forward<TParams>(params)...);
     }
 
     //*************************************************************************
@@ -373,7 +373,7 @@ namespace etl
     static TReturn lambda_stub(void* object, TParams... arg)
     {
       TLambda* p = static_cast<TLambda*>(object);
-      return (p->operator())(arg...);
+      return (p->operator())(std::forward<TParams>(arg)...);
     }
 
     //*************************************************************************

--- a/test/test_delegate.cpp
+++ b/test/test_delegate.cpp
@@ -47,6 +47,20 @@ namespace
   };
 
   //*****************************************************************************
+  // Test moveable only data structure.
+  //*****************************************************************************
+  struct MoveableOnlyData
+  {
+    MoveableOnlyData() = default;
+    ~MoveableOnlyData() = default;
+    MoveableOnlyData(const MoveableOnlyData&) = delete;
+    MoveableOnlyData& operator=(const MoveableOnlyData&) = delete;
+    MoveableOnlyData(MoveableOnlyData&&) = default;
+    MoveableOnlyData& operator=(MoveableOnlyData&&) = default;
+    int d;
+  };
+
+  //*****************************************************************************
   // The free function taking no parameters.
   //*****************************************************************************
   void free_void()
@@ -70,6 +84,15 @@ namespace
   {
     function_called = true;
     parameter_correct = (data.d == VALUE1) && (j == VALUE2);
+  }
+
+  //*****************************************************************************
+  // The free function taking a moveable only parameter.
+  //*****************************************************************************
+  void free_moveableonly(MoveableOnlyData&& data)
+  {
+    function_called = true;
+    parameter_correct = (data.d == VALUE1);
   }
 
   //*****************************************************************************
@@ -117,6 +140,14 @@ namespace
     {
       function_called = true;
       parameter_correct = (data.d == VALUE1) && (j = VALUE2);
+    }
+
+    //*******************************************
+    // moveable only data
+    void member_moveableonly(MoveableOnlyData&& data)
+    {
+      function_called = true;
+      parameter_correct = (data.d == VALUE1);
     }
 
     //*******************************************
@@ -260,6 +291,34 @@ namespace
       data.d = VALUE1;
 
       d(data, VALUE2);
+
+      CHECK(function_called);
+      CHECK(parameter_correct);
+    }
+
+    //*************************************************************************
+    TEST_FIXTURE(SetupFixture, test_free_moveableonly)
+    {
+      auto d = etl::delegate<void(MoveableOnlyData&&)>::create<free_moveableonly>();
+
+      MoveableOnlyData data;
+      data.d = VALUE1;
+
+      d(std::move(data));
+
+      CHECK(function_called);
+      CHECK(parameter_correct);
+    }
+
+    //*************************************************************************
+    TEST_FIXTURE(SetupFixture, test_free_moveableonly_constexpr)
+    {
+      constexpr auto d = etl::delegate<void(MoveableOnlyData&&)>::create<free_moveableonly>();
+
+      MoveableOnlyData data;
+      data.d = VALUE1;
+
+      d(std::move(data));
 
       CHECK(function_called);
       CHECK(parameter_correct);
@@ -548,6 +607,36 @@ namespace
       data.d = VALUE1;
 
       d(data, VALUE2);
+
+      CHECK(function_called);
+      CHECK(parameter_correct);
+    }
+
+    //*************************************************************************
+    TEST_FIXTURE(SetupFixture, test_member_moveableonly)
+    {
+      Test test;
+      auto d = etl::delegate<void(MoveableOnlyData&&)>::create<Test, &Test::member_moveableonly>(test);
+
+      MoveableOnlyData data;
+      data.d = VALUE1;
+
+      d(std::move(data));
+
+      CHECK(function_called);
+      CHECK(parameter_correct);
+    }
+
+    //*************************************************************************
+    TEST_FIXTURE(SetupFixture, test_member_moveableonly_constexpr)
+    {
+      static Test test;
+      constexpr auto d = etl::delegate<void(MoveableOnlyData&&)>::create<Test, &Test::member_moveableonly>(test);
+
+      MoveableOnlyData data;
+      data.d = VALUE1;
+
+      d(std::move(data));
 
       CHECK(function_called);
       CHECK(parameter_correct);


### PR DESCRIPTION
Currently, it is not possible to forward parameters that can't be copied but only moved as parameter to a delegate call.
Therefore, I suggest to use std::forward to enable this feature. #357 