### PR TITLE
Add peek to queue_spsc_atomic

### DIFF
--- a/include/etl/queue_spsc_atomic.h
+++ b/include/etl/queue_spsc_atomic.h
@@ -366,6 +366,24 @@ namespace etl
 #endif
 
     //*************************************************************************
+    /// Peek the next value in the queue without removing it.
+    //*************************************************************************
+    bool peek(reference value)
+    {
+      size_type read_index = read.load(etl::memory_order_relaxed);
+
+      if (read_index == write.load(etl::memory_order_acquire))
+      {
+        // Queue is empty
+        return false;
+      }
+
+      value = p_buffer[read_index];
+
+      return true;
+    }
+
+    //*************************************************************************
     /// Pop a value from the queue.
     //*************************************************************************
     bool pop(reference value)

--- a/test/test_queue_spsc_atomic.cpp
+++ b/test/test_queue_spsc_atomic.cpp
@@ -271,6 +271,52 @@ namespace
       CHECK(!queue.pop());
     }
 
+    TEST(test_size_push_peek_pop)
+    {
+      etl::queue_spsc_atomic<int, 4> queue;
+
+      CHECK_EQUAL(0U, queue.size());
+
+      queue.push(1);
+      queue.push(2);
+      queue.push(3);
+      queue.push(4);
+      CHECK_EQUAL(4U, queue.size());
+
+      int i;
+
+      CHECK(queue.peek(i));
+      CHECK_EQUAL(1, i);
+      CHECK_EQUAL(4U, queue.size());
+
+      CHECK(queue.peek(i));
+      CHECK_EQUAL(1, i);
+      CHECK_EQUAL(4U, queue.size());
+
+      CHECK(queue.pop());
+      CHECK_EQUAL(3U, queue.size());
+
+      CHECK(queue.pop());
+      CHECK_EQUAL(2U, queue.size());
+
+      CHECK(queue.pop());
+      CHECK_EQUAL(1U, queue.size());
+
+      CHECK(queue.peek(i));
+      CHECK_EQUAL(4, i);
+      CHECK_EQUAL(1U, queue.size());
+
+      CHECK(queue.peek(i));
+      CHECK_EQUAL(4, i);
+      CHECK_EQUAL(1U, queue.size());
+
+      CHECK(queue.pop());
+      CHECK_EQUAL(0U, queue.size());
+
+      CHECK(!queue.peek(i));
+      CHECK(!queue.peek(i));
+    }
+
     //*************************************************************************
     TEST(test_multiple_emplace)
     {


### PR DESCRIPTION
This adds a `peek` method to the `queue_spsc_atomic` container. Peek is the same as pop except the queue is not modified by this operation. There is no need for a `void` peek as that would essentially be a no operation. If this pattern looks good, let me know if we should more broadly apply it to the other queue classes. I wanted to wait for feedback before putting that effort in.

I also wasn't sure if I should use the `front` naming convention or not. I also am not sure if this should be returning a reference or copying into a reference argument as I have it. I have one question about move semantics which I've posted inline to the code review.

In general, I'm not 100% sure about the direction and code in this PR, and would consider it more of a starting point for a conversation.