### PR TITLE
Use a different workaround for problems with IARCC.

### DIFF
--- a/include/etl/placement_new.h
+++ b/include/etl/placement_new.h
@@ -37,7 +37,11 @@ SOFTWARE.
 // Figure out if we can use the standard library <new> header, if haven't already done so in etl_profile.h
 #if !defined(ETL_USING_STD_NEW)
   #if defined(__has_include)
-    #define ETL_USING_STD_NEW __has_include("new")
+    #if __has_include(<new>)
+      #define ETL_USING_STD_NEW 1
+    #else
+      #define ETL_USING_STD_NEW 0
+    #endif
   #elif (defined(ARDUINO) && defined(__AVR__))
     #define ETL_USING_STD_NEW 0
   #else


### PR DESCRIPTION
This is related to #593 and #592.

This approach may be better as is uses the same syntax using `< ... >` as before. Has been suggested in https://github.com/ETLCPP/etl/pull/593#issuecomment-1239222424.

This is based on the insight, that the problem with IARCC occurs only in case the `__has_include` is used as part of a preprocessor definition. See https://github.com/ETLCPP/etl/pull/593#issuecomment-1239208693.