### PR TITLE
Do not use min/max workaround for ICCAVR.

### DIFF
--- a/include/etl/private/minmax_pop.h
+++ b/include/etl/private/minmax_pop.h
@@ -32,7 +32,7 @@ SOFTWARE.
  * The header include guard has been intentionally omitted.
  * This file is intended to evaluated multiple times by design.
  */
-#if !defined(ETL_COMPILER_GREEN_HILLS)
+#if !defined(ETL_COMPILER_GREEN_HILLS) && !defined(__ICCAVR__)
   #if !defined(ETL_COMPILER_ARM5)
     #pragma pop_macro("min")
     #pragma pop_macro("max")

--- a/include/etl/private/minmax_push.h
+++ b/include/etl/private/minmax_push.h
@@ -33,7 +33,7 @@ SOFTWARE.
  * This file is intended to evaluated multiple times by design.
  */
 
-#if !defined(ETL_COMPILER_GREEN_HILLS)
+#if !defined(ETL_COMPILER_GREEN_HILLS) && !defined(__ICCAVR__)
   #if !defined(ETL_COMPILER_ARM5)
     #pragma push_macro("min")
     #pragma push_macro("max")


### PR DESCRIPTION
IAR C/C++ Compiler V6.70.1.929 for Atmel AVR does not support `push_macro` and does neither define macros for `min` or `max`.

This seems to be the same as #483 but for a different compiler.