### PR TITLE
Fix compilation of reference_counted_message_pool with ETL_LOG_ERROR enabled

### DIFF
--- a/include/etl/reference_counted_message_pool.h
+++ b/include/etl/reference_counted_message_pool.h
@@ -61,7 +61,7 @@ namespace etl
   //***************************************************************************
   /// Exception if the allocation failed.
   //***************************************************************************
-  class reference_counted_message_pool_allocation_failure : etl::reference_counted_message_pool_exception
+  class reference_counted_message_pool_allocation_failure : public etl::reference_counted_message_pool_exception
   {
   public:
 
@@ -74,7 +74,7 @@ namespace etl
   //***************************************************************************
   /// Exception if the release failed.
   //***************************************************************************
-  class reference_counted_message_pool_release_failure : etl::reference_counted_message_pool_exception
+  class reference_counted_message_pool_release_failure : public etl::reference_counted_message_pool_exception
   {
   public:
 


### PR DESCRIPTION
The fix is for the following compilation errors that were reported when `ETL_LOG_ERROR` was enabled
```
etl/include/etl/reference_counted_message_pool.h:125:7: error: ‘etl::exception’ is an inaccessible base of ‘etl::reference_counted_message_pool_allocation_failure’
  125 |       ETL_ASSERT((p != ETL_NULLPTR), ETL_ERROR(etl::reference_counted_message_pool_allocation_failure));
      |       ^~~~~~~~~~
...
etl/reference_counted_message_pool.h:167:7: error: ‘etl::exception’ is an inaccessible base of ‘etl::reference_counted_message_pool_release_failure’
  167 |       ETL_ASSERT(released, ETL_ERROR(etl::reference_counted_message_pool_release_failure));
      |       ^~~~~~~~~~
```

Here is the content of our `etl_profile.h`:
```cpp

#ifndef ETL_PROFILE_INCLUDED_
#define ETL_PROFILE_INCLUDED_

#include "etl/profiles/determine_compiler_language_support.h"
#include "etl/profiles/determine_compiler_version.h"
#include "etl/profiles/determine_development_os.h"

//*****************************************************************************
// Generic C++17
//*****************************************************************************
#ifdef UNITTEST
#define ETL_IN_UNIT_TEST

#ifndef ETL_DEVELOPMENT_OS_DETECTED
#define ETL_TARGET_OS_LINUX
#endif

#ifndef ETL_COMPILER_TYPE_DETECTED
#define ETL_COMPILER_GCC
#endif

#else /* ifdef UNITTEST */

#define ETL_TARGET_DEVICE_ARM

#ifndef ETL_DEVELOPMENT_OS_DETECTED
#define ETL_TARGET_OS_NONE
#endif

#ifndef ETL_COMPILER_TYPE_DETECTED
#define ETL_COMPILER_ARM7
#endif

#endif /* ifdef UNITTEST else */


#ifndef ETL_CPP17_SUPPORTED
#define ETL_CPP17_SUPPORTED 1
#endif

#ifdef ETL_CPP20_SUPPORTED
#undef ETL_CPP20_SUPPORTED
#endif
#define ETL_CPP20_SUPPORTED 0


/* ETL Error handling */
#define ETL_LOG_ERRORS 1
#define ETL_CHECK_PUSH_POP 1
#define ETL_VERBOSE_ERRORS 1

namespace etl {
    class exception;
};

/**
 * @brief ETL error handler
 *
 * The error handler only logs an error raised in ETL.
 * Note that many ETL methods use ETL_ASSERT macro that allows to continue
 * running the method code even if assert failed.
 *
 * @param e exception info from ETL
 */
void etl_err_handler(const etl::exception& e);

#endif /* #ifndef ETL_PROFILE_INCLUDED_ */

```