### PR TITLE
Fix etl::result<void> being unusable due to deleted default constructor

### DIFF
--- a/include/etl/result.h
+++ b/include/etl/result.h
@@ -227,9 +227,11 @@ namespace etl
   public:
 
     //*******************************************
-    /// Cannot be default constructed
+    /// Default Constructor
     //*******************************************
-    result() = delete;
+    result()
+    {
+    }
 
     //*******************************************
     /// Copy constructor
@@ -286,7 +288,7 @@ namespace etl
     //*******************************************
     bool is_value() const
     {
-      return false;
+      return (data.index() == 0U);
     }
 
     //*******************************************
@@ -294,7 +296,7 @@ namespace etl
     //*******************************************
     bool is_error() const
     {
-      return true;
+      return (data.index() == 1U);
     }
 
     //*******************************************

--- a/test/test_result.cpp
+++ b/test/test_result.cpp
@@ -222,6 +222,24 @@ namespace
     }
 
     //*************************************************************************
+    TEST(test_constructor_for_result_void_value_with_value)
+    {
+       ResultV result;
+
+       CHECK(!result.is_value());
+       CHECK(result.is_error());
+    }
+
+    //*************************************************************************
+    TEST(test_constructor_for_const_result_void_value_with_value)
+    {
+       const ResultV result;
+
+       CHECK(!result.is_value());
+       CHECK(result.is_error());
+    }
+
+    //*************************************************************************
     TEST(test_constructor_for_result_void_value_with_error)
     {
       Error input = { "error 1" };


### PR DESCRIPTION
`etl::result<void>` was unusable due to the lack of a default constructor. This resulted 🙈 in the result being unusable as functions with `etl::result<void>` could only return errors results