### PR TITLE
CMake: add a flag to enable version lookup outside the root folder

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ cmake_minimum_required(VERSION 3.5.0)
 
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/helpers.cmake)
 
-determine_version_with_git()
+determine_version_with_git(${GIT_DIR_LOOKUP_POLICY})
 
 project(etl VERSION ${ETL_VERSION})
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,13 @@ add_executable(foo main.cpp)
 target_link_libraries(foo PRIVATE etl)
 ```
 
+If ETL library is used as a Git submodule it may require additional configuration for proper ETL version resolution by allowing the lookup for Git folder outside of the library root directory.
+
+```cmake
+set(GIT_DIR_LOOKUP_POLICY ALLOW_LOOKING_ABOVE_CMAKE_SOURCE_DIR)
+add_subdirectory(etl)
+```
+
 If you want to install this library with CMake, you can perform the following steps. On Linux,
 super user rights might be required to install the library, so it might be necessary to add
 `sudo` before the last command:

--- a/cmake/GetGitRevisionDescription.cmake
+++ b/cmake/GetGitRevisionDescription.cmake
@@ -176,7 +176,7 @@ function(git_describe _var)
     if(NOT GIT_FOUND)
         find_package(Git QUIET)
     endif()
-    get_git_head_revision(refspec hash)
+    get_git_head_revision(refspec hash ${ARGN})
     if(NOT GIT_FOUND)
         set(${_var}
             "GIT-NOTFOUND"

--- a/cmake/helpers.cmake
+++ b/cmake/helpers.cmake
@@ -10,7 +10,7 @@ endfunction()
 
 function(determine_version_with_git)
     include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/GetGitRevisionDescription.cmake)
-    git_describe(VERSION)
+    git_describe(VERSION ${ARGN})
     string(FIND ${VERSION} "." VALID_VERSION)
     if(VALID_VERSION EQUAL -1)
         message(WARNING "Version string ${VERSION} retrieved with git describe is invalid")


### PR DESCRIPTION
Add ARGN  to `determine_version_with_git()` params list to allow specifying optional ALLOW_LOOKING_ABOVE_CMAKE_SOURCE_DIR flag.