### PR TITLE
harmonize copy ctor and assignment op for etl::delegate

### DIFF
--- a/include/etl/delegate.h
+++ b/include/etl/delegate.h
@@ -111,10 +111,7 @@ namespace etl
     //*************************************************************************
     // Copy constructor.
     //*************************************************************************
-    ETL_CONSTEXPR14 delegate(const delegate& other)
-      : invocation(other.invocation)
-    {
-    }
+    ETL_CONSTEXPR14 delegate(const delegate& other) = default;
 
     //*************************************************************************
     // Construct from lambda or functor.


### PR DESCRIPTION
etl::delegate has a user-written copy constructor and a defaulted assignment
operator. The copy constructor does the same as a defaulted copy constructor,
therefore there is no need to add a user-written copy constructor.

The combination of user-written copy constructor and defaulted assignment
operator causes a warning in Coverity, a static code analyzer:

`copy_without_assign: Class etl::delegate<void ()> has a user-written copy constructor etl::delegate<void ()>::delegate(etl::delegate<void ()> const &) but no corresponding user-written assignment operator.`

This commit replaces the user-written copy constructor with a defaulted copy
constructor, which does the same.