### PR TITLE
Remove unused typedef causing compilation warning.

### DIFF
--- a/include/etl/algorithm.h
+++ b/include/etl/algorithm.h
@@ -295,8 +295,6 @@ namespace etl
   typename etl::enable_if<etl::is_pointer<TIterator>::value, void>::type
     reverse(TIterator b, TIterator e)
   {
-    typedef typename etl::iterator_traits<TIterator>::value_type value_type;
-
     if (b != e)
     {
       while (b < --e)


### PR DESCRIPTION
Typedef for value_type is unused in the reverse function (pointers version), so it can be removed.