### PR TITLE
Generator resync for message_router.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,9 @@ endif()
 
 project(etl VERSION ${ETL_VERSION})
 
+# Used for testing that generators are synced to their outputs
+find_package(Python COMPONENTS Interpreter REQUIRED)
+
 option(BUILD_TESTS "Build unit tests" OFF)
 option(NO_STL "No STL" OFF)
 
@@ -65,7 +68,10 @@ if(${CMAKE_PROJECT_NAME} STREQUAL ${PROJECT_NAME})
     install(DIRECTORY ${PROJECT_SOURCE_DIR}/include/etl DESTINATION include)
 endif()
 
+# Below test checks if the generators output the corresponding headers files exactly. As of 2022-07-17 the generator for variant_pool.h has fallen significantly out-of-sync and needs to be fixed before uncommenting.
+# add_test(NAME test_generators_synced COMMAND ${Python_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/generator_test.py)
+
 if (BUILD_TESTS)
   enable_testing()
-  add_subdirectory(test) 
+  add_subdirectory(test)
 endif()

--- a/generator_test.py
+++ b/generator_test.py
@@ -1,0 +1,43 @@
+import subprocess
+from os.path import abspath
+from pathlib import Path
+import filecmp
+
+root_path = Path(abspath(__file__)).parent
+generator_folder = root_path/"include" / "etl" / "generators"
+
+# Create folder where generator outputs can go for purpose of comparison
+test_folder = root_path / "build" / "generator_tmp"
+test_folder.mkdir(parents=True, exist_ok= True)
+
+all_ok = True
+for generator in generator_folder.iterdir():
+    if generator.suffix != ".h":
+        continue
+    generator_path = str(generator_folder / generator)
+    output_name = generator.name[:-12] + ".h"
+    output_path = str(test_folder / output_name)
+
+    cog_cmd = [
+        "cog",
+        "-d",
+        "-e",
+        f"-o{output_path}",
+        "-DHandlers=16",
+        "-DNTypes=16",
+        "-DIsOneOf=16",
+        generator_path
+    ]
+
+    subprocess.run(cog_cmd)
+
+    # Compare generator output against actual file output
+    actual_path = str(generator_folder.parent / output_name)
+    if not filecmp.cmp(actual_path, output_path):
+        print(f"Generator for {output_name} does not match file contents")
+        all_ok = False
+
+if not all_ok:
+    exit(1)
+exit(0)
+

--- a/include/etl/generators/message_router_generator.h
+++ b/include/etl/generators/message_router_generator.h
@@ -331,6 +331,15 @@ namespace etl
     destination.receive(message);
   }
 
+  //***************************************************************************
+  /// Send a shared message to a router.
+  //***************************************************************************
+  static inline void send_message(etl::imessage_router& destination,
+                                  etl::shared_message message)
+  {
+    destination.receive(message);
+  }
+
 //*************************************************************************************************
 // For C++17 and above.
 //*************************************************************************************************
@@ -546,7 +555,7 @@ namespace etl
               cog.outl("")
               cog.out("                                                  ")
       cog.outl("T%s>::value)" % int(Handlers))
-      cog.outl("    {")     
+      cog.outl("    {")
       cog.outl("      static_cast<TDerived*>(this)->on_receive(msg);")
       cog.outl("    }")
       cog.outl("    else")


### PR DESCRIPTION
Partially fixes #564

I also wrote a script/test which can be used to verify as part of the build test process in the future that the generators match the actual headers, although in running it I found out that the `variant_pool.h` header is significantly out of sync. So, the test is left commented out in CMake (also, because I wasn't sure that was the best way to integrate a check like this into the build system).