### PR TITLE
Add minmax_push.h/minmax_pop.h includes

### DIFF
--- a/include/etl/string_utilities.h
+++ b/include/etl/string_utilities.h
@@ -38,6 +38,8 @@ SOFTWARE.
 #include "char_traits.h"
 #include "optional.h"
 
+#include "private/minmax_push.h"
+
 #include <ctype.h>
 #include <stdint.h>
 
@@ -832,5 +834,7 @@ namespace etl
     etl::transform(itr, s.end(), itr, ::tolower);
   }
 }
+
+#include "private/minmax_pop.h"
 
 #endif


### PR DESCRIPTION
Includes for minmax_push.h/minmax_pop.h are required due to usage of etl:min in this module. This prevents conflicts with system defined min/max macros.