### PR TITLE
Added to_string, to_ulong and to_ullong to bitset

### DIFF
--- a/include/etl/bitset.h
+++ b/include/etl/bitset.h
@@ -839,7 +839,6 @@ namespace etl
     }
 #endif
 
-
   protected:
 
     //*************************************************************************
@@ -953,7 +952,7 @@ namespace etl
     static ETL_CONSTANT size_t ARRAY_SIZE = (MAXN % BITS_PER_ELEMENT == 0) ? MAXN / BITS_PER_ELEMENT : MAXN / BITS_PER_ELEMENT + 1;
 
   public:
-  
+
     static ETL_CONSTANT size_t ALLOCATED_BITS = ARRAY_SIZE * BITS_PER_ELEMENT;
 
   public:

--- a/include/etl/bitset.h
+++ b/include/etl/bitset.h
@@ -1114,7 +1114,7 @@ namespace etl
     /// Returns a string representing the bitset.
     //*************************************************************************
     template<class STRINGT = etl::string<MAXN> >
-    STRINGT to_string(typename STRINGT::value_type zero = STRINGT::value_type('0'), typename STRINGT::value_type one = STRINGT::value_type('1')) const
+    STRINGT to_string(typename STRINGT::value_type zero = typename STRINGT::value_type('0'), typename STRINGT::value_type one = typename STRINGT::value_type('1')) const
     {
       STRINGT result;
 

--- a/include/etl/profiles/determine_compiler_language_support.h
+++ b/include/etl/profiles/determine_compiler_language_support.h
@@ -79,7 +79,7 @@ SOFTWARE.
 #endif
 
 // NAN not defined or Rowley CrossWorks
-#if !defined(NAN) || defined(__CROSSWORKS_ARM) || defined(ETL_COMPILER_ARM5)
+#if !defined(NAN) || defined(__CROSSWORKS_ARM) || defined(ETL_COMPILER_ARM5) || defined(ARDUINO)
   #define ETL_NO_CPP_NAN_SUPPORT
 #endif
 


### PR DESCRIPTION
Also defined ARDUINO as ETL_NO_CPP_NAN_SUPPORT
it does not have the functions nan, nanf or nanl, it does have `NAN` defined in `math.h` as
```C
#define NAN	__builtin_nan("")
```

was tested on arduino mega, I think the compiler is `avrisp` (I'm not that strong in arduino)
and visual studio 2020 defined to c++17