### PR TITLE
Some CMake handling improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@ cmake_minimum_required(VERSION 3.5.0)
 
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/helpers.cmake)
 
+set(MSG_PREFIX "etl |")
 determine_version_with_git(${GIT_DIR_LOOKUP_POLICY})
 if(NOT ETL_VERSION)
     determine_version("version.txt")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,9 @@ cmake_minimum_required(VERSION 3.5.0)
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/helpers.cmake)
 
 determine_version_with_git(${GIT_DIR_LOOKUP_POLICY})
+if(NOT ETL_VERSION)
+    determine_version("version.txt")
+endif()
 
 project(etl VERSION ${ETL_VERSION})
 

--- a/cmake/helpers.cmake
+++ b/cmake/helpers.cmake
@@ -3,7 +3,7 @@ function(determine_version VER_FILE_NAME)
     # Remove trailing whitespaces and/or newline
     string(STRIP ${ETL_VERSION_RAW} ETL_VERSION)
     set(ETL_VERSION ${ETL_VERSION} CACHE STRING
-        "ETL version determined from version.txt"
+        "ETL version determined from version.txt" FORCE
     )
     message(STATUS "Determined ETL version ${ETL_VERSION} from version.txt file")
 endfunction()
@@ -16,7 +16,6 @@ function(determine_version_with_git)
         message(WARNING "Version string ${VERSION} retrieved with git describe is invalid")
         return()
     endif()
-    message(STATUS ${VERSION})
     # Parse the version information into pieces.
     string(REGEX REPLACE "^([0-9]+)\\..*" "\\1" VERSION_MAJOR "${VERSION}")
     string(REGEX REPLACE "^[0-9]+\\.([0-9]+).*" "\\1" VERSION_MINOR "${VERSION}")
@@ -25,7 +24,7 @@ function(determine_version_with_git)
     set(ETL_VERSION "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}")
 
     set(ETL_VERSION ${ETL_VERSION} CACHE STRING
-        "ETL version determined from version.txt"
+        "ETL version determined from version.txt" FORCE
     )
     message(STATUS "Determined ETL version ${ETL_VERSION} from the git tag")
 endfunction()

--- a/cmake/helpers.cmake
+++ b/cmake/helpers.cmake
@@ -16,6 +16,7 @@ function(determine_version_with_git)
         message(WARNING "Version string ${VERSION} retrieved with git describe is invalid")
         return()
     endif()
+    message(STATUS "Version string determined with git describe: ${VERSION}")
     # Parse the version information into pieces.
     string(REGEX REPLACE "^([0-9]+)\\..*" "\\1" VERSION_MAJOR "${VERSION}")
     string(REGEX REPLACE "^[0-9]+\\.([0-9]+).*" "\\1" VERSION_MINOR "${VERSION}")

--- a/cmake/helpers.cmake
+++ b/cmake/helpers.cmake
@@ -24,7 +24,7 @@ function(determine_version_with_git)
     set(ETL_VERSION "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}")
 
     set(ETL_VERSION ${ETL_VERSION} CACHE STRING
-        "ETL version determined from version.txt" FORCE
+        "ETL version determined with git describe" FORCE
     )
     message(STATUS "Determined ETL version ${ETL_VERSION} from the git tag")
 endfunction()

--- a/cmake/helpers.cmake
+++ b/cmake/helpers.cmake
@@ -5,7 +5,7 @@ function(determine_version VER_FILE_NAME)
     set(ETL_VERSION ${ETL_VERSION} CACHE STRING
         "ETL version determined from version.txt" FORCE
     )
-    message(STATUS "Determined ETL version ${ETL_VERSION} from version.txt file")
+    message(STATUS "${MSG_PREFIX} Determined ETL version ${ETL_VERSION} from version.txt file")
 endfunction()
 
 function(determine_version_with_git)
@@ -16,7 +16,7 @@ function(determine_version_with_git)
         message(WARNING "Version string ${VERSION} retrieved with git describe is invalid")
         return()
     endif()
-    message(STATUS "Version string determined with git describe: ${VERSION}")
+    message(STATUS "${MSG_PREFIX} Version string determined with git describe: ${VERSION}")
     # Parse the version information into pieces.
     string(REGEX REPLACE "^([0-9]+)\\..*" "\\1" VERSION_MAJOR "${VERSION}")
     string(REGEX REPLACE "^[0-9]+\\.([0-9]+).*" "\\1" VERSION_MINOR "${VERSION}")
@@ -27,5 +27,5 @@ function(determine_version_with_git)
     set(ETL_VERSION ${ETL_VERSION} CACHE STRING
         "ETL version determined with git describe" FORCE
     )
-    message(STATUS "Determined ETL version ${ETL_VERSION} from the git tag")
+    message(STATUS "${MSG_PREFIX} Determined ETL version ${ETL_VERSION} from the git tag")
 endfunction()


### PR DESCRIPTION
- Set library version from `version.txt` file if retrieval with `git describe` fails
- Add `FORCE` flag to `ETL_VERSION` CACHE entry. This would overwrite entries specified by the user but I think this is okay for this entry.
- Some more context information on the printout of the full version string
- New message prefix for all information messages printed out by the ETL `CMakeLists.txt` 