### PR TITLE
Feature/pass partial handled events to parent

### DIFF
--- a/include/etl/fsm.h
+++ b/include/etl/fsm.h
@@ -179,6 +179,8 @@ namespace etl
     // Pass this whenever no state change is desired.
     // The highest unsigned value of fsm_state_id_t.
     static ETL_CONSTANT fsm_state_id_t No_State_Change = etl::integral_limits<fsm_state_id_t>::max;
+    // Pass this when this event also needs to be passed to the parent.
+    static ETL_CONSTANT fsm_state_id_t Pass_To_Parent = No_State_Change - 1U;
 
     /// Allows ifsm_state functions to be private.
     friend class etl::fsm;
@@ -542,7 +544,7 @@ namespace etl
 
       const bool was_handled = (process_event_type<TMessageTypes>(message, new_state_id) || ...);
 
-      if (!was_handled)
+      if (!was_handled || new_state_id == Pass_To_Parent)
       {
         new_state_id = (p_parent != nullptr) ? p_parent->process_event(message) : static_cast<TDerived*>(this)->on_event_unknown(message);
       }
@@ -630,7 +632,7 @@ namespace etl
         default: new_state_id = p_parent ? p_parent->process_event(message) : static_cast<TDerived*>(this)->on_event_unknown(message); break;
       }
 
-      return new_state_id;
+      return (new_state_id != Pass_To_Parent) ? new_state_id : (p_parent ? p_parent->process_event(message) : No_State_Change);
     }
   };
 
@@ -694,7 +696,7 @@ namespace etl
         default: new_state_id = p_parent ? p_parent->process_event(message) : static_cast<TDerived*>(this)->on_event_unknown(message); break;
       }
 
-      return new_state_id;
+      return (new_state_id != Pass_To_Parent) ? new_state_id : (p_parent ? p_parent->process_event(message) : No_State_Change);
     }
   };
 
@@ -757,7 +759,7 @@ namespace etl
         default: new_state_id = p_parent ? p_parent->process_event(message) : static_cast<TDerived*>(this)->on_event_unknown(message); break;
       }
 
-      return new_state_id;
+      return (new_state_id != Pass_To_Parent) ? new_state_id : (p_parent ? p_parent->process_event(message) : No_State_Change);
     }
   };
 
@@ -819,7 +821,7 @@ namespace etl
         default: new_state_id = p_parent ? p_parent->process_event(message) : static_cast<TDerived*>(this)->on_event_unknown(message); break;
       }
 
-      return new_state_id;
+      return (new_state_id != Pass_To_Parent) ? new_state_id : (p_parent ? p_parent->process_event(message) : No_State_Change);
     }
   };
 
@@ -879,7 +881,7 @@ namespace etl
         default: new_state_id = p_parent ? p_parent->process_event(message) : static_cast<TDerived*>(this)->on_event_unknown(message); break;
       }
 
-      return new_state_id;
+      return (new_state_id != Pass_To_Parent) ? new_state_id : (p_parent ? p_parent->process_event(message) : No_State_Change);
     }
   };
 
@@ -938,7 +940,7 @@ namespace etl
         default: new_state_id = p_parent ? p_parent->process_event(message) : static_cast<TDerived*>(this)->on_event_unknown(message); break;
       }
 
-      return new_state_id;
+      return (new_state_id != Pass_To_Parent) ? new_state_id : (p_parent ? p_parent->process_event(message) : No_State_Change);
     }
   };
 
@@ -996,7 +998,7 @@ namespace etl
         default: new_state_id = p_parent ? p_parent->process_event(message) : static_cast<TDerived*>(this)->on_event_unknown(message); break;
       }
 
-      return new_state_id;
+      return (new_state_id != Pass_To_Parent) ? new_state_id : (p_parent ? p_parent->process_event(message) : No_State_Change);
     }
   };
 
@@ -1053,7 +1055,7 @@ namespace etl
         default: new_state_id = p_parent ? p_parent->process_event(message) : static_cast<TDerived*>(this)->on_event_unknown(message); break;
       }
 
-      return new_state_id;
+      return (new_state_id != Pass_To_Parent) ? new_state_id : (p_parent ? p_parent->process_event(message) : No_State_Change);
     }
   };
 
@@ -1108,7 +1110,7 @@ namespace etl
         default: new_state_id = p_parent ? p_parent->process_event(message) : static_cast<TDerived*>(this)->on_event_unknown(message); break;
       }
 
-      return new_state_id;
+      return (new_state_id != Pass_To_Parent) ? new_state_id : (p_parent ? p_parent->process_event(message) : No_State_Change);
     }
   };
 
@@ -1162,7 +1164,7 @@ namespace etl
         default: new_state_id = p_parent ? p_parent->process_event(message) : static_cast<TDerived*>(this)->on_event_unknown(message); break;
       }
 
-      return new_state_id;
+      return (new_state_id != Pass_To_Parent) ? new_state_id : (p_parent ? p_parent->process_event(message) : No_State_Change);
     }
   };
 
@@ -1215,7 +1217,7 @@ namespace etl
         default: new_state_id = p_parent ? p_parent->process_event(message) : static_cast<TDerived*>(this)->on_event_unknown(message); break;
       }
 
-      return new_state_id;
+      return (new_state_id != Pass_To_Parent) ? new_state_id : (p_parent ? p_parent->process_event(message) : No_State_Change);
     }
   };
 
@@ -1267,7 +1269,7 @@ namespace etl
         default: new_state_id = p_parent ? p_parent->process_event(message) : static_cast<TDerived*>(this)->on_event_unknown(message); break;
       }
 
-      return new_state_id;
+      return (new_state_id != Pass_To_Parent) ? new_state_id : (p_parent ? p_parent->process_event(message) : No_State_Change);
     }
   };
 
@@ -1317,7 +1319,7 @@ namespace etl
         default: new_state_id = p_parent ? p_parent->process_event(message) : static_cast<TDerived*>(this)->on_event_unknown(message); break;
       }
 
-      return new_state_id;
+      return (new_state_id != Pass_To_Parent) ? new_state_id : (p_parent ? p_parent->process_event(message) : No_State_Change);
     }
   };
 
@@ -1366,7 +1368,7 @@ namespace etl
         default: new_state_id = p_parent ? p_parent->process_event(message) : static_cast<TDerived*>(this)->on_event_unknown(message); break;
       }
 
-      return new_state_id;
+      return (new_state_id != Pass_To_Parent) ? new_state_id : (p_parent ? p_parent->process_event(message) : No_State_Change);
     }
   };
 
@@ -1414,7 +1416,7 @@ namespace etl
         default: new_state_id = p_parent ? p_parent->process_event(message) : static_cast<TDerived*>(this)->on_event_unknown(message); break;
       }
 
-      return new_state_id;
+      return (new_state_id != Pass_To_Parent) ? new_state_id : (p_parent ? p_parent->process_event(message) : No_State_Change);
     }
   };
 
@@ -1461,7 +1463,7 @@ namespace etl
         default: new_state_id = p_parent ? p_parent->process_event(message) : static_cast<TDerived*>(this)->on_event_unknown(message); break;
       }
 
-      return new_state_id;
+      return (new_state_id != Pass_To_Parent) ? new_state_id : (p_parent ? p_parent->process_event(message) : No_State_Change);
     }
   };
 

--- a/include/etl/generators/fsm_generator.h
+++ b/include/etl/generators/fsm_generator.h
@@ -198,6 +198,8 @@ namespace etl
     // Pass this whenever no state change is desired.
     // The highest unsigned value of fsm_state_id_t.
     static ETL_CONSTANT fsm_state_id_t No_State_Change = etl::integral_limits<fsm_state_id_t>::max;
+    // Pass this when this event also needs to be passed to the parent.
+    static ETL_CONSTANT fsm_state_id_t Pass_To_Parent = No_State_Change - 1U;
 
     /// Allows ifsm_state functions to be private.
     friend class etl::fsm;
@@ -654,7 +656,7 @@ namespace etl
   cog.outl(" break;")
   cog.outl("    }")
   cog.outl("")
-  cog.outl("    return new_state_id;")
+  cog.outl("    return (new_state_id != Pass_To_Parent) ? new_state_id : (p_parent ? p_parent->process_event(message) : No_State_Change);")
   cog.outl("  }")
   cog.outl("};")
 
@@ -731,7 +733,7 @@ namespace etl
       cog.outl(" break;")
       cog.outl("    }")
       cog.outl("")
-      cog.outl("    return new_state_id;")
+      cog.outl("    return (new_state_id != Pass_To_Parent) ? new_state_id : (p_parent ? p_parent->process_event(message) : No_State_Change);")
       cog.outl("  }")
       cog.outl("};")
   ####################################

--- a/include/etl/generators/fsm_generator.h
+++ b/include/etl/generators/fsm_generator.h
@@ -570,7 +570,7 @@ namespace etl
 
       const bool was_handled = (process_event_type<TMessageTypes>(message, new_state_id) || ...);
 
-      if (!was_handled)
+      if (!was_handled || new_state_id == Pass_To_Parent)
       {
         new_state_id = (p_parent != nullptr) ? p_parent->process_event(message) : static_cast<TDerived*>(this)->on_event_unknown(message);
       }


### PR DESCRIPTION
Sometimes event data needs to be read by both a child and its parent. By using a special `Pass_To_Parent` value, a child class can partially handle an event and continue to send the event to a parent.