### PR TITLE
Add hierarchical FSM capabilities to the FSM.

### DIFF
--- a/include/etl/generators/fsm_generator.h
+++ b/include/etl/generators/fsm_generator.h
@@ -80,6 +80,7 @@ cog.outl("//********************************************************************
 namespace etl
 {
   class fsm;
+  class hfsm;
 
   /// Allow alternative type for state id.
 #if !defined(ETL_FSM_STATE_ID_TYPE)
@@ -90,6 +91,13 @@ namespace etl
 
   // For internal FSM use.
   typedef typename etl::larger_type<etl::message_id_t>::type fsm_internal_id_t;
+
+  template <typename TContext, typename TDerived, const etl::fsm_state_id_t STATE_ID_,
+          typename T1 = void, typename T2 = void, typename T3 = void, typename T4 = void,
+          typename T5 = void, typename T6 = void, typename T7 = void, typename T8 = void,
+          typename T9 = void, typename T10 = void, typename T11 = void, typename T12 = void,
+          typename T13 = void, typename T14 = void, typename T15 = void, typename T16 = void>
+  class fsm_state;
 
   //***************************************************************************
   /// Base exception class for FSM.
@@ -156,6 +164,15 @@ namespace etl
     }
   };
 
+  class fsm_state_enter_state_change_forbidden : public etl::fsm_exception
+  {
+  public:
+    fsm_state_enter_state_change_forbidden(string_type file_name_, numeric_type line_number_)
+      : etl::fsm_exception(ETL_ERROR_TEXT("fsm:enter state change in composite state forbidden", ETL_FSM_FILE_ID"E"), file_name_, line_number_)
+    {
+    }
+  };
+
   //***************************************************************************
   /// Interface class for FSM states.
   //***************************************************************************
@@ -163,8 +180,19 @@ namespace etl
   {
   public:
 
+    // Pass this whenever no state change is desired.  Specifically cast to
+    // Highest unsigned value of fsm_state_id_t.
+    static const fsm_state_id_t NO_CHANGE = static_cast<fsm_state_id_t>(-1);
+
     /// Allows ifsm_state functions to be private.
     friend class etl::fsm;
+    friend class etl::hfsm;
+    template <typename, typename, const etl::fsm_state_id_t,
+          typename, typename, typename, typename,
+          typename, typename, typename, typename,
+          typename, typename, typename, typename,
+          typename, typename, typename, typename >
+    friend class etl::fsm_state;
 
     //*******************************************
     /// Gets the id for this state.
@@ -174,6 +202,26 @@ namespace etl
       return state_id;
     }
 
+    //*******************************************
+    /// Adds a child to this state.
+    //*******************************************
+    void add_child(etl::ifsm_state& state)
+    {
+      ETL_ASSERT(state.p_parent == ETL_NULLPTR, ETL_ERROR(etl::fsm_null_state_exception));
+      state.p_parent = this;
+    }
+
+    //*******************************************
+    /// Adds the initial child to this state.
+    //*******************************************
+    void add_initial_child(etl::ifsm_state& state)
+    {
+      ETL_ASSERT(p_default_active_child == ETL_NULLPTR, ETL_ERROR(etl::fsm_null_state_exception));
+      add_child(state);
+      p_active_child = &state;
+      p_default_active_child = &state;
+    }
+
   protected:
 
     //*******************************************
@@ -181,7 +229,10 @@ namespace etl
     //*******************************************
     ifsm_state(etl::fsm_state_id_t state_id_)
       : state_id(state_id_),
-        p_context(ETL_NULLPTR)
+        p_context(ETL_NULLPTR),
+        p_parent(ETL_NULLPTR),
+        p_active_child(ETL_NULLPTR),
+        p_default_active_child(ETL_NULLPTR)
     {
     }
 
@@ -202,7 +253,7 @@ namespace etl
 
     virtual fsm_state_id_t process_event(const etl::imessage& message) = 0;
 
-    virtual fsm_state_id_t on_enter_state() { return state_id; } // By default, do nothing.
+    virtual fsm_state_id_t on_enter_state() { return NO_CHANGE; } // By default, do nothing.
     virtual void on_exit_state() {}  // By default, do nothing.
 
     //*******************************************
@@ -217,6 +268,15 @@ namespace etl
     // A pointer to the FSM context.
     etl::fsm* p_context;
 
+    // A pointer to the parent.
+    ifsm_state* p_parent;
+
+    // A pointer to the active child.
+    ifsm_state* p_active_child;
+
+    // A pointer to the default active child.
+    ifsm_state* p_default_active_child;
+
     // Disabled.
     ifsm_state(const ifsm_state&);
     ifsm_state& operator =(const ifsm_state&);
@@ -229,6 +289,7 @@ namespace etl
   {
   public:
 
+    friend etl::hfsm;
     using imessage_router::receive;
 
     //*******************************************
@@ -252,6 +313,7 @@ namespace etl
       number_of_states = etl::fsm_state_id_t(size);
 
       ETL_ASSERT(number_of_states > 0, ETL_ERROR(etl::fsm_state_list_exception));
+      ETL_ASSERT(number_of_states < ifsm_state::NO_CHANGE, ETL_ERROR(etl::fsm_state_list_exception));
 
       for (etl::fsm_state_id_t i = 0; i < size; ++i)
       {
@@ -269,26 +331,29 @@ namespace etl
     //*******************************************
     void start(bool call_on_enter_state = true)
     {
-		  // Can only be started once.
-		  if (p_state == ETL_NULLPTR)
-		  {
-			  p_state = state_list[0];
-			  ETL_ASSERT(p_state != ETL_NULLPTR, ETL_ERROR(etl::fsm_null_state_exception));
+      // Can only be started once.
+      if (p_state == ETL_NULLPTR)
+      {
+        p_state = state_list[0];
+        ETL_ASSERT(p_state != ETL_NULLPTR, ETL_ERROR(etl::fsm_null_state_exception));
 
-			  if (call_on_enter_state)
-			  {
-				  etl::fsm_state_id_t next_state_id;
-				  etl::ifsm_state*    p_last_state;
+        if (call_on_enter_state)
+        {
+          etl::fsm_state_id_t next_state_id;
+          etl::ifsm_state*    p_last_state;
 
-				  do
-				  {
-					  p_last_state = p_state;
-					  next_state_id = p_state->on_enter_state();
-					  p_state = state_list[next_state_id];
-
-				  } while (p_last_state != p_state);
-			  }
-		  }
+          do
+          {
+            p_last_state = p_state;
+            next_state_id = p_state->on_enter_state();
+            if (next_state_id != ifsm_state::NO_CHANGE)
+            {
+              ETL_ASSERT(next_state_id < number_of_states, ETL_ERROR(etl::fsm_state_id_exception));
+              p_state = state_list[next_state_id];
+            }
+          } while (p_last_state != p_state);
+        }
+      }
     }
 
     //*******************************************
@@ -296,9 +361,11 @@ namespace etl
     //*******************************************
     void receive(const etl::imessage& message) ETL_OVERRIDE
     {
-        etl::fsm_state_id_t next_state_id = p_state->process_event(message);
-        ETL_ASSERT(next_state_id < number_of_states, ETL_ERROR(etl::fsm_state_id_exception));
+      etl::fsm_state_id_t next_state_id = p_state->process_event(message);
 
+      if(next_state_id != ifsm_state::NO_CHANGE)
+      {
+        ETL_ASSERT(next_state_id < number_of_states, ETL_ERROR(etl::fsm_state_id_exception));
         etl::ifsm_state* p_next_state = state_list[next_state_id];
 
         // Have we changed state?
@@ -310,12 +377,14 @@ namespace etl
             p_state = p_next_state;
 
             next_state_id = p_state->on_enter_state();
-            ETL_ASSERT(next_state_id < number_of_states, ETL_ERROR(etl::fsm_state_id_exception));
-
-            p_next_state = state_list[next_state_id];
-
+            if(next_state_id != ifsm_state::NO_CHANGE)
+            {
+              ETL_ASSERT(next_state_id < number_of_states, ETL_ERROR(etl::fsm_state_id_exception));
+              p_next_state = state_list[next_state_id];
+            }
           } while (p_next_state != p_state); // Have we changed state again?
         }
+      }
     }
 
     using imessage_router::accepts;
@@ -414,11 +483,11 @@ namespace etl
   cog.outl("template <typename TContext, typename TDerived, const etl::fsm_state_id_t STATE_ID_, ")
   cog.out("          ")
   for n in range(1, int(Handlers)):
-      cog.out("typename T%s = void, " % n)
+      cog.out("typename T%s, " % n)
       if n % 4 == 0:
           cog.outl("")
           cog.out("          ")
-  cog.outl("typename T%s = void>" % Handlers)
+  cog.outl("typename T%s>" % Handlers)
   cog.outl("class fsm_state : public ifsm_state")
   cog.outl("{")
   cog.outl("public:")
@@ -458,7 +527,7 @@ namespace etl
       cog.out(" new_state_id = static_cast<TDerived*>(this)->on_event(static_cast<const T%d&>(message));" % n)
       cog.outl(" break;")
   cog.out("      default:")
-  cog.out(" new_state_id = static_cast<TDerived*>(this)->on_event_unknown(message);")
+  cog.out(" new_state_id = p_parent ? p_parent->process_event(message) : static_cast<TDerived*>(this)->on_event_unknown(message);")
   cog.outl(" break;")
   cog.outl("    }")
   cog.outl("")
@@ -535,7 +604,7 @@ namespace etl
           cog.out(" new_state_id = static_cast<TDerived*>(this)->on_event(static_cast<const T%d&>(message));" % n)
           cog.outl(" break;")
       cog.out("      default:")
-      cog.out(" new_state_id = static_cast<TDerived*>(this)->on_event_unknown(message);")
+      cog.out(" new_state_id = p_parent ? p_parent->process_event(message) : static_cast<TDerived*>(this)->on_event_unknown(message);")
       cog.outl(" break;")
       cog.outl("    }")
       cog.outl("")
@@ -584,7 +653,7 @@ namespace etl
   cog.outl("")
   cog.outl("  etl::fsm_state_id_t process_event(const etl::imessage& message)")
   cog.outl("  {")
-  cog.outl("    return static_cast<TDerived*>(this)->on_event_unknown(message);")
+  cog.outl("    return p_parent ? p_parent->process_event(message) : static_cast<TDerived*>(this)->on_event_unknown(message);")
   cog.outl("  }")
   cog.outl("};")
   ]]]*/

--- a/include/etl/hfsm.h
+++ b/include/etl/hfsm.h
@@ -1,0 +1,166 @@
+/******************************************************************************
+The MIT License(MIT)
+
+Embedded Template Library.
+https://github.com/ETLCPP/etl
+https://www.etlcpp.com
+
+Copyright(c) 2021
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files(the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions :
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+******************************************************************************/
+
+#ifndef ETL_HFSM_INCLUDED
+#define ETL_HFSM_INCLUDED
+
+#include "fsm.h"
+
+namespace etl
+{
+
+  //***************************************************************************
+  /// The HFSM class.
+  //***************************************************************************
+  class hfsm : public etl::fsm
+  {
+  public:
+
+    //*******************************************
+    /// Constructor.
+    //*******************************************
+    hfsm(etl::message_router_id_t id)
+      : fsm(id)
+    {
+    }
+
+    using fsm::receive;
+
+    //*******************************************
+    /// Top level message handler for the FSM.
+    //*******************************************
+    void receive(const etl::imessage& message) ETL_OVERRIDE
+    {
+      etl::fsm_state_id_t next_state_id = p_state->process_event(message);
+
+      if(next_state_id != ifsm_state::NO_CHANGE)
+      {
+        ETL_ASSERT(next_state_id < number_of_states, ETL_ERROR(etl::fsm_state_id_exception));
+        etl::ifsm_state* p_next_state = state_list[next_state_id];
+
+        // Have we changed state?
+        if(p_next_state != p_state)
+        {
+          etl::ifsm_state* p_root = common_ancestor(p_state, p_next_state);
+          do_exits(p_root, p_state);
+
+          p_state = p_next_state;
+          
+          next_state_id = do_enters(p_root, p_next_state, true);
+          if(next_state_id != ifsm_state::NO_CHANGE)
+          {
+            ETL_ASSERT(next_state_id < number_of_states, ETL_ERROR(etl::fsm_state_id_exception));
+            p_state = state_list[next_state_id];
+          }
+        }
+      }
+    }
+
+    static etl::ifsm_state* common_ancestor(etl::ifsm_state* p_one, etl::ifsm_state* p_two)
+    {
+      if(p_one == p_two)
+      {
+          return p_one;
+      }
+
+      etl::ifsm_state* p_current_state = p_one;
+
+      while (p_current_state->p_parent != ETL_NULLPTR)
+      {
+        if (p_current_state->p_parent == p_two)
+        {
+          return p_current_state->p_parent;
+        }
+
+        p_current_state = p_current_state->p_parent;
+      }
+
+      if(p_two->p_parent != ETL_NULLPTR)
+      {
+        return common_ancestor(p_one, p_two->p_parent);
+      }
+
+      return ETL_NULLPTR;
+    }
+
+    static void do_exits(const etl::ifsm_state* p_root, etl::ifsm_state* p_source)
+    {
+      etl::ifsm_state* p_current = p_source;
+
+      // Iterate down to the lowest child
+      while(p_current->p_active_child != ETL_NULLPTR)
+      {
+        p_current = p_current->p_active_child;
+      }
+
+      // Run exit state on all states up to the root
+      while (p_current != p_root)
+      {
+        p_current->on_exit_state();
+        p_current = p_current->p_parent;
+      }
+    }
+
+    static etl::fsm_state_id_t do_enters(const etl::ifsm_state* p_root, etl::ifsm_state* p_target, bool activate_default_children)
+    {
+      ETL_ASSERT(p_target != ETL_NULLPTR, ETL_ERROR(etl::fsm_null_state_exception));
+
+      // We need to go recursively up the tree if the target and root don't match
+      if (p_root != p_target && p_target->p_parent != ETL_NULLPTR)
+      {
+        if(p_target->p_parent != p_root)
+        {
+          // The parent we're calling shouldn't activate its defaults, or this state will be deactivated.
+          do_enters(p_root, p_target->p_parent, false);
+        }
+
+        // Set us as our parent's active child
+        p_target->p_parent->p_active_child = p_target;
+      }
+
+      etl::fsm_state_id_t next_state = p_target->on_enter_state();
+      ETL_ASSERT(ifsm_state::NO_CHANGE == next_state, ETL_ERROR(etl::fsm_state_enter_state_change_forbidden));
+
+      // Activate default child if we need to activate any initial states in an active composite state.
+      if (activate_default_children)
+      {
+        while (p_target->p_default_active_child != ETL_NULLPTR)
+        {
+          p_target = p_target->p_default_active_child;
+          p_target->p_parent->p_active_child = p_target;
+          next_state = p_target->on_enter_state();
+          ETL_ASSERT(ifsm_state::NO_CHANGE == next_state, ETL_ERROR(etl::fsm_state_enter_state_change_forbidden));
+        }
+        next_state = p_target->get_state_id();
+      }
+
+      return next_state;
+    }
+  };
+}
+#endif

--- a/meson.build
+++ b/meson.build
@@ -54,6 +54,7 @@ etl_test_sources = files(
 	'test/test_fnv_1.cpp',
 	'test/test_forward_list.cpp',
 	'test/test_fsm.cpp',
+	'test/test_hfsm.cpp',
 	'test/test_functional.cpp',
 	'test/test_function.cpp',
 	'test/test_hash.cpp',

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -121,6 +121,7 @@ set(TEST_SOURCE_FILES
 	test_functional.cpp
 	test_gamma.cpp
 	test_hash.cpp
+	test_hfsm.cpp
 	test_histogram.cpp
 	test_indirect_vector.cpp
 	test_indirect_vector_external_buffer.cpp


### PR DESCRIPTION
This adds the hierarchical state machine capabilities as an inherited class to the already existing FSM.

The states needed modification to add pointers to the parent and child states in the FSM, as well as a check to call the parent if it exists.

In order to work properly, states with no change need to return `ifsm_state::NO_CHANGE` rather than their given state id.
Otherwise, when an event isn't handled, it will return the parent state rather than the active state.

Also, in this implementation, a state cannot return a different state during the `on_enter_state()` function, as it would cause complexity with the enters and exits through the hierarchy.  An assert has been added to check for that.