### PR TITLE
Invoke function pointers w/ parenthesis

### DIFF
--- a/include/etl/private/delegate_cpp03.h
+++ b/include/etl/private/delegate_cpp03.h
@@ -370,7 +370,7 @@ namespace etl
       }
       else
       {
-        return Method(param);
+        return (Method)(param);
       }
     }
 
@@ -758,7 +758,7 @@ namespace etl
       }
       else
       {
-        return Method();
+        return (Method)();
       }
     }
 

--- a/include/etl/private/delegate_cpp11.h
+++ b/include/etl/private/delegate_cpp11.h
@@ -335,7 +335,7 @@ namespace etl
       }
       else
       {
-        return Method(etl::forward<TParams>(args)...);
+        return (Method)(etl::forward<TParams>(args)...);
       }
     }
 


### PR DESCRIPTION
Enclose with parenthesis when invoking function pointers. This is useful when integrating with other libraries that has macros with the same name, resulting in conflict.