### PR TITLE
cmake: write an arch independent version file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,7 @@ if(${CMAKE_PROJECT_NAME} STREQUAL ${PROJECT_NAME})
         write_basic_package_version_file(
             "${PROJECT_NAME}ConfigVersion.cmake"
             COMPATIBILITY SameMajorVersion
+            ARCH_INDEPENDENT
         )
     endif()
     configure_package_config_file(


### PR DESCRIPTION
The recently introduced changes made cross-compiling with cmake impossible.

From cmake docs:

New in version 3.14: If ARCH_INDEPENDENT is given, the installed package version will be considered compatible even if it was built for a different architecture than the requested architecture. Otherwise, an architecture check will be performed, and the package will be considered compatible only if the architecture matches exactly. For example, if the package is built for a 32-bit architecture, the package is only considered compatible if it is used on a 32-bit architecture, unless ARCH_INDEPENDENT is given, in which case the package is considered compatible on any architecture.

```
Note ARCH_INDEPENDENT is intended for header-only libraries or similar packages with no binaries.
```