### PR TITLE
Bip buffer improvements

### DIFF
--- a/include/etl/bip_buffer_spsc_atomic.h
+++ b/include/etl/bip_buffer_spsc_atomic.h
@@ -384,9 +384,9 @@ namespace etl
     using base_t::max_size;
 
     //*************************************************************************
-    // Reserves a memory area for reading up to the max_reserve_size
+    // Reserves a memory area for reading (up to the max_reserve_size).
     //*************************************************************************
-    span<T> read_reserve(size_type max_reserve_size)
+    span<T> read_reserve(size_type max_reserve_size = numeric_limits<size_type>::max())
     {
       size_type reserve_size = max_reserve_size;
       size_type rindex = get_read_reserve(&reserve_size);
@@ -433,7 +433,7 @@ namespace etl
     void clear()
     {
       // the buffer might be split into two contiguous blocks
-      for (span<T> reader = read_reserve(max_size()); reader.size() > 0; reader = read_reserve(max_size()))
+      for (span<T> reader = read_reserve(); reader.size() > 0; reader = read_reserve())
       {
         destroy(reader.begin(), reader.end());
         read_commit(reader);

--- a/test/test_bip_buffer_spsc_atomic.cpp
+++ b/test/test_bip_buffer_spsc_atomic.cpp
@@ -142,7 +142,7 @@ namespace
       CHECK_EQUAL(0U, writer.size());
 
       // Read to capacity
-      reader = istream.read_reserve(istream.size());
+      reader = istream.read_reserve();
       CHECK_EQUAL(3U, reader.size());
       CHECK_EQUAL(3, reader[0]);
       CHECK_EQUAL(4, reader[1]);
@@ -152,7 +152,7 @@ namespace
       istream.read_commit(reader); // * 2 * * *
       CHECK_EQUAL(1U, stream.size());
 
-      reader = istream.read_reserve(istream.size());
+      reader = istream.read_reserve();
       CHECK_EQUAL(1U, reader.size());
       CHECK_EQUAL(6, reader[0]);
       CHECK_EQUAL(1U, stream.size());


### PR DESCRIPTION
* improve the read reserve API by reserving all what's available by default
* add new write reserve API that allows prioritizing buffer space saving over getting large linear chunks