### PR TITLE
Feature/bip buffer spsc atomic (#402 follow-up)

### DIFF
--- a/include/etl/bip_buffer_spsc_atomic.h
+++ b/include/etl/bip_buffer_spsc_atomic.h
@@ -444,7 +444,7 @@ namespace etl
     ibip_buffer_spsc_atomic& operator =(ibip_buffer_spsc_atomic&&) = delete;
 #endif
 
-    const T* p_buffer;
+    T* const p_buffer;
   };
 
   //***************************************************************************

--- a/include/etl/bip_buffer_spsc_atomic.h
+++ b/include/etl/bip_buffer_spsc_atomic.h
@@ -188,7 +188,7 @@ namespace etl
     }
 
   protected:
-     
+
     //*************************************************************************
     /// Construccts the buffer.
     //*************************************************************************
@@ -344,6 +344,7 @@ namespace etl
 
 #if defined(ETL_POLYMORPHIC_SPSC_BIP_BUFFER_ATOMIC) || defined(ETL_POLYMORPHIC_CONTAINERS)
   public:
+
     virtual ~bip_buffer_spsc_atomic_base()
     {
     }
@@ -363,7 +364,7 @@ namespace etl
   class ibip_buffer_spsc_atomic : public bip_buffer_spsc_atomic_base<MEMORY_MODEL>
   {
   private:
-    
+
     typedef typename etl::bip_buffer_spsc_atomic_base<MEMORY_MODEL> base_t;
     using base_t::get_read_reserve;
     using base_t::apply_read_reserve;
@@ -371,7 +372,7 @@ namespace etl
     using base_t::apply_write_reserve;
 
   public:
-    
+
     typedef T                          value_type;      ///< The type stored in the buffer.
     typedef T&                         reference;       ///< A reference to the type used in the buffer.
     typedef const T&                   const_reference; ///< A const reference to the type used in the buffer.

--- a/include/etl/bip_buffer_spsc_atomic.h
+++ b/include/etl/bip_buffer_spsc_atomic.h
@@ -496,9 +496,20 @@ namespace etl
 
     static ETL_CONSTANT size_type MAX_SIZE = size_type(SIZE);
 
+    //*************************************************************************
+    /// Default constructor.
+    //*************************************************************************
     bip_buffer_spsc_atomic()
       : base_t(reinterpret_cast<T*>(&buffer[0]), RESERVED_SIZE)
     {
+    }
+
+    //*************************************************************************
+    /// Destructor.
+    //*************************************************************************
+    ~bip_buffer_spsc_atomic()
+    {
+      base_t::clear();
     }
 
   private:


### PR DESCRIPTION
With these commits I'm addressing the raised point from #402:
> I noticed that clearing or destructing the buffer does not call the destructors for the buffered items. Was this bip buffer only intended for trivially destructible types?

Now the buffer's `clear()` calls the destructors of the buffered items: 780fe8c and the buffer's destructor calls clear(): 01f8629

> Also, the top level template class does not define copy/move constructors or assignment operators. Should these be marked as disabled?

The top level template class doesn't know of the stored type, so copying that would be fine I guess. This is the same situation as in queue_spsc_atomic_base, so it would only make sense to apply the same convention on both types.

I've also fixed a regression so the tests can be built again: 304b37e (they are passing as well), and did some whitespace cleanup: 7d44c3d