### PR TITLE
Fix comment in `queue::del_out`

### DIFF
--- a/include/etl/queue.h
+++ b/include/etl/queue.h
@@ -197,7 +197,7 @@ namespace etl
     }
 
     //*************************************************************************
-    /// Decrements (and wraps) the 'out' index value to record a queue deletion.
+    /// Increments (and wraps) the 'out' index value to record a queue deletion.
     //*************************************************************************
     void del_out()
     {


### PR DESCRIPTION
Seems it was copied from stack implementation, but queue increments out
not, decrements it.