### PR TITLE
Revert back name to the original version, avoid conflict with arduino library

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,5 +1,5 @@
 {
-  "name": "Embedded Template Library ETL",
+  "name": "Embedded Template Library",
   "version": "20.22.0",
   "authors": {
     "name": "John Wellbelove",


### PR DESCRIPTION
The solution to https://github.com/ETLCPP/etl/pull/487

I propose to revert back a name to the original name https://registry.platformio.org/packages/libraries/etlcpp/Embedded%20Template%20Library

In any case, we still will have the issue. There is a `library.properties` manifest in the root of the repository which has the same manifest as https://github.com/ETLCPP/etl-arduino/blob/master/library.properties

Is it possible to REMOVE `library.properties` from the main repository? It does not make sense to keep it in the repository, the library in this form is not compatible with Arduino IDE. It will help us to avoid issues when 1 repo contains multiple manifests with the different names.