### PR TITLE
etl/span.h: prevent compound statements in constexpr methods for C++11

### DIFF
--- a/include/etl/span.h
+++ b/include/etl/span.h
@@ -333,14 +333,7 @@ namespace etl
     ETL_CONSTEXPR 
     etl::span<element_type, (COUNT != etl::dynamic_extent ? COUNT : (EXTENT != etl::dynamic_extent ? EXTENT - OFFSET : etl::dynamic_extent))> subspan() const
     {
-      if (COUNT == etl::dynamic_extent)
-      {
-        return etl::span<element_type, (COUNT != etl::dynamic_extent ? COUNT : (EXTENT != etl::dynamic_extent ? EXTENT - OFFSET : etl::dynamic_extent))>(mbegin + OFFSET, mend);
-      }
-      else
-      {
-        return etl::span<element_type, (COUNT != etl::dynamic_extent ? COUNT : (EXTENT != etl::dynamic_extent ? EXTENT - OFFSET : etl::dynamic_extent))>(mbegin + OFFSET, mbegin + OFFSET + COUNT);
-      }
+      return COUNT == etl::dynamic_extent ? etl::span<element_type, (COUNT != etl::dynamic_extent ? COUNT : (EXTENT != etl::dynamic_extent ? EXTENT - OFFSET : etl::dynamic_extent))>(mbegin + OFFSET, mend) : etl::span<element_type, (COUNT != etl::dynamic_extent ? COUNT : (EXTENT != etl::dynamic_extent ? EXTENT - OFFSET : etl::dynamic_extent))>(mbegin + OFFSET, mbegin + OFFSET + COUNT);
     }
 #else
     //*************************************************************************
@@ -705,14 +698,7 @@ namespace etl
     ETL_CONSTEXPR 
     etl::span<element_type, COUNT> subspan() const
     {
-      if (COUNT == etl::dynamic_extent)
-      {
-        return etl::span<element_type, COUNT>(mbegin + OFFSET, mend);
-      }
-      else
-      {
-        return etl::span<element_type, COUNT>(mbegin + OFFSET, mbegin + OFFSET + COUNT);
-      }     
+      return COUNT == etl::dynamic_extent ? etl::span<element_type, COUNT>(mbegin + OFFSET, mend) : etl::span<element_type, COUNT>(mbegin + OFFSET, mbegin + OFFSET + COUNT);
     }
 #else
     //*************************************************************************


### PR DESCRIPTION
C++11 doesn't support compound statements in constexpr functions
and as a result, `etl/span.h` generates a heap of warnings with
gcc's `-Wpedantic` in C++11 mode. This changes the relevant method
bodies to contain just a single return statement.