### PR TITLE
Const iterator for stl containers

### DIFF
--- a/include/etl/array.h
+++ b/include/etl/array.h
@@ -360,7 +360,7 @@ namespace etl
     //*************************************************************************
     /// Fills the array from the range.
     /// If the range is smaller than the array then the unused array elements are left unmodified.
-    ///\param first The iterator to the first item in the ramge.
+    ///\param first The iterator to the first item in the range.
     ///\param last  The iterator to one past the final item in the range.
     //*************************************************************************
     template <typename TIterator>
@@ -372,7 +372,7 @@ namespace etl
     //*************************************************************************
     /// Fills the array from the range.
     /// If the range is smaller than the array then the unused array elements are initialised with the supplied value.
-    ///\param first The iterator to the first item in the ramge.
+    ///\param first The iterator to the first item in the range.
     ///\param last  The iterator to one past the final item in the range.
     //*************************************************************************
     template <typename TIterator>

--- a/include/etl/basic_string.h
+++ b/include/etl/basic_string.h
@@ -1050,14 +1050,17 @@ namespace etl
     ///\param last     The last + 1 element to add.
     //*********************************************************************
     template <class TIterator>
-    void insert(iterator position, TIterator first, TIterator last)
+    void insert(const_iterator position, TIterator first, TIterator last)
     {
+      // Quick hack, as iterators are pointers.
+      iterator insert_position = const_cast<iterator>(position);
+
       if (first == last)
       {
         return;
       }
 
-      const size_type start = etl::distance(begin(), position);
+      const size_type start = etl::distance(cbegin(), position);
       const size_type n = etl::distance(first, last);
 
       // No effect.
@@ -1089,9 +1092,9 @@ namespace etl
 
         current_size = CAPACITY;
 
-        while (position != end())
+        while (insert_position != end())
         {
-          *position++ = *first++;
+          *insert_position++ = *first++;
         }
       }
       else
@@ -1121,11 +1124,11 @@ namespace etl
           current_size += shift_amount;
         }
 
-        etl::copy_backward(position, position + characters_to_shift, begin() + to_position + characters_to_shift);
+        etl::copy_backward(insert_position, insert_position + characters_to_shift, begin() + to_position + characters_to_shift);
 
         while (first != last)
         {
-          *position++ = *first++;
+          *insert_position++ = *first++;
         }
       }
 
@@ -1252,12 +1255,15 @@ namespace etl
     ///\param i_element Iterator to the element.
     ///\return An iterator pointing to the element that followed the erased element.
     //*********************************************************************
-    iterator erase(iterator i_element)
+    iterator erase(const_iterator i_element)
     {
-      etl::copy(i_element + 1, end(), i_element);
+      // Quick hack, as iterators are pointers.
+      iterator i_element_ = const_cast<iterator>(i_element);
+
+      etl::copy(i_element_ + 1, end(), i_element_);
       p_buffer[--current_size] = 0;
 
-      return i_element;
+      return i_element_;
     }
 
     //*********************************************************************
@@ -1268,21 +1274,25 @@ namespace etl
     ///\param last  Iterator to the last element.
     ///\return An iterator pointing to the element that followed the erased element.
     //*********************************************************************
-    iterator erase(iterator first, iterator last)
+    iterator erase(const_iterator first, const_iterator last)
     {
-      if (first == last)
+      // Quick hack, as iterators are pointers.
+      iterator first_ = const_cast<iterator>(first);
+      iterator last_ = const_cast<iterator>(last);
+
+      if (first_ == last_)
       {
-        return first;
+        return const_cast<iterator>(first);
       }
 
-      etl::copy(last, end(), first);
+      etl::copy(last_, end(), first_);
       size_type n_delete = etl::distance(first, last);
 
       current_size -= n_delete;
       p_buffer[current_size] = 0;
       cleanup();
 
-      return first;
+      return first_;
     }
 
     //*********************************************************************

--- a/include/etl/forward_list.h
+++ b/include/etl/forward_list.h
@@ -866,12 +866,12 @@ namespace etl
     //*************************************************************************
     /// Inserts a value to the forward_list after the specified position.
     //*************************************************************************
-    iterator insert_after(iterator position, const T& value)
+    iterator insert_after(const_iterator position, const T& value)
     {
       ETL_ASSERT(!full(), ETL_ERROR(forward_list_full));
 
       data_node_t& data_node = allocate_data_node(value);
-      insert_node_after(*position.p_node, data_node);
+      insert_node_after(*const_cast<node_t*>(position.p_node), data_node);
 
       return iterator(&data_node);
     }
@@ -881,14 +881,14 @@ namespace etl
     /// Emplaces a value to the forward_list after the specified position.
     //*************************************************************************
     template <typename ... Args>
-    iterator emplace_after(iterator position, Args && ... args)
+    iterator emplace_after(const_iterator position, Args && ... args)
     {
       ETL_ASSERT(!full(), ETL_ERROR(forward_list_full));
 
       data_node_t* p_data_node = create_data_node();
       ::new (&(p_data_node->value)) T(etl::forward<Args>(args)...);
       ETL_INCREMENT_DEBUG_COUNT
-      insert_node_after(*position.p_node, *p_data_node);
+      insert_node_after(*const_cast<node_t*>(position.p_node), *p_data_node);
 
       return iterator(p_data_node);
     }
@@ -897,14 +897,14 @@ namespace etl
     /// Emplaces a value to the forward_list after the specified position.
     //*************************************************************************
     template <typename T1>
-    iterator emplace_after(iterator position, const T1& value1)
+    iterator emplace_after(const_iterator position, const T1& value1)
     {
       ETL_ASSERT(!full(), ETL_ERROR(forward_list_full));
 
       data_node_t* p_data_node = create_data_node();
       ::new (&(p_data_node->value)) T(value1);
       ETL_INCREMENT_DEBUG_COUNT
-      insert_node_after(*position.p_node, *p_data_node);
+      insert_node_after(*const_cast<node_t*>(position.p_node), *p_data_node);
 
       return iterator(p_data_node);
     }
@@ -913,14 +913,14 @@ namespace etl
     /// Emplaces a value to the forward_list after the specified position.
     //*************************************************************************
     template <typename T1, typename T2>
-    iterator emplace_after(iterator position, const T1& value1, const T2& value2)
+    iterator emplace_after(const_iterator position, const T1& value1, const T2& value2)
     {
       ETL_ASSERT(!full(), ETL_ERROR(forward_list_full));
 
       data_node_t* p_data_node = create_data_node();
       ::new (&(p_data_node->value)) T(value1, value2);
       ETL_INCREMENT_DEBUG_COUNT
-      insert_node_after(*position.p_node, *p_data_node);
+      insert_node_after(*const_cast<node_t*>(position.p_node), *p_data_node);
 
       return iterator(p_data_node);
     }
@@ -929,14 +929,14 @@ namespace etl
     /// Emplaces a value to the forward_list after the specified position.
     //*************************************************************************
     template <typename T1, typename T2, typename T3>
-    iterator emplace_after(iterator position, const T1& value1, const T2& value2, const T3& value3)
+    iterator emplace_after(const_iterator position, const T1& value1, const T2& value2, const T3& value3)
     {
       ETL_ASSERT(!full(), ETL_ERROR(forward_list_full));
 
       data_node_t* p_data_node = create_data_node();
       ::new (&(p_data_node->value)) T(value1, value2, value3);
       ETL_INCREMENT_DEBUG_COUNT
-      insert_node_after(*position.p_node, *p_data_node);
+      insert_node_after(*const_cast<node_t*>(position.p_node), *p_data_node);
 
       return iterator(p_data_node);
     }
@@ -945,14 +945,14 @@ namespace etl
     /// Emplaces a value to the forward_list after the specified position.
     //*************************************************************************
     template <typename T1, typename T2, typename T3, typename T4>
-    iterator emplace_after(iterator position, const T1& value1, const T2& value2, const T3& value3, const T4& value4)
+    iterator emplace_after(const_iterator position, const T1& value1, const T2& value2, const T3& value3, const T4& value4)
     {
       ETL_ASSERT(!full(), ETL_ERROR(forward_list_full));
 
       data_node_t* p_data_node = create_data_node();
       ::new (&(p_data_node->value)) T(value1, value2, value3, value4);
       ETL_INCREMENT_DEBUG_COUNT
-      insert_node_after(*position.p_node, *p_data_node);
+      insert_node_after(*const_cast<node_t*>(position.p_node), *p_data_node);
 
       return iterator(p_data_node);
     }
@@ -961,7 +961,7 @@ namespace etl
     //*************************************************************************
     /// Inserts 'n' copies of a value to the forward_list after the specified position.
     //*************************************************************************
-    void insert_after(iterator position, size_t n, const T& value)
+    void insert_after(const_iterator position, size_t n, const T& value)
     {
       ETL_ASSERT(!full(), ETL_ERROR(forward_list_full));
 
@@ -969,7 +969,7 @@ namespace etl
       {
         // Set up the next free node.
         data_node_t& data_node = allocate_data_node(value);
-        insert_node_after(*position.p_node, data_node);
+        insert_node_after(*const_cast<node_t*>(position.p_node), data_node);
       }
     }
 
@@ -977,7 +977,7 @@ namespace etl
     /// Inserts a range of values to the forward_list after the specified position.
     //*************************************************************************
     template <typename TIterator>
-    void insert_after(iterator position, TIterator first, TIterator last)
+    void insert_after(const_iterator position, TIterator first, TIterator last)
     {
 #if defined(ETL_DEBUG)
       difference_type d = etl::distance(first, last);
@@ -988,7 +988,7 @@ namespace etl
       {
         // Set up the next free node.
         data_node_t& data_node = allocate_data_node(*first++);
-        insert_node_after(*position.p_node, data_node);
+        insert_node_after(*const_cast<node_t*>(position.p_node), data_node);
         ++position;
       }
     }
@@ -996,16 +996,16 @@ namespace etl
     //*************************************************************************
     /// Erases the value at the specified position.
     //*************************************************************************
-    iterator erase_after(iterator position)
+    iterator erase_after(const_iterator position)
     {
-      iterator next(position);
+      iterator next(const_cast<node_t*>(position.p_node));
       if (next != end())
       {
         ++next;
         if (next != end())
         {
           ++next;
-          remove_node_after(*position.p_node);
+          remove_node_after(*const_cast<node_t*>(position.p_node));
         }
       }
 
@@ -1015,13 +1015,13 @@ namespace etl
     //*************************************************************************
     /// Erases a range of elements.
     //*************************************************************************
-    iterator erase_after(iterator first, iterator last)
+    iterator erase_after(const_iterator first, const_iterator last)
     {
       if (first != end() && (first != last))
       {
-        node_t* p_first = first.p_node;
-        node_t* p_last = last.p_node;
-        node_t* p_next = p_first->next;
+        node_t* p_first = const_cast<node_t*>(first.p_node);
+        node_t* p_last = const_cast<node_t*>(last.p_node);
+        node_t* p_next = const_cast<node_t*>(p_first->next);
 
         // Join the ends.
         join(p_first, p_last);

--- a/include/etl/list.h
+++ b/include/etl/list.h
@@ -1205,20 +1205,20 @@ namespace etl
     //*************************************************************************
     /// Erases the value at the specified position.
     //*************************************************************************
-    iterator erase(iterator position)
+    iterator erase(const_iterator position)
     {
       ++position;
       remove_node(*position.p_node->previous);
-      return position;
+      return iterator(*const_cast<node_t*>(position.p_node));
     }
 
     //*************************************************************************
     /// Erases a range of elements.
     //*************************************************************************
-    iterator erase(iterator first, iterator last)
+    iterator erase(const_iterator first, const_iterator last)
     {
-      node_t* p_first = first.p_node;
-      node_t* p_last = last.p_node;
+      node_t* p_first = const_cast<node_t*>(first.p_node);
+      node_t* p_last = const_cast<node_t*>(last.p_node);
       node_t* p_next;
 
       // Join the ends.
@@ -1232,7 +1232,7 @@ namespace etl
         p_first = p_next;                                       // Move to the next node.
       }
 
-      return last;
+      return iterator(*const_cast<node_t*>(last.p_node));
     }
 
     //*************************************************************************

--- a/include/etl/list.h
+++ b/include/etl/list.h
@@ -1073,12 +1073,12 @@ namespace etl
     //*************************************************************************
     /// Inserts a value to the list at the specified position.
     //*************************************************************************
-    iterator insert(iterator position, const_reference value)
+    iterator insert(const_iterator position, const_reference value)
     {
       ETL_ASSERT(!full(), ETL_ERROR(list_full));
 
       data_node_t& data_node = allocate_data_node(value);
-      insert_node(*position.p_node, data_node);
+      insert_node(*const_cast<node_t*>(position.p_node), data_node);
 
       return iterator(data_node);
     }
@@ -1087,12 +1087,12 @@ namespace etl
     //*************************************************************************
     /// Inserts a value to the list at the specified position.
     //*************************************************************************
-    iterator insert(iterator position, rvalue_reference value)
+    iterator insert(const_iterator position, rvalue_reference value)
     {
       ETL_ASSERT(!full(), ETL_ERROR(list_full));
 
       data_node_t& data_node = allocate_data_node(etl::move(value));
-      insert_node(*position.p_node, data_node);
+      insert_node(*const_cast<node_t*>(position.p_node), data_node);
 
       return iterator(data_node);
     }
@@ -1103,7 +1103,7 @@ namespace etl
     //*************************************************************************
 #if ETL_CPP11_SUPPORTED && ETL_NOT_USING_STLPORT
     template <typename ... Args>
-    iterator emplace(iterator position, Args && ... args)
+    iterator emplace(const_iterator position, Args && ... args)
     {
       ETL_ASSERT(!full(), ETL_ERROR(list_full));
       ETL_ASSERT(p_node_pool != ETL_NULLPTR, ETL_ERROR(list_no_pool));
@@ -1111,13 +1111,13 @@ namespace etl
       data_node_t* p_data_node = create_data_node();
       ::new (&(p_data_node->value)) T(etl::forward<Args>(args)...);
       ETL_INCREMENT_DEBUG_COUNT
-      insert_node(*position.p_node, *p_data_node);
+      insert_node(*const_cast<node_t*>(position.p_node), *p_data_node);
 
       return iterator(*p_data_node);
     }
 #else
     template <typename T1>
-    iterator emplace(iterator position, const T1& value1)
+    iterator emplace(const_iterator position, const T1& value1)
     {
       ETL_ASSERT(!full(), ETL_ERROR(list_full));
       ETL_ASSERT(p_node_pool != ETL_NULLPTR, ETL_ERROR(list_no_pool));
@@ -1125,13 +1125,13 @@ namespace etl
       data_node_t* p_data_node = create_data_node();
       ::new (&(p_data_node->value)) T(value1);
       ETL_INCREMENT_DEBUG_COUNT
-      insert_node(*position.p_node, *p_data_node);
+      insert_node(*const_cast<node_t*>(position.p_node), *p_data_node);
 
       return iterator(*p_data_node);
     }
 
     template <typename T1, typename T2>
-    iterator emplace(iterator position, const T1& value1, const T2& value2)
+    iterator emplace(const_iterator position, const T1& value1, const T2& value2)
     {
       ETL_ASSERT(!full(), ETL_ERROR(list_full));
       ETL_ASSERT(p_node_pool != ETL_NULLPTR, ETL_ERROR(list_no_pool));
@@ -1139,13 +1139,13 @@ namespace etl
       data_node_t* p_data_node = create_data_node();
       ::new (&(p_data_node->value)) T(value1, value2);
       ETL_INCREMENT_DEBUG_COUNT
-      insert_node(*position.p_node, *p_data_node);
+      insert_node(*const_cast<node_t*>(position.p_node), *p_data_node);
 
       return iterator(*p_data_node);
     }
 
     template <typename T1, typename T2, typename T3>
-    iterator emplace(iterator position, const T1& value1, const T2& value2, const T3& value3)
+    iterator emplace(const_iterator position, const T1& value1, const T2& value2, const T3& value3)
     {
       ETL_ASSERT(!full(), ETL_ERROR(list_full));
       ETL_ASSERT(p_node_pool != ETL_NULLPTR, ETL_ERROR(list_no_pool));
@@ -1153,13 +1153,13 @@ namespace etl
       data_node_t* p_data_node = create_data_node();
       ::new (&(p_data_node->value)) T(value1, value2, value3);
       ETL_INCREMENT_DEBUG_COUNT
-      insert_node(*position.p_node, *p_data_node);
+      insert_node(*const_cast<node_t*>(position.p_node), *p_data_node);
 
       return iterator(*p_data_node);
     }
 
     template <typename T1, typename T2, typename T3, typename T4>
-    iterator emplace(iterator position, const T1& value1, const T2& value2, const T3& value3, const T4& value4)
+    iterator emplace(const_iterator position, const T1& value1, const T2& value2, const T3& value3, const T4& value4)
     {
       ETL_ASSERT(!full(), ETL_ERROR(list_full));
       ETL_ASSERT(p_node_pool != ETL_NULLPTR, ETL_ERROR(list_no_pool));
@@ -1167,7 +1167,7 @@ namespace etl
       data_node_t* p_data_node = create_data_node();
       ::new (&(p_data_node->value)) T(value1, value2, value3, value4);
       ETL_INCREMENT_DEBUG_COUNT
-      insert_node(*position.p_node, *p_data_node);
+      insert_node(*const_cast<node_t*>(position.p_node), *p_data_node);
 
       return iterator(*p_data_node);
     }
@@ -1176,14 +1176,14 @@ namespace etl
     //*************************************************************************
     /// Inserts 'n' copies of a value to the list at the specified position.
     //*************************************************************************
-    void insert(iterator position, size_t n, const_reference value)
+    void insert(const_iterator position, size_t n, const_reference value)
     {
       for (size_t i = 0UL; i < n; ++i)
       {
         ETL_ASSERT(!full(), ETL_ERROR(list_full));
 
         // Set up the next free node and insert.
-        insert_node(*position.p_node, allocate_data_node(value));
+        insert_node(*const_cast<node_t*>(position.p_node), allocate_data_node(value));
       }
     }
 
@@ -1191,14 +1191,14 @@ namespace etl
     /// Inserts a range of values to the list at the specified position.
     //*************************************************************************
     template <typename TIterator>
-    void insert(iterator position, TIterator first, TIterator last)
+    void insert(const_iterator position, TIterator first, TIterator last)
     {
       while (first != last)
       {
         ETL_ASSERT(!full(), ETL_ERROR(list_full));
 
         // Set up the next free node and insert.
-        insert_node(*position.p_node, allocate_data_node(*first++));
+        insert_node(*const_cast<node_t*>(position.p_node), allocate_data_node(*first++));
       }
     }
 
@@ -1360,7 +1360,7 @@ namespace etl
     //*************************************************************************
     /// Splices from another list to this.
     //*************************************************************************
-    void splice(iterator to, ilist& other)
+    void splice(const_iterator to, ilist& other)
     {
       if (&other != this)
       {
@@ -1373,7 +1373,7 @@ namespace etl
     //*************************************************************************
     /// Splices from another list to this.
     //*************************************************************************
-    void splice(iterator to, ilist&& other)
+    void splice(const_iterator to, ilist&& other)
     {
       if (&other != this)
       {
@@ -1391,7 +1391,7 @@ namespace etl
     //*************************************************************************
     /// Splices an element from another list to this.
     //*************************************************************************
-    void splice(iterator to, ilist& other, iterator from)
+    void splice(const_iterator to, ilist& other, const_iterator from)
     {
       if (&other == this)
       {
@@ -1410,7 +1410,7 @@ namespace etl
     //*************************************************************************
     /// Splices an element from another list to this.
     //*************************************************************************
-    void splice(iterator to, ilist&& other, iterator from)
+    void splice(const_iterator to, ilist&& other, const_iterator from)
     {
       if (&other == this)
       {
@@ -1429,7 +1429,7 @@ namespace etl
     //*************************************************************************
     /// Splices a range of elements from another list to this.
     //*************************************************************************
-    void splice(iterator to, ilist& other, iterator first, iterator last)
+    void splice(const_iterator to, ilist& other, const_iterator first, const_iterator last)
     {
       if (&other == this)
       {
@@ -1448,7 +1448,7 @@ namespace etl
     //*************************************************************************
     /// Splices a range of elements from another list to this.
     //*************************************************************************
-    void splice(iterator to, ilist&& other, iterator first, iterator last)
+    void splice(const_iterator to, ilist&& other, const_iterator first, const_iterator last)
     {
       if (&other == this)
       {
@@ -1458,7 +1458,7 @@ namespace etl
       else
       {
         // From another list.
-        ilist::iterator itr = first;
+        ilist::iterator itr = *const_cast<node_t*>(first.p_node);
         while (itr != last)
         {
           to = insert(to, etl::move(*itr++));
@@ -1875,15 +1875,15 @@ namespace etl
     /// Moves an element from one position to another within the list.
     /// Moves the element at position 'from' to the position before 'to'.
     //*************************************************************************
-    void move(iterator to, iterator from)
+    void move(const_iterator to, const_iterator from)
     {
       if (from == to)
       {
         return; // Can't more to before yourself!
       }
 
-      node_t& from_node = *from.p_node;
-      node_t& to_node = *to.p_node;
+      node_t& from_node = *const_cast<node_t*>(from.p_node);
+      node_t& to_node = *const_cast<node_t*>(to.p_node);
 
       // Disconnect the node from the list.
       join(*from_node.previous, *from_node.next);
@@ -1897,7 +1897,7 @@ namespace etl
     /// Moves a range from one position to another within the list.
     /// Moves a range at position 'first'/'last' to the position before 'to'.
     //*************************************************************************
-    void move(iterator to, iterator first, iterator last)
+    void move(const_iterator to, const_iterator first, const_iterator last)
     {
       if ((first == to) || (last == to))
       {
@@ -1912,10 +1912,10 @@ namespace etl
       }
 #endif
 
-      node_t& first_node = *first.p_node;
-      node_t& last_node = *last.p_node;
-      node_t& to_node = *to.p_node;
-      node_t& final_node = *last_node.previous;
+      node_t& first_node = *const_cast<node_t*>(first.p_node);
+      node_t& last_node = *const_cast<node_t*>(last.p_node);
+      node_t& to_node = *const_cast<node_t*>(to.p_node);
+      node_t& final_node = *const_cast<node_t*>(last_node.previous);
 
       // Disconnect the range from the list.
       join(*first_node.previous, last_node);

--- a/include/etl/vector.h
+++ b/include/etl/vector.h
@@ -550,9 +550,11 @@ namespace etl
     ///\param position The position to insert before.
     ///\param value    The value to insert.
     //*********************************************************************
-    iterator insert(iterator position, const_reference value)
+    iterator insert(const_iterator position, const_reference value)
     {
       ETL_ASSERT(size() != CAPACITY, ETL_ERROR(vector_full));
+
+      iterator insert_position(const_cast<iterator>(position));
 
       if (position == end())
       {
@@ -561,11 +563,11 @@ namespace etl
       else
       {
         create_back(back());
-        etl::move_backward(position, p_end - 2, p_end - 1);
-        *position = value;
+        etl::move_backward(insert_position, p_end - 2, p_end - 1);
+        *insert_position = value;
       }
 
-      return position;
+      return insert_position;
     }
 
 #if ETL_CPP11_SUPPORTED
@@ -575,22 +577,24 @@ namespace etl
     ///\param position The position to insert before.
     ///\param value    The value to insert.
     //*********************************************************************
-    iterator insert(iterator position, rvalue_reference value)
+    iterator insert(const_iterator position, rvalue_reference value)
     {
       ETL_ASSERT(size() != CAPACITY, ETL_ERROR(vector_full));
 
-      if (position == end())
+      iterator insert_position(const_cast<iterator>(position));
+
+      if (insert_position == end())
       {
         create_back(etl::move(value));
       }
       else
       {
         create_back(etl::move(back()));
-        etl::move_backward(position, p_end - 2, p_end - 1);
-        *position = etl::move(value);
+        etl::move_backward(insert_position, p_end - 2, p_end - 1);
+        *insert_position = etl::move(value);
       }
 
-      return position;
+      return insert_position;
     }
 #endif
 
@@ -599,36 +603,40 @@ namespace etl
     //*************************************************************************
 #if ETL_CPP11_SUPPORTED && ETL_NOT_USING_STLPORT
     template <typename ... Args>
-    iterator emplace(iterator position, Args && ... args)
+    iterator emplace(const_iterator position, Args && ... args)
     {
       ETL_ASSERT(!full(), ETL_ERROR(vector_full));
 
       void* p;
 
-      if (position == end())
+      iterator insert_position(const_cast<iterator>(position));
+
+      if (insert_position == end())
       {
         p = p_end++;
         ETL_INCREMENT_DEBUG_COUNT
       }
       else
       {
-        p = etl::addressof(*position);
+        p = etl::addressof(*insert_position);
         create_back(back());
-        etl::move_backward(position, p_end - 2, p_end - 1);
-        (*position).~T();
+        etl::move_backward(insert_position, p_end - 2, p_end - 1);
+        (*insert_position).~T();
       }
 
       ::new (p) T(etl::forward<Args>(args)...);
 
-      return position;
+      return insert_position;
     }
 #else
     template <typename T1>
-    iterator emplace(iterator position, const T1& value1)
+    iterator emplace(const_iterator position, const T1& value1)
     {
       ETL_ASSERT(!full(), ETL_ERROR(vector_full));
 
       void* p;
+
+      iterator insert_position(const_cast<iterator>(position));
 
       if (position == end())
       {
@@ -637,23 +645,25 @@ namespace etl
       }
       else
       {
-        p = etl::addressof(*position);
+        p = etl::addressof(*insert_position);
         create_back(back());
-        etl::move_backward(position, p_end - 2, p_end - 1);
-        (*position).~T();
+        etl::move_backward(insert_position, p_end - 2, p_end - 1);
+        (*insert_position).~T();
       }
 
       ::new (p) T(value1);
 
-      return position;
+      return insert_position;
     }
 
     template <typename T1, typename T2>
-    iterator emplace(iterator position, const T1& value1, const T2& value2)
+    iterator emplace(const_iterator position, const T1& value1, const T2& value2)
     {
       ETL_ASSERT(!full(), ETL_ERROR(vector_full));
 
       void* p;
+
+      iterator insert_position(const_cast<iterator>(position));
 
       if (position == end())
       {
@@ -662,23 +672,25 @@ namespace etl
       }
       else
       {
-        p = etl::addressof(*position);
+        p = etl::addressof(*insert_position);
         create_back(back());
-        etl::move_backward(position, p_end - 2, p_end - 1);
-        (*position).~T();
+        etl::move_backward(insert_position, p_end - 2, p_end - 1);
+        (*insert_position).~T();
       }
 
       ::new (p) T(value1, value2);
 
-      return position;
+      return insert_position;
     }
 
     template <typename T1, typename T2, typename T3>
-    iterator emplace(iterator position, const T1& value1, const T2& value2, const T3& value3)
+    iterator emplace(const_iterator position, const T1& value1, const T2& value2, const T3& value3)
     {
       ETL_ASSERT(!full(), ETL_ERROR(vector_full));
 
       void* p;
+
+      iterator insert_position(const_cast<iterator>(position));
 
       if (position == end())
       {
@@ -687,23 +699,25 @@ namespace etl
       }
       else
       {
-        p = etl::addressof(*position);
+        p = etl::addressof(*insert_position);
         create_back(back());
-        etl::move_backward(position, p_end - 2, p_end - 1);
-        (*position).~T();
+        etl::move_backward(insert_position, p_end - 2, p_end - 1);
+        (*insert_position).~T();
       }
 
       ::new (p) T(value1, value2, value3);
 
-      return position;
+      return insert_position;
     }
 
     template <typename T1, typename T2, typename T3, typename T4>
-    iterator emplace(iterator position, const T1& value1, const T2& value2, const T3& value3, const T4& value4)
+    iterator emplace(const_iterator position, const T1& value1, const T2& value2, const T3& value3, const T4& value4)
     {
       ETL_ASSERT(!full(), ETL_ERROR(vector_full));
 
       void* p;
+
+      iterator insert_position(const_cast<iterator>(position));
 
       if (position == end())
       {
@@ -712,15 +726,15 @@ namespace etl
       }
       else
       {
-        p = etl::addressof(*position);
+        p = etl::addressof(*insert_position);
         create_back(back());
-        etl::move_backward(position, p_end - 2, p_end - 1);
-        (*position).~T();
+        etl::move_backward(insert_position, p_end - 2, p_end - 1);
+        (*insert_position).~T();
       }
 
       ::new (p) T(value1, value2, value3, value4);
 
-      return position;
+      return insert_position;
     }
 #endif
 
@@ -731,12 +745,12 @@ namespace etl
     ///\param n        The number of elements to add.
     ///\param value    The value to insert.
     //*********************************************************************
-    void insert(iterator position, size_t n, parameter_t value)
+    void insert(const_iterator position, size_t n, parameter_t value)
     {
       ETL_ASSERT((size() + n) <= CAPACITY, ETL_ERROR(vector_full));
 
       size_t insert_n = n;
-      size_t insert_begin = etl::distance(begin(), position);
+      size_t insert_begin = etl::distance(cbegin(), position);
       size_t insert_end = insert_begin + insert_n;
 
       // Copy old data.
@@ -786,14 +800,14 @@ namespace etl
     ///\param last     The last + 1 element to add.
     //*********************************************************************
     template <class TIterator>
-    void insert(iterator position, TIterator first, TIterator last)
+    void insert(const_iterator position, TIterator first, TIterator last)
     {
       size_t count = etl::distance(first, last);
 
       ETL_ASSERT((size() + count) <= CAPACITY, ETL_ERROR(vector_full));
 
       size_t insert_n = count;
-      size_t insert_begin = etl::distance(begin(), position);
+      size_t insert_begin = etl::distance(cbegin(), position);
       size_t insert_end = insert_begin + insert_n;
 
       // Move old data.
@@ -856,16 +870,19 @@ namespace etl
     ///\param last  Iterator to the last element.
     ///\return An iterator pointing to the element that followed the erased element.
     //*********************************************************************
-    iterator erase(iterator first, iterator last)
+    iterator erase(const_iterator first, const_iterator last)
     {
-      if (first == begin() && last == end())
+      iterator first_(const_cast<iterator>(first));
+      iterator last_(const_cast<iterator>(last));
+
+      if (first_ == begin() && last_ == end())
       {
         clear();
       }
       else
       {
-        etl::move(last, end(), first);
-        size_t n_delete = etl::distance(first, last);
+        etl::move(last_, end(), first_);
+        size_t n_delete = etl::distance(first_, last_);
 
         // Destroy the elements left over at the end.
         etl::destroy(p_end - n_delete, p_end);
@@ -873,7 +890,7 @@ namespace etl
           p_end -= n_delete;
       }
 
-      return first;
+      return first_;
     }
 
     //*************************************************************************

--- a/include/etl/vector.h
+++ b/include/etl/vector.h
@@ -839,8 +839,9 @@ namespace etl
     ///\param i_element Iterator to the element.
     ///\return An iterator pointing to the element that followed the erased element.
     //*********************************************************************
-    iterator erase(iterator i_element)
+    iterator erase(const_iterator i_const_element)
     {
+      iterator i_element(const_cast<iterator>(i_const_element));
       etl::move(i_element + 1, end(), i_element);
       destroy_back();
 

--- a/test/test_list.cpp
+++ b/test/test_list.cpp
@@ -971,6 +971,58 @@ namespace
     }
 
     //*************************************************************************
+    TEST_FIXTURE(SetupFixture, test_const_erase_single)
+    {
+      CompareData compare_data(sorted_data.begin(), sorted_data.end());
+      DataNDC data(sorted_data.begin(), sorted_data.end());
+
+      DataNDC::const_iterator i_data = data.begin();
+      std::advance(i_data, 2);
+
+      CompareData::const_iterator i_compare_data = compare_data.begin();
+      std::advance(i_compare_data, 2);
+
+      i_compare_data = compare_data.erase(i_compare_data);
+      i_data         = data.erase(i_data);
+
+      CHECK_EQUAL(compare_data.size(), data.size());
+
+      are_equal = std::equal(data.begin(), data.end(), compare_data.begin());
+
+      CHECK(are_equal);
+      CHECK(*i_compare_data == *i_data);
+
+      i_compare_data = compare_data.erase(compare_data.begin());
+      i_data         = data.erase(data.begin());
+
+      CHECK_EQUAL(compare_data.size(), data.size());
+
+      are_equal = std::equal(data.begin(), data.end(), compare_data.begin());
+
+      CHECK(are_equal);
+
+      are_equal = i_data == data.begin();
+      CHECK(are_equal);
+
+      // Move to the last value and erase.
+      i_compare_data = compare_data.begin();
+      std::advance(i_compare_data, compare_data.size() - 1);
+      i_compare_data = compare_data.erase(i_compare_data);
+
+      i_data = data.begin();
+      std::advance(i_data, data.size() - 1);
+      i_data = data.erase(i_data);
+
+      CHECK_EQUAL(compare_data.size(), data.size());
+
+      are_equal = std::equal(data.begin(), data.end(), compare_data.begin());
+
+      CHECK(are_equal);
+      are_equal = i_data == data.end();
+      CHECK(are_equal);
+    }
+
+    //*************************************************************************
     TEST_FIXTURE(SetupFixture, test_erase_range)
     {
       CompareData compare_data(sorted_data.begin(), sorted_data.end());

--- a/test/test_vector.cpp
+++ b/test/test_vector.cpp
@@ -913,11 +913,41 @@ namespace
       Compare_Data compare_data(initial_data.begin(), initial_data.end());
       Data data(initial_data.begin(), initial_data.end());
 
-      compare_data.erase(compare_data.begin() + 2);
+      Compare_Data::iterator i_compare = compare_data.begin();
+      Data::iterator i_data            = data.begin();
 
-      data.erase(data.begin() + 2);
+      std::advance(i_compare, 2);
+      std::advance(i_data,    2);
+
+      Compare_Data::iterator i_compare1 = compare_data.erase(i_compare);
+      Data::iterator i_data1 = data.erase(i_data);
+
+      CHECK_EQUAL(*i_compare1, *i_data1);
+
+      bool is_equal = std::equal(data.begin(),
+                                data.end(),
+                                compare_data.begin());
+
+      CHECK(is_equal);
+    }
+
+    //*************************************************************************
+    TEST_FIXTURE(SetupFixture, test_const_erase_single)
+    {
+      Compare_Data compare_data(initial_data.begin(), initial_data.end());
+      Data data(initial_data.begin(), initial_data.end());
+
+      Compare_Data::const_iterator i_compare = compare_data.cbegin();
+      Data::const_iterator i_data = data.cbegin();
+
+      std::advance(i_compare, 2);
+      std::advance(i_data, 2);
+
+      Compare_Data::const_iterator i_compare1 = compare_data.erase(i_compare);
+      Data::const_iterator i_data1 = data.erase(i_data);
 
       CHECK_EQUAL(compare_data.size(), data.size());
+      CHECK_EQUAL(*i_compare1, *i_data1);
 
       bool is_equal = std::equal(data.begin(),
                                 data.end(),


### PR DESCRIPTION
Beginning with C++11, most STL container modifier methods (like insert, emplace, erase, ...) accept a const_iterator instead of a iterator.

This PR improves C++11 compatibility for the STL container replacements in etl by accepting a const_iterator as argument. 

I didn't touch the flat_* and reference_flat_* containers in etl because I'm not very familiar with them. If necessary, I could try to add const_iterator there as well.