### PR TITLE
let map/multimap/set/multiset return iterator on erase

### DIFF
--- a/include/etl/map.h
+++ b/include/etl/map.h
@@ -993,10 +993,10 @@ namespace etl
     //*************************************************************************
     /// Erases the value at the specified position.
     //*************************************************************************
-    void erase(iterator position)
+    iterator erase(iterator position)
     {
-      // Remove the node by its key
-      erase((*position).first);
+      // Remove the node by its node specified in iterator position
+      return erase(const_iterator(position));
     }
 
     //*************************************************************************

--- a/include/etl/multimap.h
+++ b/include/etl/multimap.h
@@ -1101,10 +1101,10 @@ namespace etl
     //*************************************************************************
     /// Erases the value at the specified position.
     //*************************************************************************
-    void erase(iterator position)
+    iterator erase(iterator position)
     {
       // Remove the node by its node specified in iterator position
-      (void)erase(const_iterator(position));
+      return erase(const_iterator(position));
     }
 
     //*************************************************************************

--- a/include/etl/multiset.h
+++ b/include/etl/multiset.h
@@ -1085,10 +1085,10 @@ namespace etl
     //*************************************************************************
     /// Erases the value at the specified position.
     //*************************************************************************
-    void erase(iterator position)
+    iterator erase(iterator position)
     {
       // Remove the node by its node specified in iterator position
-      (void)erase(const_iterator(position));
+      return erase(const_iterator(position));
     }
 
     //*************************************************************************

--- a/include/etl/set.h
+++ b/include/etl/set.h
@@ -956,10 +956,10 @@ namespace etl
     //*************************************************************************
     /// Erases the value at the specified position.
     //*************************************************************************
-    void erase(iterator position)
+    iterator erase(iterator position)
     {
-      // Remove the node by its key
-      erase((*position));
+      // Remove the node by its node specified in iterator position
+      return erase(const_iterator(position));
     }
 
     //*************************************************************************

--- a/test/test_map.cpp
+++ b/test/test_map.cpp
@@ -830,8 +830,10 @@ namespace
       std::advance(i_compare, 2);
       std::advance(i_data,    2);
 
-      compare_data.erase(i_compare);
-      data.erase(i_data);
+      Compare_Data::iterator i_compare1 = compare_data.erase(i_compare);
+      Data::iterator i_data1 = data.erase(i_data);
+
+      CHECK(i_compare1->second == i_data1->second);
 
       bool isEqual = Check_Equal(data.begin(),
                                  data.end(),

--- a/test/test_multimap.cpp
+++ b/test/test_multimap.cpp
@@ -699,8 +699,10 @@ namespace
       Compare_Data::iterator i_compare = compare_data.begin();
       Data::iterator i_data            = data.begin();
 
-      compare_data.erase(i_compare);
-      data.erase(i_data);
+      Compare_Data::iterator i_compare1 = compare_data.erase(i_compare);
+      Data::iterator i_data1 = data.erase(i_data);
+
+      CHECK(i_compare1->second == i_data1->second);
 
       bool isEqual = Check_Equal(data.begin(),
                                  data.end(),

--- a/test/test_multiset.cpp
+++ b/test/test_multiset.cpp
@@ -713,8 +713,10 @@ namespace
       Compare_Data::iterator i_compare = compare_data.begin();
       Data::iterator i_data            = data.begin();
 
-      compare_data.erase(i_compare);
-      data.erase(i_data);
+      Compare_Data::iterator i_compare1 = compare_data.erase(i_compare);
+      Data::iterator i_data1 = data.erase(i_data);
+
+      CHECK_EQUAL(*i_compare1, *i_data1);
 
       bool isEqual = Check_Equal(data.begin(),
                                  data.end(),

--- a/test/test_set.cpp
+++ b/test/test_set.cpp
@@ -754,8 +754,10 @@ namespace
       std::advance(i_compare, 2);
       std::advance(i_data,    2);
 
-      compare_data.erase(i_compare);
-      data.erase(i_data);
+      Compare_Data::iterator i_compare1 = compare_data.erase(i_compare);
+      Data::iterator i_data1 = data.erase(i_data);
+
+      CHECK_EQUAL(*i_compare1, *i_data1);
 
       bool isEqual = Check_Equal(data.begin(),
                                  data.end(),


### PR DESCRIPTION
Beginning with C++11, erase(iterator) and erase(const_iterator) returns an iterator following the removed element.

This PR improves C++11 compatibility for the STL container replacements in etl by adding the missing return value.

I didn't touch the flat_* and reference_flat_* containers in etl because I'm not very familiar with them. If necessary, I could try to add the return value there as well.