### PR TITLE
Fix cplusplus constant type

### DIFF
--- a/include/etl/platform.h
+++ b/include/etl/platform.h
@@ -377,7 +377,7 @@ namespace etl
     static ETL_CONSTANT bool has_mutable_array_view           = (ETL_HAS_MUTABLE_ARRAY_VIEW == 1);
     static ETL_CONSTANT bool has_ideque_repair                = (ETL_HAS_IDEQUE_REPAIR == 1);
     static ETL_CONSTANT bool is_debug_build                   = (ETL_IS_DEBUG_BUILD == 1);
-    static ETL_CONSTANT  int cplusplus                        = __cplusplus;
+    static ETL_CONSTANT long cplusplus                        = __cplusplus;
   }
 }
 


### PR DESCRIPTION
Hi!
A super minor issue I've faced.
Hope this helps.

Adjust the ETL variable type to match C++'s.

Macro __cplusplus is defined as a `long` as in:
- 199711L (C++98 or C++03)
- 201103L (C++11)
- 201402L (C++14)
- 201703L (C++17)
- 202002L (C++20)

It usually fits an int (4 bytes), but on some platforms (e.g. some Arduinos) an int is defined as a 2-bytes value.
