### PR TITLE
Fixed IAR build warnings in message_packet

### DIFF
--- a/include/etl/generators/message_packet_generator.h
+++ b/include/etl/generators/message_packet_generator.h
@@ -750,7 +750,7 @@ namespace etl
         for t in range(1, n):
             cog.out("T%s, " % t)
         cog.outl("T%s>::value, int>::type>" % n)
-        cog.outl("  explicit message_packet(etl::imessage&& msg)")
+        cog.outl("  explicit message_packet(TMessage&& msg)")
         cog.outl("    : data()")
         cog.outl("    , valid(true)")
         cog.outl("  {")

--- a/include/etl/message_packet.h
+++ b/include/etl/message_packet.h
@@ -663,7 +663,7 @@ namespace etl
     template <typename TMessage, typename = typename etl::enable_if<!etl::is_same<typename etl::remove_reference<TMessage>::type, etl::message_packet<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> >::value &&
                                                                     !etl::is_same<typename etl::remove_reference<TMessage>::type, etl::imessage>::value &&
                                                                     !etl::is_one_of<typename etl::remove_reference<TMessage>::type, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>::value, int>::type>
-    explicit message_packet(etl::imessage&& msg)
+    explicit message_packet(TMessage&& msg)
       : data()
       , valid(true)
     {
@@ -945,7 +945,7 @@ namespace etl
     template <typename TMessage, typename = typename etl::enable_if<!etl::is_same<typename etl::remove_reference<TMessage>::type, etl::message_packet<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> >::value &&
                                                                     !etl::is_same<typename etl::remove_reference<TMessage>::type, etl::imessage>::value &&
                                                                     !etl::is_one_of<typename etl::remove_reference<TMessage>::type, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>::value, int>::type>
-    explicit message_packet(etl::imessage&& msg)
+    explicit message_packet(TMessage&& msg)
       : data()
       , valid(true)
     {
@@ -1225,7 +1225,7 @@ namespace etl
     template <typename TMessage, typename = typename etl::enable_if<!etl::is_same<typename etl::remove_reference<TMessage>::type, etl::message_packet<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> >::value &&
                                                                     !etl::is_same<typename etl::remove_reference<TMessage>::type, etl::imessage>::value &&
                                                                     !etl::is_one_of<typename etl::remove_reference<TMessage>::type, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>::value, int>::type>
-    explicit message_packet(etl::imessage&& msg)
+    explicit message_packet(TMessage&& msg)
       : data()
       , valid(true)
     {
@@ -1502,7 +1502,7 @@ namespace etl
     template <typename TMessage, typename = typename etl::enable_if<!etl::is_same<typename etl::remove_reference<TMessage>::type, etl::message_packet<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> >::value &&
                                                                     !etl::is_same<typename etl::remove_reference<TMessage>::type, etl::imessage>::value &&
                                                                     !etl::is_one_of<typename etl::remove_reference<TMessage>::type, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>::value, int>::type>
-    explicit message_packet(etl::imessage&& msg)
+    explicit message_packet(TMessage&& msg)
       : data()
       , valid(true)
     {
@@ -1774,7 +1774,7 @@ namespace etl
     template <typename TMessage, typename = typename etl::enable_if<!etl::is_same<typename etl::remove_reference<TMessage>::type, etl::message_packet<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> >::value &&
                                                                     !etl::is_same<typename etl::remove_reference<TMessage>::type, etl::imessage>::value &&
                                                                     !etl::is_one_of<typename etl::remove_reference<TMessage>::type, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>::value, int>::type>
-    explicit message_packet(etl::imessage&& msg)
+    explicit message_packet(TMessage&& msg)
       : data()
       , valid(true)
     {
@@ -2044,7 +2044,7 @@ namespace etl
     template <typename TMessage, typename = typename etl::enable_if<!etl::is_same<typename etl::remove_reference<TMessage>::type, etl::message_packet<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> >::value &&
                                                                     !etl::is_same<typename etl::remove_reference<TMessage>::type, etl::imessage>::value &&
                                                                     !etl::is_one_of<typename etl::remove_reference<TMessage>::type, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>::value, int>::type>
-    explicit message_packet(etl::imessage&& msg)
+    explicit message_packet(TMessage&& msg)
       : data()
       , valid(true)
     {
@@ -2312,7 +2312,7 @@ namespace etl
     template <typename TMessage, typename = typename etl::enable_if<!etl::is_same<typename etl::remove_reference<TMessage>::type, etl::message_packet<T1, T2, T3, T4, T5, T6, T7, T8, T9> >::value &&
                                                                     !etl::is_same<typename etl::remove_reference<TMessage>::type, etl::imessage>::value &&
                                                                     !etl::is_one_of<typename etl::remove_reference<TMessage>::type, T1, T2, T3, T4, T5, T6, T7, T8, T9>::value, int>::type>
-    explicit message_packet(etl::imessage&& msg)
+    explicit message_packet(TMessage&& msg)
       : data()
       , valid(true)
     {
@@ -2577,7 +2577,7 @@ namespace etl
     template <typename TMessage, typename = typename etl::enable_if<!etl::is_same<typename etl::remove_reference<TMessage>::type, etl::message_packet<T1, T2, T3, T4, T5, T6, T7, T8> >::value &&
                                                                     !etl::is_same<typename etl::remove_reference<TMessage>::type, etl::imessage>::value &&
                                                                     !etl::is_one_of<typename etl::remove_reference<TMessage>::type, T1, T2, T3, T4, T5, T6, T7, T8>::value, int>::type>
-    explicit message_packet(etl::imessage&& msg)
+    explicit message_packet(TMessage&& msg)
       : data()
       , valid(true)
     {
@@ -2837,7 +2837,7 @@ namespace etl
     template <typename TMessage, typename = typename etl::enable_if<!etl::is_same<typename etl::remove_reference<TMessage>::type, etl::message_packet<T1, T2, T3, T4, T5, T6, T7> >::value &&
                                                                     !etl::is_same<typename etl::remove_reference<TMessage>::type, etl::imessage>::value &&
                                                                     !etl::is_one_of<typename etl::remove_reference<TMessage>::type, T1, T2, T3, T4, T5, T6, T7>::value, int>::type>
-    explicit message_packet(etl::imessage&& msg)
+    explicit message_packet(TMessage&& msg)
       : data()
       , valid(true)
     {
@@ -3095,7 +3095,7 @@ namespace etl
     template <typename TMessage, typename = typename etl::enable_if<!etl::is_same<typename etl::remove_reference<TMessage>::type, etl::message_packet<T1, T2, T3, T4, T5, T6> >::value &&
                                                                     !etl::is_same<typename etl::remove_reference<TMessage>::type, etl::imessage>::value &&
                                                                     !etl::is_one_of<typename etl::remove_reference<TMessage>::type, T1, T2, T3, T4, T5, T6>::value, int>::type>
-    explicit message_packet(etl::imessage&& msg)
+    explicit message_packet(TMessage&& msg)
       : data()
       , valid(true)
     {
@@ -3351,7 +3351,7 @@ namespace etl
     template <typename TMessage, typename = typename etl::enable_if<!etl::is_same<typename etl::remove_reference<TMessage>::type, etl::message_packet<T1, T2, T3, T4, T5> >::value &&
                                                                     !etl::is_same<typename etl::remove_reference<TMessage>::type, etl::imessage>::value &&
                                                                     !etl::is_one_of<typename etl::remove_reference<TMessage>::type, T1, T2, T3, T4, T5>::value, int>::type>
-    explicit message_packet(etl::imessage&& msg)
+    explicit message_packet(TMessage&& msg)
       : data()
       , valid(true)
     {
@@ -3604,7 +3604,7 @@ namespace etl
     template <typename TMessage, typename = typename etl::enable_if<!etl::is_same<typename etl::remove_reference<TMessage>::type, etl::message_packet<T1, T2, T3, T4> >::value &&
                                                                     !etl::is_same<typename etl::remove_reference<TMessage>::type, etl::imessage>::value &&
                                                                     !etl::is_one_of<typename etl::remove_reference<TMessage>::type, T1, T2, T3, T4>::value, int>::type>
-    explicit message_packet(etl::imessage&& msg)
+    explicit message_packet(TMessage&& msg)
       : data()
       , valid(true)
     {
@@ -3852,7 +3852,7 @@ namespace etl
     template <typename TMessage, typename = typename etl::enable_if<!etl::is_same<typename etl::remove_reference<TMessage>::type, etl::message_packet<T1, T2, T3> >::value &&
                                                                     !etl::is_same<typename etl::remove_reference<TMessage>::type, etl::imessage>::value &&
                                                                     !etl::is_one_of<typename etl::remove_reference<TMessage>::type, T1, T2, T3>::value, int>::type>
-    explicit message_packet(etl::imessage&& msg)
+    explicit message_packet(TMessage&& msg)
       : data()
       , valid(true)
     {
@@ -4098,7 +4098,7 @@ namespace etl
     template <typename TMessage, typename = typename etl::enable_if<!etl::is_same<typename etl::remove_reference<TMessage>::type, etl::message_packet<T1, T2> >::value &&
                                                                     !etl::is_same<typename etl::remove_reference<TMessage>::type, etl::imessage>::value &&
                                                                     !etl::is_one_of<typename etl::remove_reference<TMessage>::type, T1, T2>::value, int>::type>
-    explicit message_packet(etl::imessage&& msg)
+    explicit message_packet(TMessage&& msg)
       : data()
       , valid(true)
     {
@@ -4342,7 +4342,7 @@ namespace etl
     template <typename TMessage, typename = typename etl::enable_if<!etl::is_same<typename etl::remove_reference<TMessage>::type, etl::message_packet<T1> >::value &&
                                                                     !etl::is_same<typename etl::remove_reference<TMessage>::type, etl::imessage>::value &&
                                                                     !etl::is_one_of<typename etl::remove_reference<TMessage>::type, T1>::value, int>::type>
-    explicit message_packet(etl::imessage&& msg)
+    explicit message_packet(TMessage&& msg)
       : data()
       , valid(true)
     {


### PR DESCRIPTION
IAR was tripping up on the syntax, generating warnings.  This addresses that per the discussion in #586 