### PR TITLE
initial version of a clang format file that matches quite good with the existing code style

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,25 @@
+---
+Language: Cpp
+
+SortIncludes: false
+
+BasedOnStyle: Chromium
+
+BreakBeforeBraces: Stroustrup
+
+AllowShortBlocksOnASingleLine: true
+AllowShortCaseLabelsOnASingleLine: true
+AllowShortFunctionsOnASingleLine: Inline
+AllowShortIfStatementsOnASingleLine: false
+
+ConstructorInitializerAllOnOneLineOrOnePerLine: 'true'
+ConstructorInitializerIndentWidth: '2'
+
+ColumnLimit: '150'
+ContinuationIndentWidth: '2'
+TabWidth: '2'
+IndentWidth: '2'
+AccessModifierOffset : '-2'
+IndentCaseLabels: false
+Cpp11BracedListStyle: 'true'
+...


### PR DESCRIPTION
I did a partial formating of new code by this configuration see [here](https://github.com/ETLCPP/etl/pull/433/commits/e5f38f3d2270169f7275bf908e289b06195f084f)