### PR TITLE
New alias target etl::etl and CMake instructions update

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,9 @@ option(BUILD_TESTS "Build unit tests" OFF)
 option(NO_STL "No STL" OFF)
 
 add_library(${PROJECT_NAME} INTERFACE)
+# This allows users which use the add_subdirectory or FetchContent
+# to use the same target as users which use find_package
+add_library(etl::etl ALIAS ${PROJECT_NAME})
 
 target_include_directories(${PROJECT_NAME} SYSTEM INTERFACE
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Replace `<majorVersionRequirement>` with your desired major version:
 ```cmake
 find_package(etl <majorVersionRequirement>)
 add_executable(foo main.cpp)
-target_link_libraries(foo PRIVATE etl)
+target_link_libraries(foo PRIVATE etl::etl)
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ and then make the library available by using `add_subdirectory`
 ```cmake
 add_subdirectory(etl)
 add_executable(foo main.cpp)
-target_link_libraries(foo PRIVATE etl)
+target_link_libraries(foo PRIVATE etl::etl)
 ```
 
 If ETL library is used as a Git submodule it may require additional configuration for proper ETL version resolution by allowing the lookup for Git folder outside of the library root directory.
@@ -122,7 +122,7 @@ FetchContent_Declare(
 FetchContent_MakeAvailable(etl)
 
 add_executable(foo main.cpp)
-target_link_libraries(foo PRIVATE etl)
+target_link_libraries(foo PRIVATE etl::etl)
 ```
 
 ## Arduino library


### PR DESCRIPTION
When installing ETL with `find_package`, the actual import target is inside the `etl` namespace. This is the correction for the `CMake` instructions