### PR TITLE
is_enum implementation

### DIFF
--- a/include/etl/generators/type_traits_generator.h
+++ b/include/etl/generators/type_traits_generator.h
@@ -93,7 +93,7 @@ namespace etl
   //*****************************************************************************
   // Traits are defined by the ETL
   //*****************************************************************************
-  
+
   //***************************************************************************
   /// integral_constant
   template <typename T, const T VALUE>
@@ -426,17 +426,6 @@ namespace etl
 #endif
 
   //***************************************************************************
-  /// is_reference
-  template<typename T> struct is_reference_helper : false_type {};
-  template<typename T> struct is_reference_helper<T&> : true_type {};
-  template<typename T> struct is_reference : is_reference_helper<typename remove_cv<T>::type> {};
-
-#if ETL_USING_CPP17
-  template <typename T>
-  inline constexpr bool is_reference_v = is_reference<T>::value;
-#endif
-
-  //***************************************************************************
   /// is_lvalue_reference
   template<typename T> struct is_lvalue_reference_helper : false_type {};
   template<typename T> struct is_lvalue_reference_helper<T&> : true_type {};
@@ -458,6 +447,21 @@ namespace etl
   template <typename T>
   inline constexpr bool is_rvalue_reference_v = etl::is_rvalue_reference<T>::value;
 #endif
+#endif
+
+  //***************************************************************************
+  /// is_reference
+  // Either lvalue or rvalue (for CPP11)
+  template<typename T> struct is_reference : integral_constant<bool,
+    is_lvalue_reference<T>::value
+    #if ETL_USING_CPP11
+        || is_rvalue_reference<T>::value
+    #endif
+  >{};
+
+#if ETL_USING_CPP17
+  template <typename T>
+  inline constexpr bool is_reference_v = is_reference<T>::value;
 #endif
 
   //***************************************************************************
@@ -630,8 +634,8 @@ namespace etl
     struct internal: TDerived, dummy<int>{};
 
     static TBase* check(TBase*) { return (TBase*)0; }
-    
-    template<typename T> 
+
+    template<typename T>
     static char check(dummy<T>*) { return 0; }
 
   public:
@@ -705,6 +709,40 @@ namespace etl
   template <typename T>
   typename etl::add_rvalue_reference<T>::type declval() ETL_NOEXCEPT;
 #endif
+
+#if ETL_USING_CPP11
+  //***************************************************************************
+  /// is_enum
+  ///\ingroup type_traits
+  /// Implemented by checking if type is convertable to an integer thru static_cast
+
+  namespace private_type_traits {
+
+    // Base case
+    template <typename T, typename = int>
+    struct is_convertible_to_int : false_type {};
+
+    // Selected if `static_cast<int>(declval<T>())` is a valid statement
+    // 2nd template argument of base case defaults to int to ensure that this partial specialization is always tried first
+    template <typename T>
+    struct is_convertible_to_int<
+        T, decltype(static_cast<int>(declval<T>()))>
+        : true_type {};
+
+  } // namespace private_type_traits
+  template <typename T>
+  struct is_enum
+    : integral_constant<bool, private_type_traits::is_convertible_to_int<T>::value &&
+                                       !is_class<T>::value &&
+                                       !is_arithmetic<T>::value &&
+                                       !is_reference<T>::value> {};
+
+#if ETL_USING_CPP17
+  template <typename T>
+  inline constexpr bool is_enum_v = etl::is_enum<T>::value;
+#endif
+
+#endif // ETL_USING_CPP11
 
   //***************************************************************************
   /// is_convertible
@@ -1917,7 +1955,7 @@ namespace etl
 #else
 
   //*********************************************
-  // Assume that anything other than arithmetics 
+  // Assume that anything other than arithmetics
   // and pointers return false for the traits.
   //*********************************************
 

--- a/include/etl/type_traits.h
+++ b/include/etl/type_traits.h
@@ -81,7 +81,7 @@ namespace etl
   //*****************************************************************************
   // Traits are defined by the ETL
   //*****************************************************************************
-  
+
   //***************************************************************************
   /// integral_constant
   template <typename T, const T VALUE>
@@ -414,17 +414,6 @@ namespace etl
 #endif
 
   //***************************************************************************
-  /// is_reference
-  template<typename T> struct is_reference_helper : false_type {};
-  template<typename T> struct is_reference_helper<T&> : true_type {};
-  template<typename T> struct is_reference : is_reference_helper<typename remove_cv<T>::type> {};
-
-#if ETL_USING_CPP17
-  template <typename T>
-  inline constexpr bool is_reference_v = is_reference<T>::value;
-#endif
-
-  //***************************************************************************
   /// is_lvalue_reference
   template<typename T> struct is_lvalue_reference_helper : false_type {};
   template<typename T> struct is_lvalue_reference_helper<T&> : true_type {};
@@ -446,6 +435,21 @@ namespace etl
   template <typename T>
   inline constexpr bool is_rvalue_reference_v = etl::is_rvalue_reference<T>::value;
 #endif
+#endif
+
+  //***************************************************************************
+  /// is_reference
+  // Either lvalue or rvalue (for CPP11)
+  template<typename T> struct is_reference : integral_constant<bool,
+    is_lvalue_reference<T>::value
+    #if ETL_USING_CPP11
+        || is_rvalue_reference<T>::value
+    #endif
+  >{};
+
+#if ETL_USING_CPP17
+  template <typename T>
+  inline constexpr bool is_reference_v = is_reference<T>::value;
 #endif
 
   //***************************************************************************
@@ -618,8 +622,8 @@ namespace etl
     struct internal: TDerived, dummy<int>{};
 
     static TBase* check(TBase*) { return (TBase*)0; }
-    
-    template<typename T> 
+
+    template<typename T>
     static char check(dummy<T>*) { return 0; }
 
   public:
@@ -693,6 +697,40 @@ namespace etl
   template <typename T>
   typename etl::add_rvalue_reference<T>::type declval() ETL_NOEXCEPT;
 #endif
+
+#if ETL_USING_CPP11
+  //***************************************************************************
+  /// is_enum
+  ///\ingroup type_traits
+  /// Implemented by checking if type is convertable to an integer thru static_cast
+
+  namespace private_type_traits {
+
+    // Base case
+    template <typename T, typename = int>
+    struct is_convertible_to_int : false_type {};
+
+    // Selected if `static_cast<int>(declval<T>())` is a valid statement
+    // 2nd template argument of base case defaults to int to ensure that this partial specialization is always tried first
+    template <typename T>
+    struct is_convertible_to_int<
+        T, decltype(static_cast<int>(declval<T>()))>
+        : true_type {};
+
+  } // namespace private_type_traits
+  template <typename T>
+  struct is_enum
+    : integral_constant<bool, private_type_traits::is_convertible_to_int<T>::value &&
+                                       !is_class<T>::value &&
+                                       !is_arithmetic<T>::value &&
+                                       !is_reference<T>::value> {};
+
+#if ETL_USING_CPP17
+  template <typename T>
+  inline constexpr bool is_enum_v = etl::is_enum<T>::value;
+#endif
+
+#endif // ETL_USING_CPP11
 
   //***************************************************************************
   /// is_convertible
@@ -1910,7 +1948,7 @@ namespace etl
 #else
 
   //*********************************************
-  // Assume that anything other than arithmetics 
+  // Assume that anything other than arithmetics
   // and pointers return false for the traits.
   //*********************************************
 

--- a/test/test_type_traits.cpp
+++ b/test/test_type_traits.cpp
@@ -56,6 +56,28 @@ namespace
   {
   };
 
+  // Unscoped enum
+  enum Enum
+  {
+  };
+
+  // Scoped enum
+  enum class EnumClass
+  {
+  };
+
+  // Class which can be implicitly converted to/from any default-constructable type
+  struct ToAny {
+    ToAny() = default;
+    template <typename T> ToAny(T){};
+    template <typename T> operator T() { return T(); }
+  };
+
+  // Can't be default constructed
+  struct NotDefaultConstructable {
+    NotDefaultConstructable() = delete;
+  };
+
   //*********************************************
   struct Copyable
   {
@@ -304,6 +326,10 @@ namespace
       CHECK(etl::is_reference<const int&>::value          == std::is_reference<const int&>::value);
       CHECK(etl::is_reference<volatile int&>::value       == std::is_reference<volatile int&>::value);
       CHECK(etl::is_reference<const volatile int&>::value == std::is_reference<const volatile int&>::value);
+      CHECK(etl::is_reference<int&&>::value                == std::is_reference<int&&>::value);
+      CHECK(etl::is_reference<const int&&>::value          == std::is_reference<const int&&>::value);
+      CHECK(etl::is_reference<volatile int&&>::value       == std::is_reference<volatile int&&>::value);
+      CHECK(etl::is_reference<const volatile int&&>::value == std::is_reference<const volatile int&&>::value);
     }
 
     //*************************************************************************
@@ -956,6 +982,33 @@ namespace
     CHECK_EQUAL(std::is_rvalue_reference_v<int&>,  etl::is_rvalue_reference_v<int&>);
     CHECK_EQUAL(std::is_rvalue_reference_v<int&&>, etl::is_rvalue_reference_v<int&&>);
   }
+
+  //*************************************************************************
+  #define CHECK_EQUAL_FOR_TYPE(type) CHECK_EQUAL(std::is_enum_v<type>, etl::is_enum_v<type>)
+  TEST(test_is_enum) {
+    CHECK_EQUAL_FOR_TYPE(void);
+    CHECK_EQUAL_FOR_TYPE(void*);
+    CHECK_EQUAL_FOR_TYPE(int);
+    CHECK_EQUAL_FOR_TYPE(int*);
+    CHECK_EQUAL_FOR_TYPE(ToAny);
+    CHECK_EQUAL_FOR_TYPE(NotDefaultConstructable);
+    CHECK_EQUAL_FOR_TYPE(Enum);
+    CHECK_EQUAL_FOR_TYPE(Enum&);
+    CHECK_EQUAL_FOR_TYPE(Enum&&);
+    CHECK_EQUAL_FOR_TYPE(Enum*);
+    CHECK_EQUAL_FOR_TYPE(const Enum);
+    CHECK_EQUAL_FOR_TYPE(volatile Enum);
+    CHECK_EQUAL_FOR_TYPE(const volatile Enum);
+    CHECK_EQUAL_FOR_TYPE(EnumClass);
+    CHECK_EQUAL_FOR_TYPE(EnumClass&);
+    CHECK_EQUAL_FOR_TYPE(EnumClass&&);
+    CHECK_EQUAL_FOR_TYPE(EnumClass*);
+    CHECK_EQUAL_FOR_TYPE(const EnumClass);
+    CHECK_EQUAL_FOR_TYPE(volatile EnumClass);
+    CHECK_EQUAL_FOR_TYPE(const volatile EnumClass);
+
+  }
+  #undef CHECK_EQUAL_FOR_TYPE
 
   //*************************************************************************
   TEST(test_integral_constants)


### PR DESCRIPTION
Discussion in #227 notes that a lack of implementation of `is_enum` prevents it from moving forward; not sure if it's because new type traits have been added since but I was able to implement `is_enum` by checking for `static_cast`ability into `int` with SFINAE, then ignoring other types that have this capability (arithmetic types, any class types with `operator int()` overloads, and reference types).

In the process I found that `is_reference` gave the wrong result for rvalue references, which this relies on, so I fixed that too.

Some other bugs which I noticed - I'll raise issues and submit PRs for these when I get the chance:
- `etl::void_t` suffers from a C++11 defect - see https://en.cppreference.com/w/cpp/types/void_t and search for CWG issue 1558
- The `message_parser` file has gotten out of sync with the generator for that file; the CMake should probably be setup to run all the generators as part of the build process...

I ran the unit tests with g++ 8.4 on Ubuntu 18.04, but don't have clang or MSVC so can't readily test those. https://www.etlcpp.com/unit_testing.html says that there should be CI for this? 