### PR TITLE
Automatically detect native endianness for IAR compiler platform.

### DIFF
--- a/include/etl/endianness.h
+++ b/include/etl/endianness.h
@@ -45,6 +45,14 @@ SOFTWARE.
 /// Constants & utilities for endianess
 ///\ingroup utilities
 
+#if !defined(ETL_ENDIAN_NATIVE) && defined(__IAR_SYSTEMS_ICC__) && defined(__LITTLE_ENDIAN__)
+  #if __LITTLE_ENDIAN__ == 1
+    #define ETL_ENDIAN_NATIVE 0
+  #elif __LITTLE_ENDIAN__ == 0
+    #define ETL_ENDIAN_NATIVE 1
+  #endif
+#endif
+
 // Have we not already defined ETL_ENDIAN_NATIVE?
 #if !defined(ETL_ENDIAN_NATIVE)
   // Can we use the C++20 definitions?

--- a/include/etl/endianness.h
+++ b/include/etl/endianness.h
@@ -42,7 +42,7 @@ SOFTWARE.
 #endif
 
 ///\defgroup endian endian
-/// Constants & utilities for endianess
+/// Constants & utilities for endianness
 ///\ingroup utilities
 
 #if !defined(ETL_ENDIAN_NATIVE) && defined(__IAR_SYSTEMS_ICC__) && defined(__LITTLE_ENDIAN__)


### PR DESCRIPTION
For for IAR compiler platform it is possible to automatically detect the native endianness.

References:

- [IAR C/C++ Development Guide Compiling and Linking for Arm Limited’s **Arm**® Cores](https://wwwfiles.iar.com/arm/webic/doc/ewarm_developmentguide.enu.pdf)
- [IAR C/C++ Compiler User Guide for Microchip Technology’s **AVR** Microcontroller Family](https://wwwfiles.iar.com/AVR/webic/doc/EWAVR_CompilerGuide.pdf)