### PR TITLE
Fix traits error for arduino examples

### DIFF
--- a/arduino/examples/Vector_Examples/Example_Vector_1_simple_use/Example_Vector_1_simple_use.ino
+++ b/arduino/examples/Vector_Examples/Example_Vector_1_simple_use/Example_Vector_1_simple_use.ino
@@ -1,3 +1,6 @@
+// make sure that we do not rely on the STL
+#define ETL_NO_STL
+
 #include "Embedded_Template_Library.h"
 #include "etl/vector.h"
 


### PR DESCRIPTION
Fix issue #399 by defining the ```ETL_NO_STL``` macro in the vector container arduino example. Without this, the sketch does not compile for Arduino Uno.