### PR TITLE
Fix 'maybe-uninitialized' g++ error on macos

### DIFF
--- a/test/test_fixed_iterator.cpp
+++ b/test/test_fixed_iterator.cpp
@@ -55,7 +55,7 @@ namespace
     //*************************************************************************
     TEST(test_copy_constructor)
     {
-      int a;
+      int a{};
 
       etl::fixed_iterator<const int*> fi1(&a);
       etl::fixed_iterator<const int*> fi2(fi1);
@@ -66,7 +66,7 @@ namespace
     //*************************************************************************
     TEST(test_constructor)
     {
-      int a;
+      int a{};
 
       etl::fixed_iterator<const int*> fi(&a);
 
@@ -76,7 +76,7 @@ namespace
     //*************************************************************************
     TEST(test_make)
     {
-      int a;
+      int a{};
 
       etl::fixed_iterator<const int*> fi = &a;
 
@@ -121,7 +121,7 @@ namespace
     //*************************************************************************
     TEST(test_conversion_operator)
     {
-      int a;
+      int a{};
 
       etl::fixed_iterator<const int*> fi(&a);
 
@@ -202,8 +202,8 @@ namespace
     //*************************************************************************
     TEST(test_assignment)
     {
-      int a;
-      int b;
+      int a{};
+      int b{};
 
       etl::fixed_iterator<int*> fi = &a;
       fi = &b;
@@ -218,8 +218,8 @@ namespace
     //*************************************************************************
     TEST(test_equality)
     {
-      int a;
-      int b;
+      int a{};
+      int b{};
 
       etl::fixed_iterator<int*> fi1 = &a;
       etl::fixed_iterator<int*> fi2 = &a;

--- a/test/test_hash.cpp
+++ b/test/test_hash.cpp
@@ -202,7 +202,7 @@ namespace
     //*************************************************************************
     TEST(test_hash_pointer)
     {
-      int i;
+      int i{};
       size_t hash = etl::hash<int*>()(&i);
 
       CHECK_EQUAL(size_t(&i), hash);
@@ -211,7 +211,7 @@ namespace
     //*************************************************************************
     TEST(test_hash_const_pointer)
     {
-      int i;
+      int i{};
       size_t hash = etl::hash<const int*>()(&i);
 
       CHECK_EQUAL(size_t(&i), hash);
@@ -220,7 +220,7 @@ namespace
     //*************************************************************************
     TEST(test_hash_const_pointer_const)
     {
-      int i;
+      int i{};
       const int * const pi = &i;
 
       size_t hash = etl::hash<const int *>()(pi);

--- a/test/test_multi_array.cpp
+++ b/test/test_multi_array.cpp
@@ -298,7 +298,7 @@ namespace
     //*************************************************************************
     TEST(test_empty)
     {
-      Data data;
+      Data data{};
 
       CHECK(!data.empty());
       CHECK(!data[0].empty());


### PR DESCRIPTION
Fix errors when trying to compile using g++ on mac os.

The errors were like this one : 

```
/Users/XXX/wip/2022/09/etl/test/test_array.cpp: In member function 'virtual void {anonymous}::Suitetest_array::Testtest_empty::RunImpl() const':
/Users/XXX/wip/2022/09/etl/test/test_array.cpp:309:24: error: 'data' may be used uninitialized [-Werror=maybe-uninitialized]
  309 |       CHECK(!data.empty());
      |                        ^
In file included from /Users/XXX/wip/2022/09/etl/test/test_array.cpp:33:
/Users/XXX/wip/2022/09/etl/test/../include/etl/array.h:313:24: note: by argument 1 of type 'const etl::array<int, 10>*' to 'constexpr bool etl::array<T, SIZE_>::empty() const [with T = int; long unsigned int SIZE_ = 10]' declared here
  313 |     ETL_CONSTEXPR bool empty() const ETL_NOEXCEPT
      |                        ^~~~~
/Users/XXX/wip/2022/09/etl/test/test_array.cpp:307:12: note: 'data' declared here
  307 |       Data data;
      |            ^~~~
cc1plus: all warnings being treated as errors
make[2]: *** [test/CMakeFiles/etl_tests.dir/test_array.cpp.o] Error 1
make[1]: *** [test/CMakeFiles/etl_tests.dir/all] Error 2
make: *** [all] Error 2
```

I was using these command : 

```shell
mkdir build-cmake-gcc && cd build-cmake-gcc 

export CC=gcc
        export CXX=g++
        export ASAN_OPTIONS=alloc_dealloc_mismatch=0,detect_leaks=0

gcc --version
g++ --version

# g++ (Homebrew GCC 12.2.0) 12.2.0
# Copyright (C) 2022 Free Software Foundation, Inc.
# This is free software; see the source for copying conditions.  There is NO
# warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

cmake -D BUILD_TESTS=ON -DNO_STL=OFF -DETL_USE_TYPE_TRAITS_BUILTINS=OFF -DETL_USER_DEFINED_TYPE_TRAITS=OFF -DETL_FORCE_TEST_CPP03=OFF ..

make
```
