### PR TITLE
Define missing macro when cross-compiling with clang

### DIFF
--- a/include/etl/limits.h
+++ b/include/etl/limits.h
@@ -332,6 +332,11 @@ namespace etl
     static ETL_CONSTANT bool is_signed = etl::is_signed<wchar_t>::value;
     static ETL_CONSTANT bool is_modulo = etl::is_unsigned<wchar_t>::value;
 
+#if defined(ETL_COMPILER_CLANG) && defined(CROSS_COMPILING_TO_AVR)
+#undef WCHAR_MIN
+#define WCHAR_MIN (-WCHAR_MAX - 1)
+#endif
+
     static ETL_CONSTEXPR wchar_t min() { return WCHAR_MIN; }
     static ETL_CONSTEXPR wchar_t max() { return WCHAR_MAX; }
     static ETL_CONSTEXPR wchar_t lowest() { return WCHAR_MIN; }

--- a/include/etl/profiles/determine_compiler.h
+++ b/include/etl/profiles/determine_compiler.h
@@ -75,6 +75,9 @@ SOFTWARE.
     #if defined(__clang__) || defined(__llvm__)
       #define ETL_COMPILER_CLANG
       #define ETL_COMPILER_TYPE_DETECTED
+      #if __AVR__ == 1
+        #define CROSS_COMPILING_TO_AVR
+      #endif
     #endif
   #endif
 


### PR DESCRIPTION
# Issue
When using clang to cross-compile to AVR this error arises:
```
[build] include/etl/limits.h:340:49: error: use of undeclared identifier '__WCHAR_MIN__'
[build]     static ETL_CONSTEXPR wchar_t min() { return WCHAR_MIN; }
[build]                                                 ^
[build] /usr/lib/avr/include/stdint.h:602:19: note: expanded from macro 'WCHAR_MIN'
[build] #define WCHAR_MIN __WCHAR_MIN__
```

# Cause
Unlike gcc (avr-gcc), clang does not define `__WCHAR_MIN__`.

This can be verified by running this command:
`clang -dM -E --target=avr - </dev/null | grep WCHAR`

**Note: you need a clang version that supports AVR, I believe from clang 12 onwards the AVR architecture is supported out of the box.**

The above command will produce this output:
```
clang-11: warning: no target microcontroller specified on command line, cannot link standard libraries, please pass -mmcu=<mcu name> [-Wavr-rtlib-linking-quirks]
clang-11: warning: standard library not linked and so no interrupt vector table or compiler runtime routines will be linked [-Wavr-rtlib-linking-quirks]
#define __CLANG_ATOMIC_WCHAR_T_LOCK_FREE 1
#define __GCC_ATOMIC_WCHAR_T_LOCK_FREE 1
#define __SIZEOF_WCHAR_T__ 2
#define __WCHAR_MAX__ 32767
#define __WCHAR_TYPE__ int
#define __WCHAR_WIDTH__ 16
```
We can see that only `__WCHAR_MAX__` is defined.

# Solution
When cross-compiling with clang to AVR, the `__AVR__` macro is defined to `1`.

This can be verified by running this command:
`clang -dM -E --target=avr - </dev/null | grep AVR`

The above command will produce this output:
```
clang-11: warning: no target microcontroller specified on command line, cannot link standard libraries, please pass -mmcu=<mcu name> [-Wavr-rtlib-linking-quirks]
clang-11: warning: standard library not linked and so no interrupt vector table or compiler runtime routines will be linked [-Wavr-rtlib-linking-quirks]
#define AVR 1
#define __AVR 1
#define __AVR__ 1
```
We can use this macro to define another macro that informs whether or not we are cross-compiling to AVR. In this pull request, I chose to name the macro: `CROSS_COMPILING_TO_AVR`.

By using `ETL_COMPILER_CLANG` and `CROSS_COMPILING_TO_AVR` we can define `WCHAR_MIN` in `limits.h` as follows:
```cpp
#if defined(ETL_COMPILER_CLANG) && defined(CROSS_COMPILING_TO_AVR)
#undef WCHAR_MIN
#define WCHAR_MIN (-WCHAR_MAX - 1)
#endif
```