### PR TITLE
Sync library name with arduino version

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,5 +1,5 @@
 {
-  "name": "ETL Embedded Template Library",
+  "name": "Embedded Template Library ETL",
   "version": "20.22.0",
   "author s": {
     "name": "John Wellbelove",

--- a/library.json
+++ b/library.json
@@ -1,13 +1,14 @@
 {
   "name": "Embedded Template Library ETL",
   "version": "20.22.0",
-  "author s": {
+  "authors": {
     "name": "John Wellbelove",
     "email": "john.wellbelove@etlcpp.com"
   },
   "homepage": "https://www.etlcpp.com/",
   "license": "MIT",
   "description": "ETL. A C++ template library tailored for embedded systems.",
+  "keywords": "c-plus-plus, cpp, algorithms, containers, templates",
   "repository": {
     "type": "git",
     "url": "https://github.com/ETLCPP/etl.git"


### PR DESCRIPTION
There is a conflict between the two library manifests: the field "name" differs. As result, PlatformIO Crawler fails and can't fetch the latest version. See 

https://registry.platformio.org/packages/libraries/etlcpp/Embedded%20Template%20Library