### PR TITLE
Change != to < in ipool to get rid of erroneous clang-tidy nullptr dereference warning

### DIFF
--- a/include/etl/ipool.h
+++ b/include/etl/ipool.h
@@ -353,7 +353,7 @@ namespace etl
         p_value = p_next;
 
         ++items_allocated;
-        if (items_allocated != Max_Size)
+        if (items_allocated < Max_Size)
         {
           // Set up the pointer to the next free item
           p_next = *reinterpret_cast<char**>(p_next);


### PR DESCRIPTION
When doing two allocations from the pool in a row, clang-tidy complains that line 359 is a `nullptr` dereference due to the `!=` operator and some erroneous assumptions as to the value of `items_allocated`.

Changing the `!=` to a `<` results in this error going away and tests still pass.