### PR TITLE
Fix uninitialised warning in etl::optional

### DIFF
--- a/include/etl/optional.h
+++ b/include/etl/optional.h
@@ -112,7 +112,8 @@ namespace etl
     /// Constructor.
     //***************************************************************************
     optional()
-      : valid(false)
+      : storage()
+      , valid(false)
     {
     }
 
@@ -120,7 +121,8 @@ namespace etl
     /// Constructor with nullopt.
     //***************************************************************************
     optional(etl::nullopt_t)
-      : valid(false)
+      : storage()
+      , valid(false)
     {
     }
 


### PR DESCRIPTION
The constructors of etl::optional with no argument or with etl::nullopt_t
argument do not initalise the storage data member. When compiling with
gcc with some specific optimisation levels, this can generate a
-Wmaybe-uninitialized diagnostic warning.

Resolves #380 