### PR TITLE
Add "make install" option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,11 +7,21 @@ project(etl)
 option(BUILD_TESTS "Build unit tests" OFF)
 option(NO_STL "No STL" OFF)
 
-add_library(etl INTERFACE)
+add_library(${PROJECT_NAME} INTERFACE)
 
-target_include_directories(etl SYSTEM INTERFACE include)
+target_include_directories(${PROJECT_NAME} SYSTEM INTERFACE
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+        $<INSTALL_INTERFACE:include>
+        )
 
-target_compile_definitions(etl INTERFACE)
+target_link_libraries(${PROJECT_NAME} INTERFACE)
+
+# only install if top level project
+if(${CMAKE_PROJECT_NAME} STREQUAL ${PROJECT_NAME})
+   install(TARGETS ${PROJECT_NAME}  EXPORT ${PROJECT_NAME}Config)
+   install(EXPORT ${PROJECT_NAME}Config  DESTINATION lib/cmake/${PROJECT_NAME})
+   install(DIRECTORY include/${PROJECT_NAME}  DESTINATION include)
+endif()
 
 if (BUILD_TESTS)
   enable_testing()


### PR DESCRIPTION
This PR enables installation of the library, by adding a "make install" option.  It also installs a cmake config file so the library can be consumed by applications using the standard cmake ```find_package(etl)``` approach

```
mkdir build
cmake -DCMAKE_INSTALL_PREFIX=~/some_directory ..
make install
```