### PR TITLE
Add container_type type definition to etl::queue to better match std::queue

### DIFF
--- a/include/etl/priority_queue.h
+++ b/include/etl/priority_queue.h
@@ -418,6 +418,7 @@ namespace etl
   public:
 
     typedef typename TContainer::size_type size_type;
+    typedef TContainer                     container_type;
 
     static ETL_CONSTANT size_type MAX_SIZE = size_type(SIZE);
 

--- a/include/etl/queue.h
+++ b/include/etl/queue.h
@@ -584,7 +584,8 @@ namespace etl
 
   public:
 
-    typedef typename base_t::size_type size_type;
+    typedef typename base_t::size_type                                                  size_type;
+    typedef typename etl::aligned_storage<sizeof(T), etl::alignment_of<T>::value>::type container_type;
 
     ETL_STATIC_ASSERT((SIZE <= etl::integral_limits<size_type>::max), "Size too large for memory model");
 
@@ -657,7 +658,7 @@ namespace etl
   private:
 
     /// The uninitialised buffer of T used in the queue.
-    typename etl::aligned_storage<sizeof(T), etl::alignment_of<T>::value>::type buffer[SIZE];
+    container_type buffer[SIZE];
   };
 }
 

--- a/include/etl/stack.h
+++ b/include/etl/stack.h
@@ -528,6 +528,7 @@ namespace etl
   class stack : public etl::istack<T>
   {
   public:
+    typedef typename etl::aligned_storage<sizeof(T), etl::alignment_of<T>::value>::type container_type;
 
     static ETL_CONSTANT size_t MAX_SIZE = SIZE;
 
@@ -598,7 +599,7 @@ namespace etl
   private:
 
     /// The unintitialised buffer of T used in the stack.
-    typename etl::aligned_storage<sizeof(T), etl::alignment_of<T>::value>::type buffer[SIZE];
+    container_type buffer[SIZE];
   };
 }
 


### PR DESCRIPTION
In my project I'm trying to pass `etl::queue` to a library function that expects a "queue-like" container. The library is expecting `etl::queue` to have a type defintion for `container_type`, just like `std::queue` - and the compilation fails with the error 

```
no type named 'container_type' in 'etl::queue
```

Adding this typedef to the `etl::queue` class solves the issue, and the class is more in-line with `std::queue`.