### PR TITLE
fix unused-local-typedefs warning

### DIFF
--- a/include/etl/algorithm.h
+++ b/include/etl/algorithm.h
@@ -295,8 +295,6 @@ namespace etl
   typename etl::enable_if<etl::is_pointer<TIterator>::value, void>::type
     reverse(TIterator b, TIterator e)
   {
-    typedef typename etl::iterator_traits<TIterator>::value_type value_type;
-
     if (b != e)
     {
       while (b < --e)


### PR DESCRIPTION
clang complains about the line:

include/etl/algorithm.h:298:66: error: typedef 'value_type' locally defined but not used [-Werror=unused-local-typedefs]
typedef typename etl::iterator_traits<TIterator>::value_type value_type;