### PR TITLE
Fix constexpr accepts() implementation to be C++11 compliant

### DIFF
--- a/include/etl/generators/message_packet_generator.h
+++ b/include/etl/generators/message_packet_generator.h
@@ -367,6 +367,16 @@ namespace etl
 
   /*[[[cog
     import cog
+    def joined_elements(prefix, suffix, elem_fmt, joiner, elem_range, indent = None, chunk_size = 4):
+        if indent is None:
+            indent = ''
+        lines = [joiner.join([elem_fmt % i for i in r]) for r in [
+            elem_range[i:i + chunk_size] for i in range(0, len(elem_range), chunk_size)
+        ]]
+        for ix, line in enumerate(lines):
+            line = (prefix if ix == 0 else indent) + line
+            line += suffix if ix == len(lines) - 1 else joiner.rstrip()
+            cog.outl(line)
     ################################################
     # The first definition for all of the messages.
     ################################################
@@ -484,18 +494,7 @@ namespace etl
     cog.outl("  //**********************************************")
     cog.outl("  static ETL_CONSTEXPR bool accepts(etl::message_id_t id)")
     cog.outl("  {")
-    cog.outl("    switch (id)")
-    cog.outl("    {")
-    cog.out("      ")
-    for n in range(1, int(Handlers) + 1):
-        cog.out("case T%d::ID: " % n)
-        if n % 8 == 0:
-            cog.outl("")
-            cog.out("      ")
-    cog.outl("  return true;")
-    cog.outl("      default:")
-    cog.outl("        return false;")
-    cog.outl("    }")
+    joined_elements('    return ', ';', 'T%d::ID == id', ' || ', range(1, int(Handlers) + 1), ' '*11)
     cog.outl("  }")
     cog.outl("")
     cog.outl("  //**********************************************")
@@ -722,19 +721,7 @@ namespace etl
         cog.outl("  //**********************************************")
         cog.outl("  static ETL_CONSTEXPR bool accepts(etl::message_id_t id)")
         cog.outl("  {")
-        cog.outl("    switch (id)")
-        cog.outl("    {")
-        cog.out("      ")
-        for t in range(1, n + 1):
-            cog.out("case T%d::ID: " % t)
-            if t % 8 == 0:
-                cog.outl("")
-                cog.out("      ")
-        cog.outl("")
-        cog.outl("        return true;")
-        cog.outl("      default:")
-        cog.outl("        return false;")
-        cog.outl("    }")
+        joined_elements('    return ', ';', 'T%d::ID == id', ' || ', range(1, n + 1), ' '*11)
         cog.outl("  }")
         cog.outl("")
         cog.outl("  //**********************************************")

--- a/include/etl/message_packet.h
+++ b/include/etl/message_packet.h
@@ -463,14 +463,10 @@ namespace etl
     //**********************************************
     static ETL_CONSTEXPR bool accepts(etl::message_id_t id)
     {
-      switch (id)
-      {
-        case T1::ID: case T2::ID: case T3::ID: case T4::ID: case T5::ID: case T6::ID: case T7::ID: case T8::ID: 
-        case T9::ID: case T10::ID: case T11::ID: case T12::ID: case T13::ID: case T14::ID: case T15::ID: case T16::ID: 
-          return true;
-        default:
-          return false;
-      }
+      return T1::ID == id || T2::ID == id || T3::ID == id || T4::ID == id ||
+             T5::ID == id || T6::ID == id || T7::ID == id || T8::ID == id ||
+             T9::ID == id || T10::ID == id || T11::ID == id || T12::ID == id ||
+             T13::ID == id || T14::ID == id || T15::ID == id || T16::ID == id;
     }
 
     //**********************************************
@@ -711,14 +707,10 @@ namespace etl
     //**********************************************
     static ETL_CONSTEXPR bool accepts(etl::message_id_t id)
     {
-      switch (id)
-      {
-        case T1::ID: case T2::ID: case T3::ID: case T4::ID: case T5::ID: case T6::ID: case T7::ID: case T8::ID: 
-        case T9::ID: case T10::ID: case T11::ID: case T12::ID: case T13::ID: case T14::ID: case T15::ID: 
-          return true;
-        default:
-          return false;
-      }
+      return T1::ID == id || T2::ID == id || T3::ID == id || T4::ID == id ||
+             T5::ID == id || T6::ID == id || T7::ID == id || T8::ID == id ||
+             T9::ID == id || T10::ID == id || T11::ID == id || T12::ID == id ||
+             T13::ID == id || T14::ID == id || T15::ID == id;
     }
 
     //**********************************************
@@ -956,14 +948,10 @@ namespace etl
     //**********************************************
     static ETL_CONSTEXPR bool accepts(etl::message_id_t id)
     {
-      switch (id)
-      {
-        case T1::ID: case T2::ID: case T3::ID: case T4::ID: case T5::ID: case T6::ID: case T7::ID: case T8::ID: 
-        case T9::ID: case T10::ID: case T11::ID: case T12::ID: case T13::ID: case T14::ID: 
-          return true;
-        default:
-          return false;
-      }
+      return T1::ID == id || T2::ID == id || T3::ID == id || T4::ID == id ||
+             T5::ID == id || T6::ID == id || T7::ID == id || T8::ID == id ||
+             T9::ID == id || T10::ID == id || T11::ID == id || T12::ID == id ||
+             T13::ID == id || T14::ID == id;
     }
 
     //**********************************************
@@ -1198,14 +1186,10 @@ namespace etl
     //**********************************************
     static ETL_CONSTEXPR bool accepts(etl::message_id_t id)
     {
-      switch (id)
-      {
-        case T1::ID: case T2::ID: case T3::ID: case T4::ID: case T5::ID: case T6::ID: case T7::ID: case T8::ID: 
-        case T9::ID: case T10::ID: case T11::ID: case T12::ID: case T13::ID: 
-          return true;
-        default:
-          return false;
-      }
+      return T1::ID == id || T2::ID == id || T3::ID == id || T4::ID == id ||
+             T5::ID == id || T6::ID == id || T7::ID == id || T8::ID == id ||
+             T9::ID == id || T10::ID == id || T11::ID == id || T12::ID == id ||
+             T13::ID == id;
     }
 
     //**********************************************
@@ -1436,14 +1420,9 @@ namespace etl
     //**********************************************
     static ETL_CONSTEXPR bool accepts(etl::message_id_t id)
     {
-      switch (id)
-      {
-        case T1::ID: case T2::ID: case T3::ID: case T4::ID: case T5::ID: case T6::ID: case T7::ID: case T8::ID: 
-        case T9::ID: case T10::ID: case T11::ID: case T12::ID: 
-          return true;
-        default:
-          return false;
-      }
+      return T1::ID == id || T2::ID == id || T3::ID == id || T4::ID == id ||
+             T5::ID == id || T6::ID == id || T7::ID == id || T8::ID == id ||
+             T9::ID == id || T10::ID == id || T11::ID == id || T12::ID == id;
     }
 
     //**********************************************
@@ -1671,14 +1650,9 @@ namespace etl
     //**********************************************
     static ETL_CONSTEXPR bool accepts(etl::message_id_t id)
     {
-      switch (id)
-      {
-        case T1::ID: case T2::ID: case T3::ID: case T4::ID: case T5::ID: case T6::ID: case T7::ID: case T8::ID: 
-        case T9::ID: case T10::ID: case T11::ID: 
-          return true;
-        default:
-          return false;
-      }
+      return T1::ID == id || T2::ID == id || T3::ID == id || T4::ID == id ||
+             T5::ID == id || T6::ID == id || T7::ID == id || T8::ID == id ||
+             T9::ID == id || T10::ID == id || T11::ID == id;
     }
 
     //**********************************************
@@ -1903,14 +1877,9 @@ namespace etl
     //**********************************************
     static ETL_CONSTEXPR bool accepts(etl::message_id_t id)
     {
-      switch (id)
-      {
-        case T1::ID: case T2::ID: case T3::ID: case T4::ID: case T5::ID: case T6::ID: case T7::ID: case T8::ID: 
-        case T9::ID: case T10::ID: 
-          return true;
-        default:
-          return false;
-      }
+      return T1::ID == id || T2::ID == id || T3::ID == id || T4::ID == id ||
+             T5::ID == id || T6::ID == id || T7::ID == id || T8::ID == id ||
+             T9::ID == id || T10::ID == id;
     }
 
     //**********************************************
@@ -2132,14 +2101,9 @@ namespace etl
     //**********************************************
     static ETL_CONSTEXPR bool accepts(etl::message_id_t id)
     {
-      switch (id)
-      {
-        case T1::ID: case T2::ID: case T3::ID: case T4::ID: case T5::ID: case T6::ID: case T7::ID: case T8::ID: 
-        case T9::ID: 
-          return true;
-        default:
-          return false;
-      }
+      return T1::ID == id || T2::ID == id || T3::ID == id || T4::ID == id ||
+             T5::ID == id || T6::ID == id || T7::ID == id || T8::ID == id ||
+             T9::ID == id;
     }
 
     //**********************************************
@@ -2357,14 +2321,8 @@ namespace etl
     //**********************************************
     static ETL_CONSTEXPR bool accepts(etl::message_id_t id)
     {
-      switch (id)
-      {
-        case T1::ID: case T2::ID: case T3::ID: case T4::ID: case T5::ID: case T6::ID: case T7::ID: case T8::ID: 
-        
-          return true;
-        default:
-          return false;
-      }
+      return T1::ID == id || T2::ID == id || T3::ID == id || T4::ID == id ||
+             T5::ID == id || T6::ID == id || T7::ID == id || T8::ID == id;
     }
 
     //**********************************************
@@ -2579,13 +2537,8 @@ namespace etl
     //**********************************************
     static ETL_CONSTEXPR bool accepts(etl::message_id_t id)
     {
-      switch (id)
-      {
-        case T1::ID: case T2::ID: case T3::ID: case T4::ID: case T5::ID: case T6::ID: case T7::ID: 
-          return true;
-        default:
-          return false;
-      }
+      return T1::ID == id || T2::ID == id || T3::ID == id || T4::ID == id ||
+             T5::ID == id || T6::ID == id || T7::ID == id;
     }
 
     //**********************************************
@@ -2797,13 +2750,8 @@ namespace etl
     //**********************************************
     static ETL_CONSTEXPR bool accepts(etl::message_id_t id)
     {
-      switch (id)
-      {
-        case T1::ID: case T2::ID: case T3::ID: case T4::ID: case T5::ID: case T6::ID: 
-          return true;
-        default:
-          return false;
-      }
+      return T1::ID == id || T2::ID == id || T3::ID == id || T4::ID == id ||
+             T5::ID == id || T6::ID == id;
     }
 
     //**********************************************
@@ -3012,13 +2960,8 @@ namespace etl
     //**********************************************
     static ETL_CONSTEXPR bool accepts(etl::message_id_t id)
     {
-      switch (id)
-      {
-        case T1::ID: case T2::ID: case T3::ID: case T4::ID: case T5::ID: 
-          return true;
-        default:
-          return false;
-      }
+      return T1::ID == id || T2::ID == id || T3::ID == id || T4::ID == id ||
+             T5::ID == id;
     }
 
     //**********************************************
@@ -3223,13 +3166,7 @@ namespace etl
     //**********************************************
     static ETL_CONSTEXPR bool accepts(etl::message_id_t id)
     {
-      switch (id)
-      {
-        case T1::ID: case T2::ID: case T3::ID: case T4::ID: 
-          return true;
-        default:
-          return false;
-      }
+      return T1::ID == id || T2::ID == id || T3::ID == id || T4::ID == id;
     }
 
     //**********************************************
@@ -3431,13 +3368,7 @@ namespace etl
     //**********************************************
     static ETL_CONSTEXPR bool accepts(etl::message_id_t id)
     {
-      switch (id)
-      {
-        case T1::ID: case T2::ID: case T3::ID: 
-          return true;
-        default:
-          return false;
-      }
+      return T1::ID == id || T2::ID == id || T3::ID == id;
     }
 
     //**********************************************
@@ -3636,13 +3567,7 @@ namespace etl
     //**********************************************
     static ETL_CONSTEXPR bool accepts(etl::message_id_t id)
     {
-      switch (id)
-      {
-        case T1::ID: case T2::ID: 
-          return true;
-        default:
-          return false;
-      }
+      return T1::ID == id || T2::ID == id;
     }
 
     //**********************************************
@@ -3838,13 +3763,7 @@ namespace etl
     //**********************************************
     static ETL_CONSTEXPR bool accepts(etl::message_id_t id)
     {
-      switch (id)
-      {
-        case T1::ID: 
-          return true;
-        default:
-          return false;
-      }
+      return T1::ID == id;
     }
 
     //**********************************************


### PR DESCRIPTION
In C++11, `constexpr` functions must not contain compound statements.
This change makes the implementation of `message_packet::accepts` use
a single conjunction instead of a `switch` statement.

See https://gcc.godbolt.org/z/zKbsx3nY5.