### PR TITLE
Fix spelling

### DIFF
--- a/examples/SharedMessage/SharedMessage.cpp
+++ b/examples/SharedMessage/SharedMessage.cpp
@@ -188,7 +188,7 @@ private:
 };
 
 //*****************************************************************************
-// A message bus that can accomodate two subscribers.
+// A message bus that can accommodate two subscribers.
 //*****************************************************************************
 struct Bus : public etl::message_bus<2U>
 {

--- a/include/etl/algorithm.h
+++ b/include/etl/algorithm.h
@@ -106,14 +106,14 @@ namespace etl
   //***************************************************************************
   // swap_ranges
   //***************************************************************************
-  template <typename T1terator1, typename TIterator2>
+  template <typename TIterator1, typename TIterator2>
 #if ETL_USING_STD_NAMESPACE
   ETL_CONSTEXPR20
 #else
   ETL_CONSTEXPR14
 #endif
-  TIterator2 swap_ranges(T1terator1 first1,
-                         T1terator1 last1,
+  TIterator2 swap_ranges(TIterator1 first1,
+                         TIterator1 last1,
                          TIterator2 first2)
   {
     while (first1 != last1)

--- a/include/etl/alignment.h
+++ b/include/etl/alignment.h
@@ -28,8 +28,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 ******************************************************************************/
 
-#ifndef ETL_ALIGNEMENT_INCLUDED
-#define ETL_ALIGNEMENT_INCLUDED
+#ifndef ETL_ALIGNMENT_INCLUDED
+#define ETL_ALIGNMENT_INCLUDED
 
 #include <stdint.h>
 

--- a/include/etl/array.h
+++ b/include/etl/array.h
@@ -362,7 +362,7 @@ namespace etl
     //*************************************************************************
     /// Fills the array from the range.
     /// If the range is smaller than the array then the unused array elements are left unmodified.
-    ///\param first The iterator to the first item in the ramge.
+    ///\param first The iterator to the first item in the range.
     ///\param last  The iterator to one past the final item in the range.
     //*************************************************************************
     template <typename TIterator>
@@ -374,7 +374,7 @@ namespace etl
     //*************************************************************************
     /// Fills the array from the range.
     /// If the range is smaller than the array then the unused array elements are initialised with the supplied value.
-    ///\param first The iterator to the first item in the ramge.
+    ///\param first The iterator to the first item in the range.
     ///\param last  The iterator to one past the final item in the range.
     //*************************************************************************
     template <typename TIterator>

--- a/include/etl/basic_format_spec.h
+++ b/include/etl/basic_format_spec.h
@@ -219,7 +219,7 @@ namespace etl
     }
 
     //***************************************************************************
-    /// Cconstructor.
+    /// Constructor.
     //***************************************************************************
     ETL_CONSTEXPR basic_format_spec(uint_least8_t base__,
                                     uint_least8_t width__,

--- a/include/etl/basic_string.h
+++ b/include/etl/basic_string.h
@@ -1626,7 +1626,7 @@ namespace etl
     }
 
     //*********************************************************************
-    /// Replace characters from 'position' of 'length' with 'str' from 'subpsotion' of 'sublength'.
+    /// Replace characters from 'position' of 'length' with 'str' from 'subposition' of 'sublength'.
     //*********************************************************************
     ibasic_string& replace(size_type position, size_type length_, const ibasic_string& str, size_type subposition, size_type sublength)
     {

--- a/include/etl/bresenham_line.h
+++ b/include/etl/bresenham_line.h
@@ -81,7 +81,7 @@ namespace etl
       }
 
       //***************************************************
-      /// Copy constuctor
+      /// Copy constructor
       //***************************************************
       const_iterator(const const_iterator& other)
         : p_bresenham_line(other.p_bresenham_line)

--- a/include/etl/compare.h
+++ b/include/etl/compare.h
@@ -44,7 +44,7 @@ SOFTWARE.
 namespace etl
 {
   //***************************************************************************
-  /// Defines <=, >, >= interms of <
+  /// Defines <=, >, >= in terms of <
   /// Default
   //***************************************************************************
   template <typename T, typename TLess = etl::less<T> >

--- a/include/etl/covariance.h
+++ b/include/etl/covariance.h
@@ -159,7 +159,7 @@ namespace etl
     }
 
     //*********************************
-    /// Get the covaniance.
+    /// Get the covariance.
     //*********************************
     double get_covariance() const
     {

--- a/include/etl/cumulative_moving_average.h
+++ b/include/etl/cumulative_moving_average.h
@@ -260,7 +260,7 @@ namespace etl
   private:
 
     T        average; ///< The current cumulative average.
-    sample_t samples; ///< The nuimber of samples to average over.
+    sample_t samples; ///< The number of samples to average over.
   };
 
   //***************************************************************************

--- a/include/etl/fibonacci.h
+++ b/include/etl/fibonacci.h
@@ -43,8 +43,8 @@ namespace etl
 {
   //***************************************************************************
   ///\ingroup fibonacci
-  /// Defines <b>value</b> as the Nth Fibbonacci number.
-  ///\tparam N The number to find the Fibbonacci value of.
+  /// Defines <b>value</b> as the Nth Fibonacci number.
+  ///\tparam N The number to find the Fibonacci value of.
   //***************************************************************************
   template <size_t N>
   struct fibonacci

--- a/include/etl/hfsm.h
+++ b/include/etl/hfsm.h
@@ -86,7 +86,7 @@ namespace etl
   private:
 
     //*******************************************
-    /// Return the first common ancester of the two states.
+    /// Return the first common ancestor of the two states.
     //*******************************************
     static etl::ifsm_state* common_ancestor(etl::ifsm_state* s1, etl::ifsm_state* s2)
     {

--- a/include/etl/indirect_vector.h
+++ b/include/etl/indirect_vector.h
@@ -604,7 +604,7 @@ namespace etl
 
     //*********************************************************************
     /// Does nothing.
-    /// For compatilbilty with the STL vector API.
+    /// For compatibility with the STL vector API.
     //*********************************************************************
     void reserve(size_t)
     {

--- a/include/etl/instance_count.h
+++ b/include/etl/instance_count.h
@@ -103,7 +103,7 @@ namespace etl
   private:
 
     //*************************************************************************
-    /// Get a referenceto the count.
+    /// Get a reference to the count.
     //*************************************************************************
     static counter_type& current_instance_count()
     {

--- a/include/etl/integral_limits.h
+++ b/include/etl/integral_limits.h
@@ -41,7 +41,7 @@ SOFTWARE.
 
 //*****************************************************************************
 ///\defgroup integral_limits integral_limits
-/// A set of templated compile time constants that mirror some of std::numeric_limits funtionality.
+/// A set of templated compile time constants that mirror some of std::numeric_limits functionality.
 ///\ingroup utilities
 //*****************************************************************************
 

--- a/include/etl/intrusive_queue.h
+++ b/include/etl/intrusive_queue.h
@@ -128,7 +128,7 @@ namespace etl
     //*************************************************************************
     /// Removes the oldest item from the queue and pushes it to the destination.
     /// Undefined behaviour if the queue is already empty.
-    /// NOTE: The destination must be an intrusize container that supports a push(TLink) member function.
+    /// NOTE: The destination must be an intrusive container that supports a push(TLink) member function.
     //*************************************************************************
     template <typename TContainer>
     void pop_into(TContainer& destination)

--- a/include/etl/intrusive_stack.h
+++ b/include/etl/intrusive_stack.h
@@ -116,7 +116,7 @@ namespace etl
     //*************************************************************************
     /// Removes the oldest item from the queue and pushes it to the destination.
     /// Undefined behaviour if the queue is already empty.
-    /// NOTE: The destination must be an intrusize container that supports a push(TLink) member function.
+    /// NOTE: The destination must be an intrusive container that supports a push(TLink) member function.
     //*************************************************************************
     template <typename TContainer>
     void pop_into(TContainer& destination)

--- a/include/etl/map.h
+++ b/include/etl/map.h
@@ -1991,7 +1991,7 @@ namespace etl
           }
           else
           {
-            // Attatch node to right
+            // Attach node to right
             attach_node(found->children[found->dir], node);
 
             // Return newly added node
@@ -2024,7 +2024,7 @@ namespace etl
       }
       else
       {
-        // Attatch node to current position
+        // Attach node to current position
         attach_node(position, node);
 
         // Return newly added node at current position

--- a/include/etl/memory.h
+++ b/include/etl/memory.h
@@ -1629,7 +1629,7 @@ bool operator >=(const etl::unique_ptr<T1, TD1>&lhs, const etl::unique_ptr<T2, T
 namespace etl
 {
   //*****************************************************************************
-  /// Default contruct an item at address p.
+  /// Default construct an item at address p.
   ///\ingroup memory
   //*****************************************************************************
   template <typename T>
@@ -1639,7 +1639,7 @@ namespace etl
   }
 
   //*****************************************************************************
-  /// Default contruct an item at address p.
+  /// Default construct an item at address p.
   ///\ingroup memory
   //*****************************************************************************
   template <typename T, typename TCounter>
@@ -1650,7 +1650,7 @@ namespace etl
   }
 
   //*****************************************************************************
-  /// Default contruct an item at address p.
+  /// Default construct an item at address p.
   ///\ingroup memory
   //*****************************************************************************
   template <typename T>
@@ -1661,7 +1661,7 @@ namespace etl
   }
 
   //*****************************************************************************
-  /// Default contruct an item at address p.
+  /// Default construct an item at address p.
   ///\ingroup memory
   //*****************************************************************************
   template <typename T, typename TCounter>

--- a/include/etl/multi_array.h
+++ b/include/etl/multi_array.h
@@ -35,7 +35,7 @@ SOFTWARE.
 #include "array.h"
 
 ///\defgroup multi_array multi_array
-/// A multi dimentional array.
+/// A multi dimensional array.
 ///\ingroup containers
 
 namespace etl

--- a/include/etl/multi_vector.h
+++ b/include/etl/multi_vector.h
@@ -35,7 +35,7 @@
 #include "vector.h"
 
 ///\defgroup multi_vector multi_vector
-/// A multi dimentional vector.
+/// A multi dimensional vector.
 ///\ingroup containers
 
 #if ETL_USING_CPP11

--- a/include/etl/multiset.h
+++ b/include/etl/multiset.h
@@ -2029,7 +2029,7 @@ namespace etl
       }
       else
       {
-        // Attatch node to current position (which is assumed to be root)
+        // Attach node to current position (which is assumed to be root)
         attach_node(ETL_NULLPTR, position, node);
 
         // Return newly added node at current position

--- a/include/etl/observer.h
+++ b/include/etl/observer.h
@@ -92,7 +92,7 @@ namespace etl
   //*********************************************************************
   /// The object that is being observed.
   ///\tparam TObserver     The observer type.
-  ///\tparam MAX_OBSERVERS The maximum number of observers that can be accomodated.
+  ///\tparam MAX_OBSERVERS The maximum number of observers that can be accommodated.
   ///\ingroup observer
   //*********************************************************************
   template <typename TObserver, const size_t MAX_OBSERVERS>

--- a/include/etl/permutations.h
+++ b/include/etl/permutations.h
@@ -41,7 +41,7 @@ namespace etl
 {
   //***************************************************************************
   ///\ingroup permutations
-  /// Calculates permutaions.
+  /// Calculates permutations.
   //***************************************************************************
   template <const size_t NV, const size_t KV>
   struct permutations

--- a/include/etl/private/to_string_helper.h
+++ b/include/etl/private/to_string_helper.h
@@ -157,7 +157,7 @@ namespace etl
 
       if (value == 0)
       {
-        // If number is negative, append '-' (a negative zero might occure for fractional numbers > -1.0)
+        // If number is negative, append '-' (a negative zero might occur for fractional numbers > -1.0)
         if ((format.get_base() == 10U) && negative)
         {
           str.push_back(type('-'));
@@ -377,7 +377,7 @@ namespace etl
 
       iterator start = str.end();
 
-      // Caculate the denominator.
+      // Calculate the denominator.
       working_t denominator = 1U;
 
       for (uint32_t i = 0U; i < denominator_exponent; ++i)
@@ -558,11 +558,11 @@ namespace etl
     typename etl::enable_if<etl::is_integral<T>::value &&
                             !etl::is_same<T, bool>::value &&
                             !etl::is_one_of<T, int64_t, uint64_t>::value, const TIString&>::type
-      to_string(const T value, uint32_t denominator_exponant, TIString& str, const etl::basic_format_spec<TIString>& format, const bool append = false)
+      to_string(const T value, uint32_t denominator_exponent, TIString& str, const etl::basic_format_spec<TIString>& format, const bool append = false)
     {
       typedef typename etl::conditional<etl::is_signed<T>::value, int32_t, uint32_t>::type type;
 
-      etl::private_to_string::add_integral_denominated(type(value), denominator_exponant, str, format, append);
+      etl::private_to_string::add_integral_denominated(type(value), denominator_exponent, str, format, append);
 
       return str;
     }
@@ -574,9 +574,9 @@ namespace etl
     typename etl::enable_if<etl::is_integral<T>::value&&
                             !etl::is_same<T, bool>::value&&
                             etl::is_one_of<T, int64_t, uint64_t>::value, const TIString&>::type
-      to_string(const T value, uint32_t denominator_exponant, TIString& str, const etl::basic_format_spec<TIString>& format, const bool append = false)
+      to_string(const T value, uint32_t denominator_exponent, TIString& str, const etl::basic_format_spec<TIString>& format, const bool append = false)
     {
-      etl::private_to_string::add_integral_denominated(value, denominator_exponant, str, format, append);
+      etl::private_to_string::add_integral_denominated(value, denominator_exponent, str, format, append);
 
       return str;
     }
@@ -602,9 +602,9 @@ namespace etl
     template <typename T, typename TIString>
     typename etl::enable_if<etl::is_integral<T>::value &&
       !etl::is_same<T, bool>::value>::value, const TIString& > ::type
-      to_string(const T value, uint32_t denominator_exponant, TIString& str, const etl::basic_format_spec<TIString>& format, const bool append = false)
+      to_string(const T value, uint32_t denominator_exponent, TIString& str, const etl::basic_format_spec<TIString>& format, const bool append = false)
     {
-      etl::private_to_string::add_integral_denominated(type(value), denominator_exponant, str, format, append, false);
+      etl::private_to_string::add_integral_denominated(type(value), denominator_exponent, str, format, append, false);
 
       return str;
     }

--- a/include/etl/private/variant_variadic.h
+++ b/include/etl/private/variant_variadic.h
@@ -857,7 +857,7 @@ namespace etl
 
 #if ETL_USING_CPP17 && !defined(ETL_VARIANT_FORCE_CPP11)
     //***************************************************************************
-    /// Call the relevent visitor by attemptng each one.
+    /// Call the relevent visitor by attempting each one.
     //***************************************************************************
     template <size_t... I>
     void do_accept(etl::visitor<TTypes...>& visitor, etl::index_sequence<I...>)
@@ -934,7 +934,7 @@ namespace etl
 
 #if ETL_USING_CPP17 && !defined(ETL_VARIANT_FORCE_CPP11)
     //***************************************************************************
-    /// Call the relevent visitor by attemptng each one.
+    /// Call the relevent visitor by attempting each one.
     //***************************************************************************
     template <typename TVisitor, size_t... I>
     void do_operator(TVisitor& visitor, etl::index_sequence<I...>)

--- a/include/etl/quantize.h
+++ b/include/etl/quantize.h
@@ -28,8 +28,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 ******************************************************************************/
 
-#ifndef ETL_QUANTATIZE_INCLUDED
-#define ETL_QUANTATIZE_INCLUDED
+#ifndef ETL_QUANTIZE_INCLUDED
+#define ETL_QUANTIZE_INCLUDED
 
 #include "platform.h"
 #include "functional.h"

--- a/include/etl/queue_lockable.h
+++ b/include/etl/queue_lockable.h
@@ -66,7 +66,7 @@ namespace etl
     //*************************************************************************
     size_type available_unlocked() const
     {
-      return available_impementation();
+      return available_implementation();
     }
 
     //*************************************************************************
@@ -76,7 +76,7 @@ namespace etl
     {
       this->lock();
 
-      size_type result = available_impementation();
+      size_type result = available_implementation();
 
       this->unlock();
 
@@ -89,7 +89,7 @@ namespace etl
     //*************************************************************************
     bool empty_unlocked() const
     {
-      return empty_impementation();
+      return empty_implementation();
     }
 
     //*************************************************************************
@@ -99,7 +99,7 @@ namespace etl
     {
       this->lock();
 
-      size_type result = empty_impementation();
+      size_type result = empty_implementation();
 
       this->unlock();
 
@@ -112,7 +112,7 @@ namespace etl
     //*************************************************************************
     bool full_unlocked() const
     {
-      return full_impementation();
+      return full_implementation();
     }
 
     //*************************************************************************
@@ -122,7 +122,7 @@ namespace etl
     {
       this->lock();
 
-      size_type result = full_impementation();
+      size_type result = full_implementation();
 
       this->unlock();
 
@@ -135,7 +135,7 @@ namespace etl
     //*************************************************************************
     size_type size_unlocked() const
     {
-      return size_impementation();
+      return size_implementation();
     }
 
     //*************************************************************************
@@ -145,7 +145,7 @@ namespace etl
     {
       this->lock();
 
-      size_type result = size_impementation();
+      size_type result = size_implementation();
 
       this->unlock();
 
@@ -209,7 +209,7 @@ namespace etl
     //*************************************************************************
     /// How much free space available in the queue.
     //*************************************************************************
-    size_type available_impementation() const
+    size_type available_implementation() const
     {
       return Max_Size - current_size;
     }
@@ -217,7 +217,7 @@ namespace etl
     //*************************************************************************
     /// Is the queue empty?
     //*************************************************************************
-    bool empty_impementation() const
+    bool empty_implementation() const
     {
       return (current_size == 0);
     }
@@ -225,7 +225,7 @@ namespace etl
     //*************************************************************************
     /// Is the queue full?
     //*************************************************************************
-    bool full_impementation() const
+    bool full_implementation() const
     {
       return (current_size == Max_Size);;
     }
@@ -233,7 +233,7 @@ namespace etl
     //*************************************************************************
     /// How many items in the queue?
     //*************************************************************************
-    size_type size_impementation() const
+    size_type size_implementation() const
     {
       return current_size;
     }

--- a/include/etl/queue_mpmc_mutex.h
+++ b/include/etl/queue_mpmc_mutex.h
@@ -120,7 +120,7 @@ namespace etl
 
   //***************************************************************************
   ///\ingroup queue_mpmc
-  ///\brief This is the base for all queue_mpmc_mutexs that contain a particular type.
+  ///\brief This is the base for all queue_mpmc_mutex's that contain a particular type.
   ///\details Normally a reference to this type will be taken from a derived queue_mpmc_mutex.
   ///\code
   /// etl::queue_mpmc_mutex<int, 10> myQueue;

--- a/include/etl/reference_flat_multimap.h
+++ b/include/etl/reference_flat_multimap.h
@@ -475,7 +475,7 @@ namespace etl
     }
 
     //*********************************************************************
-    /// Inserts a value to the flast_multi.
+    /// Inserts a value to the flat_multi.
     /// If asserts or exceptions are enabled, emits flat_map_full if the flat_map is already full.
     ///\param position The position to insert at.
     ///\param value    The value to insert.

--- a/include/etl/scaled_rounding.h
+++ b/include/etl/scaled_rounding.h
@@ -252,7 +252,7 @@ namespace etl
   //***************************************************************************
   /// Round toward infinity.
   /// \param value Scaled integral.
-  /// \return Ccaled, rounded integral.
+  /// \return Scaled, rounded integral.
   //***************************************************************************
   template <const size_t SCALING, typename T>
   T round_infinity_scaled(T value)

--- a/include/etl/set.h
+++ b/include/etl/set.h
@@ -1902,7 +1902,7 @@ namespace etl
           }
           else
           {
-            // Attatch node to right
+            // Attach node to right
             attach_node(found->children[found->dir], node);
 
             // Return newly added node
@@ -1935,7 +1935,7 @@ namespace etl
       }
       else
       {
-        // Attatch node to current position
+        // Attach node to current position
         attach_node(position, node);
 
         // Return newly added node at current position

--- a/include/etl/stack.h
+++ b/include/etl/stack.h
@@ -100,7 +100,7 @@ namespace etl
   //***************************************************************************
   ///\ingroup stack
   /// A fixed capacity stack written in the STL style.
-  /// \warntopg This stack cannot be used for concurrent access from multiple threads.
+  /// \warning This stack cannot be used for concurrent access from multiple threads.
   //***************************************************************************
   class stack_base
   {
@@ -598,7 +598,7 @@ namespace etl
 
   private:
 
-    /// The unintitialised buffer of T used in the stack.
+    /// The uninitialised buffer of T used in the stack.
     container_type buffer[SIZE];
   };
 }

--- a/include/etl/string_utilities.h
+++ b/include/etl/string_utilities.h
@@ -212,7 +212,7 @@ namespace etl
 
   //***************************************************************************
   /// trim_whitespace_right
-  /// Trim firght of whitespace
+  /// Trim from right of whitespace
   //***************************************************************************
   template <typename TIString>
   void trim_whitespace_right(TIString& s)

--- a/include/etl/vector.h
+++ b/include/etl/vector.h
@@ -269,7 +269,7 @@ namespace etl
 
     //*********************************************************************
     /// Does nothing.
-    /// For compatilbilty with the STL vector API.
+    /// For compatibility with the STL vector API.
     //*********************************************************************
     void reserve(size_t)
     {

--- a/support/Release notes.txt
+++ b/support/Release notes.txt
@@ -28,7 +28,7 @@ Added etl::functor_wrapper for converting a member function operator to a static
 Added constexpr support for etl::unaligned_type.
 Added etl::traits namespace containing traits mirroring many ETL macros.
 Traits are const for C++03, constexpr for C++11 and above.
-Removed some uses of GCC builtins due to compatibilty with constexpr.
+Removed some uses of GCC builtins due to compatibility with constexpr.
 etl::swap is now ETL_CONSTEXPR14.
 Changed ETL_ENDIANNESS_IS_CONSTEXPR to ETL_HAS_CONSTEXPR_ENDIANNESS.
 Changed ETL_CONSTEXPR17 to ETL_CONSTEXPR14 for reverse iterators
@@ -58,7 +58,7 @@ Fixed send_message function signatures.
 
 ===============================================================================
 20.24.0
-#503 Algorithm transform uses expensive post increment operator - Fixed for all occurences of iterator increment.
+#503 Algorithm transform uses expensive post increment operator - Fixed for all occurrences of iterator increment.
 #504 ETL_CONSTANT vs const in binary.h - Fixed.
 Many algorithms will leverage built-ins, if available. Dependant on compiler version.
 Added detection or selection of built-ins.
@@ -90,7 +90,7 @@ Updated C++ standard detection.
 20.22.0
 Split callback and message timer to atomic and locked interrupt versions.
 #480 Fixed: Double formatting with precision > 9
-#481 Fixed: etl::span const datacannot be created from non const c array of data.
+#481 Fixed: etl::span const data cannot be created from non const c array of data.
 #482 Fixed: Two or more etl::span/array_view of different types create ambiguous overloading set 
 #483 Fixed: Added Green Hills compiler to minmax push and pop.
 #484 Fixed: etl::vector test_uninitialized_resize_excess not calling uninitialized_resize.
@@ -106,7 +106,7 @@ etl::deque::resize throws etl::deque_full instead of etl::deque_out_of_bounds, i
 ===============================================================================
 20.20.0
 Updated container 'insert' and 'erase' to C++11 style const_iterator parameters. (#463)
-Fixed container template function overload abiguity. (#466)
+Fixed container template function overload ambiguity. (#466)
 Harmonize copy ctor and assignment for etl::delegate. (#465)
 Added constexpr support for etl::enum_type. (#462)
 Added 'make' functions to construct containers.
@@ -140,7 +140,7 @@ Added .clang-format rules.
 Added etl::pool_ext and etl::generic_pool_ext.
 Added etl::multi_span.
 Added CMSIS RTOS2 mutex variant.
-Added 'unchecked' read and write membvers functions to byte_stream_reader and byte_stream_writer.
+Added 'unchecked' read and write members functions to byte_stream_reader and byte_stream_writer.
 Fixed byte_stream_reader to be able to use const buffers.
 Removed compiler warning messages.
 Fixed missing 'public' access for message_router_registry iterator.
@@ -202,7 +202,7 @@ Changed std::forward to etl::forward in etl::variant (variadic)
 
 ===============================================================================
 20.14.0
-Added a vaiadic version of etl::variant. Usable for C++11 and up.
+Added a variadic version of etl::variant. Usable for C++11 and up.
 Added etl::overload pattern class. Groups lambdas into a functor class.
 Refactored type_traits.h. Uses STL, compiler built-ins or user defined specialisations, dependent on settings.
 Added etl::conditional_t to type_traits.h
@@ -243,7 +243,7 @@ Fixed ambiguous function call in etl::mem_cast for clang.
 
 ===============================================================================
 20.11.0
-Added etl::mem_cast, etl::mem_cast_ptr & etl::mem_cast_types for reinterpretion of memory blocks.
+Added etl::mem_cast, etl::mem_cast_ptr & etl::mem_cast_types for reinterpretation of memory blocks.
 State tables in etl::debounce are now constexpr in C++11 or above.
 
 ===============================================================================
@@ -299,7 +299,7 @@ Added maths algorithms and functors.
   etl::gamma_encode
   etl:;gamma_decode
   etl::histogram
-  etl::sparce_histogram
+  etl::sparse_histogram
   etl::mean
   etl::invert
   etl::threshold
@@ -386,7 +386,7 @@ Fixed indexing error in find_next() for etl::bitset.
 
 ===============================================================================
 20.2.2
-Added non-const get_message() member funtions in shared message framework.
+Added non-const get_message() member functions in shared message framework.
 
 ===============================================================================
 20.2.1
@@ -413,7 +413,7 @@ Added move constructor and move assignment operator to etl::shared_message.
 ===============================================================================
 19.5.2
 Fixed rollover error for etl::queue_spsc_atomic
-Added 'required_alignment' parameter to 'allocate' for etl::imemeory_block_allocator.
+Added 'required_alignment' parameter to 'allocate' for etl::imemory_block_allocator.
 Updated QueuedMessageRouter example.
 
 ===============================================================================
@@ -426,7 +426,7 @@ Added shared messages to the messaging framework + supporting allocator classes.
 Some refactoring of the messaging framework internals.
 Added example application for shared messages.
 Added a lockable queue with locks implemented as pure virtuals.
-Refeactored the other queues.
+Refactored the other queues.
 Fixed missing virtual destructor for C++11 observer.
 Added etl::successor class for consistant 'chain of responsibilty' pattern generation.
 Added missing constructors to unique_ptr.
@@ -474,7 +474,7 @@ Make etl::span compliant with STL API by adding missing overloads for span::firs
 
 ===============================================================================
 19.3.3
-Added check for existance of <new> in platform.h
+Added check for existence of <new> in platform.h
 Added placement_new.h which selects between <new> and ETL definitions.
 
 ===============================================================================
@@ -548,7 +548,7 @@ Expanded the use of constexpr in etl::flags
 
 ===============================================================================
 18.19.1
-Added ETL_CONSTEXPR for state_chart, transision and state constructors.
+Added ETL_CONSTEXPR for state_chart, transition and state constructors.
 Eliminate ARM compiler v5 warnings for state_chart.
 Fixed return type error for atomic GCC.
 
@@ -908,8 +908,8 @@ Added partial compile time versions of binary_fill and has_zero_byte.
 ===============================================================================
 17.0.0
 Recoded binary_fill, has_zero_byte and has_byte_n as runtime functions to fix
-compiler compatibilty issues. All functions may be constexpr if the compiler supports it.
-Added tests for binary constextr functions.
+compiler compatibility issues. All functions may be constexpr if the compiler supports it.
+Added tests for binary constexpr functions.
 
 Added option to define ETL_NO_64BIT_TYPES macro if the compiler does not support 64bit types.
 Conditional compilation macros added to affected files.
@@ -1161,7 +1161,7 @@ Fixed unordered_map iterator operator* return type
 
 ===============================================================================
 14.29.3
-Minor updatess for etl::delegate
+Minor updates for etl::delegate
 
 ===============================================================================
 14.29.2
@@ -1313,13 +1313,13 @@ Finalised 'to string'.
 
 ===============================================================================
 14.18.1
-Changed etl::format_sepc template to etl::basic_firmat_spec.
+Changed etl::format_spec template to etl::basic_format_spec.
 Created individual format_spec typedefs for each string type.
 
 ===============================================================================
 14.18.0
 Added etl::to_string, etl::to_wstring, etl::to_u16string and etl::to_u32string
-plus formating support for integrals.
+plus formatting support for integrals.
 
 ===============================================================================
 14.17.0
@@ -1568,7 +1568,7 @@ Moved non-template code in pvoidvector to cpp file.
 
 ===============================================================================
 11.12.1
-Made atomic load const for non STL vesions
+Made atomic load const for non STL versions
 
 ===============================================================================
 11.12.0
@@ -1577,11 +1577,11 @@ Removed non-conforming std::nullptr
 
 ===============================================================================
 11.11.1
-Compatibilty changes for Segger IDE, GCC & STLPort
+Compatibility changes for Segger IDE, GCC & STLPort
 
 ===============================================================================
 11.11.0
-Compatibilty changes for Segger IDE, GCC & STLPort
+Compatibility changes for Segger IDE, GCC & STLPort
 
 ===============================================================================
 11.10.0

--- a/test/test_correlation.cpp
+++ b/test/test_correlation.cpp
@@ -84,7 +84,7 @@ namespace
   SUITE(test_correlation)
   {
     //*************************************************************************
-    TEST(test_char_correlation_default_constuctor)
+    TEST(test_char_correlation_default_constructor)
     {
       etl::correlation<etl::correlation_type::Population, char, int32_t> correlation;
 
@@ -94,7 +94,7 @@ namespace
     }
 
     //*************************************************************************
-    TEST(test_float_correlation_default_constuctor)
+    TEST(test_float_correlation_default_constructor)
     {
       etl::correlation<etl::correlation_type::Population, float> correlation;
 
@@ -104,7 +104,7 @@ namespace
     }
 
     //*************************************************************************
-    TEST(test_double_correlation_default_constuctor)
+    TEST(test_double_correlation_default_constructor)
     {
       etl::correlation<etl::correlation_type::Population, double> correlation;
 
@@ -114,7 +114,7 @@ namespace
     }
 
     //*************************************************************************
-    TEST(test_char_correlation_constuctor_population)
+    TEST(test_char_correlation_constructor_population)
     {
       double correlation_result;
       double covariance_result;
@@ -142,7 +142,7 @@ namespace
     }
 
     //*************************************************************************
-    TEST(test_char_correlation_constuctor_sample)
+    TEST(test_char_correlation_constructor_sample)
     {
       double correlation_result;
       double covariance_result;
@@ -170,7 +170,7 @@ namespace
     }
 
     //*************************************************************************
-    TEST(test_float_correlation_constuctor_population)
+    TEST(test_float_correlation_constructor_population)
     {
       double correlation_result;
       double covariance_result;
@@ -198,7 +198,7 @@ namespace
     }
 
     //*************************************************************************
-    TEST(test_float_correlation_constuctor_sample)
+    TEST(test_float_correlation_constructor_sample)
     {
       double correlation_result;
       double covariance_result;
@@ -226,7 +226,7 @@ namespace
     }
 
     //*************************************************************************
-    TEST(test_double_correlation_constuctor_population)
+    TEST(test_double_correlation_constructor_population)
     {
       double correlation_result;
       double covariance_result;
@@ -254,7 +254,7 @@ namespace
     }
 
     //*************************************************************************
-    TEST(test_double_correlation_constuctor_sample)
+    TEST(test_double_correlation_constructor_sample)
     {
       double correlation_result;
       double covariance_result;

--- a/test/test_covariance.cpp
+++ b/test/test_covariance.cpp
@@ -84,7 +84,7 @@ namespace
   SUITE(test_covariance)
   {
     //*************************************************************************
-    TEST(test_char_covariance_default_constuctor)
+    TEST(test_char_covariance_default_constructor)
     {
       etl::covariance<etl::covariance_type::Population, char, int32_t> covariance;
 
@@ -94,7 +94,7 @@ namespace
     }
 
     //*************************************************************************
-    TEST(test_float_covariance_default_constuctor)
+    TEST(test_float_covariance_default_constructor)
     {
       etl::covariance<etl::covariance_type::Population, float> covariance;
 
@@ -104,7 +104,7 @@ namespace
     }
 
     //*************************************************************************
-    TEST(test_double_covariance_default_constuctor)
+    TEST(test_double_covariance_default_constructor)
     {
       etl::covariance<etl::covariance_type::Population, double> covariance;
 
@@ -114,7 +114,7 @@ namespace
     }
 
     //*************************************************************************
-    TEST(test_char_covariance_constuctor_population)
+    TEST(test_char_covariance_constructor_population)
     {
       double covariance_result;
 
@@ -135,7 +135,7 @@ namespace
     }
 
     //*************************************************************************
-    TEST(test_char_covariance_constuctor_sample)
+    TEST(test_char_covariance_constructor_sample)
     {
       double covariance_result;
 
@@ -156,7 +156,7 @@ namespace
     }
 
     //*************************************************************************
-    TEST(test_float_covariance_constuctor_population)
+    TEST(test_float_covariance_constructor_population)
     {
       double covariance_result;
 
@@ -177,7 +177,7 @@ namespace
     }
 
     //*************************************************************************
-    TEST(test_float_covariance_constuctor_sample)
+    TEST(test_float_covariance_constructor_sample)
     {
       double covariance_result;
 
@@ -198,7 +198,7 @@ namespace
     }
 
     //*************************************************************************
-    TEST(test_double_covariance_constuctor_population)
+    TEST(test_double_covariance_constructor_population)
     {
       double covariance_result;
 
@@ -219,7 +219,7 @@ namespace
     }
 
     //*************************************************************************
-    TEST(test_double_covariance_constuctor_sample)
+    TEST(test_double_covariance_constructor_sample)
     {
       double covariance_result;
 

--- a/test/test_maths.cpp
+++ b/test/test_maths.cpp
@@ -341,7 +341,7 @@ namespace
     }
 
     //*************************************************************************
-    TEST(test_fibbonacci)
+    TEST(test_fibonacci)
     {
       CHECK_EQUAL(0U,          (size_t)etl::fibonacci<0>::value);
       CHECK_EQUAL(1U,          (size_t)etl::fibonacci<1>::value);

--- a/test/test_mean.cpp
+++ b/test/test_mean.cpp
@@ -54,7 +54,7 @@ namespace
   SUITE(test_mean)
   {
     //*************************************************************************
-    TEST(test_char_mean_default_constuctor)
+    TEST(test_char_mean_default_constructor)
     {
       etl::mean<char, int32_t> mean;
 
@@ -64,7 +64,7 @@ namespace
     }
 
     //*************************************************************************
-    TEST(test_float_mean_default_constuctor)
+    TEST(test_float_mean_default_constructor)
     {
       etl::mean<float> mean;
 
@@ -74,7 +74,7 @@ namespace
     }
 
     //*************************************************************************
-    TEST(test_double_mean_default_constuctor)
+    TEST(test_double_mean_default_constructor)
     {
       etl::mean<double> mean;
 
@@ -84,7 +84,7 @@ namespace
     }
 
     //*************************************************************************
-    TEST(test_char_mean_constuctor)
+    TEST(test_char_mean_constructor)
     {
       double mean_result;
 
@@ -94,7 +94,7 @@ namespace
     }
 
     //*************************************************************************
-    TEST(test_float_mean_constuctor)
+    TEST(test_float_mean_constructor)
     {
       double mean_result;
 
@@ -104,7 +104,7 @@ namespace
     }
 
     //*************************************************************************
-    TEST(test_double_mean_constuctor)
+    TEST(test_double_mean_constructor)
     {
       double mean_result;
 

--- a/test/test_message_packet.cpp
+++ b/test/test_message_packet.cpp
@@ -286,7 +286,7 @@ namespace
     }
 
     //*************************************************************************
-    TEST(message_packet_copy_consructor)
+    TEST(message_packet_copy_constructor)
     {
       Message1 message1(1);
       Message2 message2(2.2);
@@ -309,7 +309,7 @@ namespace
 
 #if !defined(ETL_MESSAGE_PACKET_FORCE_CPP03_IMPLEMENTATION)
     //*************************************************************************
-    TEST(message_packet_move_consructor)
+    TEST(message_packet_move_constructor)
     {
       Message1 message1(1);
       Message2 message2(2.2);

--- a/test/test_message_router_registry.cpp
+++ b/test/test_message_router_registry.cpp
@@ -264,7 +264,7 @@ namespace
     }
 
     //*************************************************************************
-    TEST(test_registery_contains)
+    TEST(test_registry_contains)
     {
       etl::imessage_router* routers[] = { &router1, &router2, &router3 };
       etl::message_router_registry<Registry_Size> registry(std::begin(routers), std::end(routers));

--- a/test/test_random.cpp
+++ b/test/test_random.cpp
@@ -201,7 +201,7 @@ namespace
     }
 
     //*************************************************************************
-    TEST(test_random_lfsr_sequence)
+    TEST(test_random_lsfr_sequence)
     {
       std::vector<uint32_t> out1(10000);
       etl::random_lsfr r;
@@ -237,7 +237,7 @@ namespace
     }
 
     //*************************************************************************
-    TEST(test_random_lfsr_range)
+    TEST(test_random_lsfr_range)
     {
       etl::random_lsfr r;
 

--- a/test/test_reference_flat_map.cpp
+++ b/test/test_reference_flat_map.cpp
@@ -590,7 +590,7 @@ namespace
     }
 
     //*************************************************************************
-    TEST_FIXTURE(SetupFixture, test_erase_key_using_transparent_comparitor)
+    TEST_FIXTURE(SetupFixture, test_erase_key_using_transparent_comparator)
     {
       using CMap = std::map<int, NDC>;
       using EMap = etl::reference_flat_map<int, NDC, SIZE, etl::less<>>;
@@ -795,7 +795,7 @@ namespace
     }
 
     //*************************************************************************
-    TEST_FIXTURE(SetupFixture, test_find_using_transparent_comparitor)
+    TEST_FIXTURE(SetupFixture, test_find_using_transparent_comparator)
     {
       using EMap = etl::reference_flat_map<int, NDC, SIZE, etl::less<>>;
       EMap data(initial_data.begin(), initial_data.end());
@@ -817,7 +817,7 @@ namespace
     }
 
     //*************************************************************************
-    TEST_FIXTURE(SetupFixture, test_find_not_present_using_transparent_comparitor)
+    TEST_FIXTURE(SetupFixture, test_find_not_present_using_transparent_comparator)
     {
       using EMap = etl::reference_flat_map<int, NDC, SIZE, etl::less<>>;
       EMap data(initial_data.begin(), initial_data.end());
@@ -839,7 +839,7 @@ namespace
     }
 
     //*************************************************************************
-    TEST_FIXTURE(SetupFixture, test_find_const_using_transparent_comparitor)
+    TEST_FIXTURE(SetupFixture, test_find_const_using_transparent_comparator)
     {
       using EMap = etl::reference_flat_map<int, NDC, SIZE, etl::less<>>;
       const EMap data(initial_data.begin(), initial_data.end());
@@ -861,7 +861,7 @@ namespace
     }
 
     //*************************************************************************
-    TEST_FIXTURE(SetupFixture, test_find_const_not_present_using_transparent_comparitor)
+    TEST_FIXTURE(SetupFixture, test_find_const_not_present_using_transparent_comparator)
     {
       using EMap = etl::reference_flat_map<int, NDC, SIZE, etl::less<>>;
       const EMap data(initial_data.begin(), initial_data.end());

--- a/test/test_reference_flat_multimap.cpp
+++ b/test/test_reference_flat_multimap.cpp
@@ -380,7 +380,7 @@ namespace
     }
 
     //*************************************************************************
-    TEST_FIXTURE(SetupFixture, test_erase_key_using_transparent_comparitor)
+    TEST_FIXTURE(SetupFixture, test_erase_key_using_transparent_comparator)
     {
       using CMap = std::multimap<int, NDC>;
       using EMap = etl::reference_flat_multimap<int, NDC, SIZE, etl::less<>>;
@@ -588,7 +588,7 @@ namespace
     }
 
     //*************************************************************************
-    TEST_FIXTURE(SetupFixture, test_find_using_transparent_comparitor)
+    TEST_FIXTURE(SetupFixture, test_find_using_transparent_comparator)
     {
       using EMap = etl::reference_flat_multimap<int, NDC, SIZE, etl::less<>>;
       EMap data(initial_data.begin(), initial_data.end());
@@ -613,7 +613,7 @@ namespace
     }
 
     //*************************************************************************
-    TEST_FIXTURE(SetupFixture, test_find_not_present_using_transparent_comparitor)
+    TEST_FIXTURE(SetupFixture, test_find_not_present_using_transparent_comparator)
     {
       using EMap = etl::reference_flat_multimap<int, NDC, SIZE, etl::less<>>;
       EMap data(initial_data.begin(), initial_data.end());
@@ -638,7 +638,7 @@ namespace
     }
 
     //*************************************************************************
-    TEST_FIXTURE(SetupFixture, test_find_const_using_transparent_comparitor)
+    TEST_FIXTURE(SetupFixture, test_find_const_using_transparent_comparator)
     {
       using EMap = etl::reference_flat_multimap<int, NDC, SIZE, etl::less<>>;
       const EMap data(initial_data.begin(), initial_data.end());
@@ -663,7 +663,7 @@ namespace
     }
 
     //*************************************************************************
-    TEST_FIXTURE(SetupFixture, test_find_const_not_present_using_transparent_comparitor)
+    TEST_FIXTURE(SetupFixture, test_find_const_not_present_using_transparent_comparator)
     {
       using EMap = etl::reference_flat_multimap<int, NDC, SIZE, etl::less<>>;
       const EMap data(initial_data.begin(), initial_data.end());
@@ -688,7 +688,7 @@ namespace
     }
 
     //*************************************************************************
-    TEST_FIXTURE(SetupFixture, test_lower_bound_using_transparent_comparitor)
+    TEST_FIXTURE(SetupFixture, test_lower_bound_using_transparent_comparator)
     {
       using CMap = std::multimap<int, NDC>;
       using EMap = etl::reference_flat_multimap<int, NDC, SIZE, etl::less<>>;
@@ -715,7 +715,7 @@ namespace
     }
 
     //*************************************************************************
-    TEST_FIXTURE(SetupFixture, test_upper_bound_using_transparent_comparitor)
+    TEST_FIXTURE(SetupFixture, test_upper_bound_using_transparent_comparator)
     {
       using CMap = std::multimap<int, NDC>;
       using EMap = etl::reference_flat_multimap<int, NDC, SIZE, etl::less<>>;
@@ -743,7 +743,7 @@ namespace
     }
 
     //*************************************************************************
-    TEST_FIXTURE(SetupFixture, test_equal_range_using_transparent_comparitor)
+    TEST_FIXTURE(SetupFixture, test_equal_range_using_transparent_comparator)
     {
       using CMap = std::multimap<int, NDC>;
       using EMap = etl::reference_flat_multimap<int, NDC, SIZE, etl::less<>>;
@@ -775,7 +775,7 @@ namespace
     }
 
     //*************************************************************************
-    TEST_FIXTURE(SetupFixture, test_equal_range_not_present_using_transparent_comparitor)
+    TEST_FIXTURE(SetupFixture, test_equal_range_not_present_using_transparent_comparator)
     {
       using EMap = etl::reference_flat_multimap<int, NDC, SIZE, etl::less<>>;
       EMap data(initial_data.begin(), initial_data.end());
@@ -852,7 +852,7 @@ namespace
     }
 
     //*************************************************************************
-    TEST_FIXTURE(SetupFixture, test_multi_using_transparent_comparitor)
+    TEST_FIXTURE(SetupFixture, test_multi_using_transparent_comparator)
     {
       using CMap = std::multimap<int, NDC>;
       using EMap = etl::reference_flat_multimap<int, NDC, SIZE, etl::less<>>;
@@ -903,7 +903,7 @@ namespace
     }
 
     //*************************************************************************
-    TEST_FIXTURE(SetupFixture, test_count_using_transparent_comparitor)
+    TEST_FIXTURE(SetupFixture, test_count_using_transparent_comparator)
     {
       using CMap = std::multimap<int, NDC>;
       using EMap = etl::reference_flat_multimap<int, NDC, SIZE, etl::less<>>;

--- a/test/test_result.cpp
+++ b/test/test_result.cpp
@@ -90,7 +90,7 @@ namespace
   using ResultM = etl::result<ValueM, ErrorM>;
 }
 
-// Definitions for when the STL and compiler built-ins are not avalable.
+// Definitions for when the STL and compiler built-ins are not available.
 #if ETL_NOT_USING_STL && !defined(ETL_USE_TYPE_TRAITS_BUILTINS)
 
 using etl::is_copy_constructible;

--- a/test/test_smallest.cpp
+++ b/test/test_smallest.cpp
@@ -34,7 +34,7 @@ SOFTWARE.
 
 namespace
 {
-  SUITE(test_smallst)
+  SUITE(test_smallest)
   {
     //*************************************************************************
     TEST(test_pod)

--- a/test/test_standard_deviation.cpp
+++ b/test/test_standard_deviation.cpp
@@ -54,7 +54,7 @@ namespace
   SUITE(test_standard_deviation)
   {
     //*************************************************************************
-    TEST(test_char_standard_deviation_default_constuctor)
+    TEST(test_char_standard_deviation_default_constructor)
     {
       etl::standard_deviation<etl::standard_deviation_type::Population, char, int32_t> standard_deviation;
 
@@ -64,7 +64,7 @@ namespace
     }
 
     //*************************************************************************
-    TEST(test_float_standard_deviation_default_constuctor)
+    TEST(test_float_standard_deviation_default_constructor)
     {
       etl::standard_deviation<etl::standard_deviation_type::Population, float> standard_deviation;
 
@@ -74,7 +74,7 @@ namespace
     }
 
     //*************************************************************************
-    TEST(test_double_standard_deviation_default_constuctor)
+    TEST(test_double_standard_deviation_default_constructor)
     {
       etl::standard_deviation<etl::standard_deviation_type::Population, double> standard_deviation;
 
@@ -84,7 +84,7 @@ namespace
     }
 
     //*************************************************************************
-    TEST(test_char_standard_deviation_constuctor_population)
+    TEST(test_char_standard_deviation_constructor_population)
     {
       double standard_deviation_result;
       double variance_result;
@@ -97,7 +97,7 @@ namespace
     }
 
     //*************************************************************************
-    TEST(test_char_standard_deviation_constuctor_sample)
+    TEST(test_char_standard_deviation_constructor_sample)
     {
       double standard_deviation_result;
       double variance_result;
@@ -110,7 +110,7 @@ namespace
     }
 
     //*************************************************************************
-    TEST(test_float_standard_deviation_constuctor_population)
+    TEST(test_float_standard_deviation_constructor_population)
     {
       double standard_deviation_result;
       double variance_result;
@@ -123,7 +123,7 @@ namespace
     }
 
     //*************************************************************************
-    TEST(test_float_standard_deviation_constuctor_sample)
+    TEST(test_float_standard_deviation_constructor_sample)
     {
       double standard_deviation_result;
       double variance_result;
@@ -136,7 +136,7 @@ namespace
     }
 
     //*************************************************************************
-    TEST(test_double_standard_deviation_constuctor_population)
+    TEST(test_double_standard_deviation_constructor_population)
     {
       double standard_deviation_result;
       double variance_result;
@@ -149,7 +149,7 @@ namespace
     }
 
     //*************************************************************************
-    TEST(test_double_standard_deviation_constuctor_sample)
+    TEST(test_double_standard_deviation_constructor_sample)
     {
       double standard_deviation_result;
       double variance_result;

--- a/test/test_string_char.cpp
+++ b/test/test_string_char.cpp
@@ -3348,7 +3348,7 @@ namespace
     }
 
     //*************************************************************************
-    TEST_FIXTURE(SetupFixture, test_compare_positon_length_string)
+    TEST_FIXTURE(SetupFixture, test_compare_position_length_string)
     {
       Compare_Text compare_text(STR("xxxABCDEFyyy"));
       Text text(STR("xxxABCDEFyyy"));
@@ -3383,7 +3383,7 @@ namespace
     }
 
     //*************************************************************************
-    TEST_FIXTURE(SetupFixture, test_compare_positon_length_string_subposition_sublength)
+    TEST_FIXTURE(SetupFixture, test_compare_position_length_string_subposition_sublength)
     {
       Compare_Text compare_text(STR("xxxABCDEFyyy"));
       Text text(STR("xxxABCDEFyyy"));
@@ -3453,7 +3453,7 @@ namespace
     }
 
     //*************************************************************************
-    TEST_FIXTURE(SetupFixture, test_compare_positon_length_c_string)
+    TEST_FIXTURE(SetupFixture, test_compare_position_length_c_string)
     {
       Compare_Text compare_text(STR("xxxABCDEFyyy"));
       Text text(STR("xxxABCDEFyyy"));
@@ -3488,7 +3488,7 @@ namespace
     }
 
     //*************************************************************************
-    TEST_FIXTURE(SetupFixture, test_compare_positon_length_c_string_n)
+    TEST_FIXTURE(SetupFixture, test_compare_position_length_c_string_n)
     {
       Compare_Text compare_text(STR("xxxABCDEFyyy"));
       Text text(STR("xxxABCDEFyyy"));

--- a/test/test_string_char_external_buffer.cpp
+++ b/test/test_string_char_external_buffer.cpp
@@ -3629,7 +3629,7 @@ namespace
     }
 
     //*************************************************************************
-    TEST_FIXTURE(SetupFixture, test_compare_positon_length_string)
+    TEST_FIXTURE(SetupFixture, test_compare_position_length_string)
     {
       Compare_Text compare_text(STR("xxxABCDEFyyy"));
 
@@ -3666,7 +3666,7 @@ namespace
     }
 
     //*************************************************************************
-    TEST_FIXTURE(SetupFixture, test_compare_positon_length_string_subposition_sublength)
+    TEST_FIXTURE(SetupFixture, test_compare_position_length_string_subposition_sublength)
     {
       Compare_Text compare_text(STR("xxxABCDEFyyy"));
 
@@ -3740,7 +3740,7 @@ namespace
     }
 
     //*************************************************************************
-    TEST_FIXTURE(SetupFixture, test_compare_positon_length_c_string)
+    TEST_FIXTURE(SetupFixture, test_compare_position_length_c_string)
     {
       Compare_Text compare_text(STR("xxxABCDEFyyy"));
 
@@ -3777,7 +3777,7 @@ namespace
     }
 
     //*************************************************************************
-    TEST_FIXTURE(SetupFixture, test_compare_positon_length_c_string_n)
+    TEST_FIXTURE(SetupFixture, test_compare_position_length_c_string_n)
     {
       Compare_Text compare_text(STR("xxxABCDEFyyy"));
 

--- a/test/test_string_u16.cpp
+++ b/test/test_string_u16.cpp
@@ -3364,7 +3364,7 @@ namespace
     }
 
     //*************************************************************************
-    TEST_FIXTURE(SetupFixture, test_compare_positon_length_string)
+    TEST_FIXTURE(SetupFixture, test_compare_position_length_string)
     {
       Compare_Text compare_text(STR("xxxABCDEFyyy"));
       Text text(STR("xxxABCDEFyyy"));
@@ -3399,7 +3399,7 @@ namespace
     }
 
     //*************************************************************************
-    TEST_FIXTURE(SetupFixture, test_compare_positon_length_string_subposition_sublength)
+    TEST_FIXTURE(SetupFixture, test_compare_position_length_string_subposition_sublength)
     {
       Compare_Text compare_text(STR("xxxABCDEFyyy"));
       Text text(STR("xxxABCDEFyyy"));
@@ -3469,7 +3469,7 @@ namespace
     }
 
     //*************************************************************************
-    TEST_FIXTURE(SetupFixture, test_compare_positon_length_c_string)
+    TEST_FIXTURE(SetupFixture, test_compare_position_length_c_string)
     {
       Compare_Text compare_text(STR("xxxABCDEFyyy"));
       Text text(STR("xxxABCDEFyyy"));
@@ -3504,7 +3504,7 @@ namespace
     }
 
     //*************************************************************************
-    TEST_FIXTURE(SetupFixture, test_compare_positon_length_c_string_n)
+    TEST_FIXTURE(SetupFixture, test_compare_position_length_c_string_n)
     {
       Compare_Text compare_text(STR("xxxABCDEFyyy"));
       Text text(STR("xxxABCDEFyyy"));

--- a/test/test_string_u16_external_buffer.cpp
+++ b/test/test_string_u16_external_buffer.cpp
@@ -3662,7 +3662,7 @@ namespace
     }
 
     //*************************************************************************
-    TEST_FIXTURE(SetupFixture, test_compare_positon_length_string)
+    TEST_FIXTURE(SetupFixture, test_compare_position_length_string)
     {
       Compare_Text compare_text(STR("xxxABCDEFyyy"));
 
@@ -3699,7 +3699,7 @@ namespace
     }
 
     //*************************************************************************
-    TEST_FIXTURE(SetupFixture, test_compare_positon_length_string_subposition_sublength)
+    TEST_FIXTURE(SetupFixture, test_compare_position_length_string_subposition_sublength)
     {
       Compare_Text compare_text(STR("xxxABCDEFyyy"));
 
@@ -3773,7 +3773,7 @@ namespace
     }
 
     //*************************************************************************
-    TEST_FIXTURE(SetupFixture, test_compare_positon_length_c_string)
+    TEST_FIXTURE(SetupFixture, test_compare_position_length_c_string)
     {
       Compare_Text compare_text(STR("xxxABCDEFyyy"));
 
@@ -3810,7 +3810,7 @@ namespace
     }
 
     //*************************************************************************
-    TEST_FIXTURE(SetupFixture, test_compare_positon_length_c_string_n)
+    TEST_FIXTURE(SetupFixture, test_compare_position_length_c_string_n)
     {
       Compare_Text compare_text(STR("xxxABCDEFyyy"));
 

--- a/test/test_string_u32.cpp
+++ b/test/test_string_u32.cpp
@@ -3364,7 +3364,7 @@ namespace
     }
 
     //*************************************************************************
-    TEST_FIXTURE(SetupFixture, test_compare_positon_length_string)
+    TEST_FIXTURE(SetupFixture, test_compare_position_length_string)
     {
       Compare_Text compare_text(STR("xxxABCDEFyyy"));
       Text text(STR("xxxABCDEFyyy"));
@@ -3399,7 +3399,7 @@ namespace
     }
 
     //*************************************************************************
-    TEST_FIXTURE(SetupFixture, test_compare_positon_length_string_subposition_sublength)
+    TEST_FIXTURE(SetupFixture, test_compare_position_length_string_subposition_sublength)
     {
       Compare_Text compare_text(STR("xxxABCDEFyyy"));
       Text text(STR("xxxABCDEFyyy"));
@@ -3469,7 +3469,7 @@ namespace
     }
 
     //*************************************************************************
-    TEST_FIXTURE(SetupFixture, test_compare_positon_length_c_string)
+    TEST_FIXTURE(SetupFixture, test_compare_position_length_c_string)
     {
       Compare_Text compare_text(STR("xxxABCDEFyyy"));
       Text text(STR("xxxABCDEFyyy"));
@@ -3504,7 +3504,7 @@ namespace
     }
 
     //*************************************************************************
-    TEST_FIXTURE(SetupFixture, test_compare_positon_length_c_string_n)
+    TEST_FIXTURE(SetupFixture, test_compare_position_length_c_string_n)
     {
       Compare_Text compare_text(STR("xxxABCDEFyyy"));
       Text text(STR("xxxABCDEFyyy"));

--- a/test/test_string_u32_external_buffer.cpp
+++ b/test/test_string_u32_external_buffer.cpp
@@ -3662,7 +3662,7 @@ namespace
     }
 
     //*************************************************************************
-    TEST_FIXTURE(SetupFixture, test_compare_positon_length_string)
+    TEST_FIXTURE(SetupFixture, test_compare_position_length_string)
     {
       Compare_Text compare_text(STR("xxxABCDEFyyy"));
 
@@ -3699,7 +3699,7 @@ namespace
     }
 
     //*************************************************************************
-    TEST_FIXTURE(SetupFixture, test_compare_positon_length_string_subposition_sublength)
+    TEST_FIXTURE(SetupFixture, test_compare_position_length_string_subposition_sublength)
     {
       Compare_Text compare_text(STR("xxxABCDEFyyy"));
 
@@ -3773,7 +3773,7 @@ namespace
     }
 
     //*************************************************************************
-    TEST_FIXTURE(SetupFixture, test_compare_positon_length_c_string)
+    TEST_FIXTURE(SetupFixture, test_compare_position_length_c_string)
     {
       Compare_Text compare_text(STR("xxxABCDEFyyy"));
 
@@ -3810,7 +3810,7 @@ namespace
     }
 
     //*************************************************************************
-    TEST_FIXTURE(SetupFixture, test_compare_positon_length_c_string_n)
+    TEST_FIXTURE(SetupFixture, test_compare_position_length_c_string_n)
     {
       Compare_Text compare_text(STR("xxxABCDEFyyy"));
 

--- a/test/test_string_wchar_t.cpp
+++ b/test/test_string_wchar_t.cpp
@@ -3363,7 +3363,7 @@ namespace
     }
 
     //*************************************************************************
-    TEST_FIXTURE(SetupFixture, test_compare_positon_length_string)
+    TEST_FIXTURE(SetupFixture, test_compare_position_length_string)
     {
       Compare_Text compare_text(STR("xxxABCDEFyyy"));
       Text text(STR("xxxABCDEFyyy"));
@@ -3398,7 +3398,7 @@ namespace
     }
 
     //*************************************************************************
-    TEST_FIXTURE(SetupFixture, test_compare_positon_length_string_subposition_sublength)
+    TEST_FIXTURE(SetupFixture, test_compare_position_length_string_subposition_sublength)
     {
       Compare_Text compare_text(STR("xxxABCDEFyyy"));
       Text text(STR("xxxABCDEFyyy"));
@@ -3468,7 +3468,7 @@ namespace
     }
 
     //*************************************************************************
-    TEST_FIXTURE(SetupFixture, test_compare_positon_length_c_string)
+    TEST_FIXTURE(SetupFixture, test_compare_position_length_c_string)
     {
       Compare_Text compare_text(STR("xxxABCDEFyyy"));
       Text text(STR("xxxABCDEFyyy"));
@@ -3503,7 +3503,7 @@ namespace
     }
 
     //*************************************************************************
-    TEST_FIXTURE(SetupFixture, test_compare_positon_length_c_string_n)
+    TEST_FIXTURE(SetupFixture, test_compare_position_length_c_string_n)
     {
       Compare_Text compare_text(STR("xxxABCDEFyyy"));
       Text text(STR("xxxABCDEFyyy"));

--- a/test/test_string_wchar_t_external_buffer.cpp
+++ b/test/test_string_wchar_t_external_buffer.cpp
@@ -3662,7 +3662,7 @@ namespace
     }
 
     //*************************************************************************
-    TEST_FIXTURE(SetupFixture, test_compare_positon_length_string)
+    TEST_FIXTURE(SetupFixture, test_compare_position_length_string)
     {
       Compare_Text compare_text(STR("xxxABCDEFyyy"));
 
@@ -3699,7 +3699,7 @@ namespace
     }
 
     //*************************************************************************
-    TEST_FIXTURE(SetupFixture, test_compare_positon_length_string_subposition_sublength)
+    TEST_FIXTURE(SetupFixture, test_compare_position_length_string_subposition_sublength)
     {
       Compare_Text compare_text(STR("xxxABCDEFyyy"));
 
@@ -3773,7 +3773,7 @@ namespace
     }
 
     //*************************************************************************
-    TEST_FIXTURE(SetupFixture, test_compare_positon_length_c_string)
+    TEST_FIXTURE(SetupFixture, test_compare_position_length_c_string)
     {
       Compare_Text compare_text(STR("xxxABCDEFyyy"));
 
@@ -3810,7 +3810,7 @@ namespace
     }
 
     //*************************************************************************
-    TEST_FIXTURE(SetupFixture, test_compare_positon_length_c_string_n)
+    TEST_FIXTURE(SetupFixture, test_compare_position_length_c_string_n)
     {
       Compare_Text compare_text(STR("xxxABCDEFyyy"));
 

--- a/test/test_task_scheduler.cpp
+++ b/test/test_task_scheduler.cpp
@@ -205,7 +205,7 @@ namespace
       s.set_idle_callback(common.idle_callback);
       s.set_watchdog_callback(common.watchdog_callback);
       s.add_task_list(taskList, std::size(taskList));
-      s.start(); // If 'start' returns then the idle callback was sucessfully called.
+      s.start(); // If 'start' returns then the idle callback was successfully called.
 
       WorkList_t expected = { "T3W1", "T2W1", "T1W1", "T3W2", "T2W2", "T1W2", "T3W3", "T2W3", "T1W3", "T2W4" };
 
@@ -230,7 +230,7 @@ namespace
       s.set_idle_callback(common.idle_callback);
       s.set_watchdog_callback(common.watchdog_callback);
       s.add_task_list(taskList, std::size(taskList));
-      s.start(); // If 'start' returns then the idle callback was sucessfully called.
+      s.start(); // If 'start' returns then the idle callback was successfully called.
 
       WorkList_t expected = { "T3W1", "T3W2", "T2W1", "T2W2", "T2W3", "T2W4", "T1W1", "T1W2", "T1W3", "T3W3" };
 
@@ -255,7 +255,7 @@ namespace
       s.set_idle_callback(common.idle_callback);
       s.set_watchdog_callback(common.watchdog_callback);
       s.add_task_list(taskList, std::size(taskList));
-      s.start(); // If 'start' returns then the idle callback was sucessfully called.
+      s.start(); // If 'start' returns then the idle callback was successfully called.
 
       WorkList_t expected = { "T3W1", "T3W2", "T2W1", "T2W2", "T3W3", "T2W3", "T2W4", "T1W1", "T1W2", "T1W3" };
 
@@ -280,7 +280,7 @@ namespace
       s.set_idle_callback(common.idle_callback);
       s.set_watchdog_callback(common.watchdog_callback);
       s.add_task_list(taskList, std::size(taskList));
-      s.start(); // If 'start' returns then the idle callback was sucessfully called.
+      s.start(); // If 'start' returns then the idle callback was successfully called.
 
       WorkList_t expected = { "T2W1", "T2W2", "T1W1", "T3W1", "T2W3", "T3W2", "T1W2", "T3W3", "T2W4", "T1W3" };
 

--- a/test/test_type_traits.cpp
+++ b/test/test_type_traits.cpp
@@ -89,7 +89,7 @@ namespace
   };
 }
 
-// Definitions for when the STL and compiler built-ins are not avalable.
+// Definitions for when the STL and compiler built-ins are not available.
 #if ETL_NOT_USING_STL && !defined(ETL_USE_TYPE_TRAITS_BUILTINS)
 
 using etl::is_assignable;

--- a/test/test_user_type.cpp
+++ b/test/test_user_type.cpp
@@ -142,7 +142,7 @@ namespace
     }
 
     //*************************************************************************
-    TEST(test_muliply_equal)
+    TEST(test_multiply_equal)
     {
       CompassDirection value = CompassDirection::North;
       value *= 3;

--- a/test/test_variance.cpp
+++ b/test/test_variance.cpp
@@ -54,7 +54,7 @@ namespace
   SUITE(test_variance)
   {
     //*************************************************************************
-    TEST(test_char_variance_default_constuctor)
+    TEST(test_char_variance_default_constructor)
     {
       etl::variance<etl::variance_type::Population, char, int32_t> variance;
 
@@ -64,7 +64,7 @@ namespace
     }
 
     //*************************************************************************
-    TEST(test_float_variance_default_constuctor)
+    TEST(test_float_variance_default_constructor)
     {
       etl::variance<etl::variance_type::Population, float> variance;
 
@@ -74,7 +74,7 @@ namespace
     }
 
     //*************************************************************************
-    TEST(test_double_variance_default_constuctor)
+    TEST(test_double_variance_default_constructor)
     {
       etl::variance<etl::variance_type::Population, double> variance;
 
@@ -84,7 +84,7 @@ namespace
     }
 
     //*************************************************************************
-    TEST(test_char_variance_constuctor_population)
+    TEST(test_char_variance_constructor_population)
     {
       double variance_result;
 
@@ -94,7 +94,7 @@ namespace
     }
 
     //*************************************************************************
-    TEST(test_char_variance_constuctor_sample)
+    TEST(test_char_variance_constructor_sample)
     {
       double variance_result;
 
@@ -104,7 +104,7 @@ namespace
     }
 
     //*************************************************************************
-    TEST(test_float_variance_constuctor_population)
+    TEST(test_float_variance_constructor_population)
     {
       double variance_result;
 
@@ -114,7 +114,7 @@ namespace
     }
 
     //*************************************************************************
-    TEST(test_float_variance_constuctor_sample)
+    TEST(test_float_variance_constructor_sample)
     {
       double variance_result;
 
@@ -124,7 +124,7 @@ namespace
     }
 
     //*************************************************************************
-    TEST(test_double_variance_constuctor_population)
+    TEST(test_double_variance_constructor_population)
     {
       double variance_result;
 
@@ -134,7 +134,7 @@ namespace
     }
 
     //*************************************************************************
-    TEST(test_double_variance_constuctor_sample)
+    TEST(test_double_variance_constructor_sample)
     {
       double variance_result;
 

--- a/test/test_variant_variadic.cpp
+++ b/test/test_variant_variadic.cpp
@@ -290,7 +290,7 @@ namespace
   };
 }
 
-// Definitions for when the STL and compiler built-ins are not avalable.
+// Definitions for when the STL and compiler built-ins are not available.
 #if ETL_NOT_USING_STL && !defined(ETL_USE_TYPE_TRAITS_BUILTINS)
 
 using etl::is_copy_constructible;


### PR DESCRIPTION
1. I can reformat/split/separate by commits any parts of pull request.
2. I found spelling errors using [this script](https://github.com/melg8/cit/blob/main/ci/checks/spelling.sh)  (shameless plug)  - from my project with custom dictionary.
3. If needed i can post custom dictionary which contains all ignored words.
4. I didn't fix this words:
``` C++
Finalises -> Finalizes
Optimise -> Optimize
Optimised -> Optimized
Specialisation -> Specialization
deserialiser -> deserializer
finalised -> finalized
optimisations -> optimizations
parametrised -> parametrized
serialiser -> serializer
specialisations -> specializations
specialised -> specialized
uninitialised -> uninitialized
```
if you want i can fix them too in this pull request or in separate one.
