### PR TITLE
Allow users to remove SYSTEM keyword because it forces C linkage for some gcc versions.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,13 +15,22 @@ project(etl VERSION ${ETL_VERSION})
 
 option(BUILD_TESTS "Build unit tests" OFF)
 option(NO_STL "No STL" OFF)
+# There is a bug on old gcc versions for some targets that causes all system headers
+# to be implicitly wrapped with 'extern "C"'
+# Users can add set(NO_SYSTEM_INCLUDE ON) to their top level CMakeLists.txt to work around this.
+option(NO_SYSTEM_INCLUDE "Do not include with -isystem" OFF)
+if (NO_SYSTEM_INCLUDE)
+    set(INCLUDE_SPECIFIER "")
+else()
+    set(INCLUDE_SPECIFIER "SYSTEM")
+endif()
 
 add_library(${PROJECT_NAME} INTERFACE)
 # This allows users which use the add_subdirectory or FetchContent
 # to use the same target as users which use find_package
 add_library(etl::etl ALIAS ${PROJECT_NAME})
 
-target_include_directories(${PROJECT_NAME} SYSTEM INTERFACE
+target_include_directories(${PROJECT_NAME} ${INCLUDE_SPECIFIER} INTERFACE
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
         $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
         )


### PR DESCRIPTION
I've been having the same problem as the user @jwellbelove mentioned in this comment: https://github.com/ETLCPP/etl/pull/340#issuecomment-804758033

I'm pretty sure it has to do with this bug in my version of GCC that automatically adds `extern "C"` to system headers for some targets.  
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=85211  

I added this option to give uses a way to opt out of treating these files like a system include without changing the default behavior.