### PR TITLE
unaligned types: match the signedness of the storage type with the template type

### DIFF
--- a/include/etl/unaligned_type.h
+++ b/include/etl/unaligned_type.h
@@ -58,10 +58,10 @@ namespace etl
 
       static ETL_CONSTANT size_t Size = Size_;
 
-      typedef char*                                 pointer;
-      typedef const char*                           const_pointer;
-      typedef char*                                 iterator;
-      typedef const char*                           const_iterator;
+      typedef unsigned char*                        pointer;
+      typedef const unsigned char*                  const_pointer;
+      typedef unsigned char*                        iterator;
+      typedef const unsigned char*                  const_iterator;
       typedef etl::reverse_iterator<iterator>       reverse_iterator;
       typedef etl::reverse_iterator<const_iterator> const_reverse_iterator;
 
@@ -196,7 +196,7 @@ namespace etl
       //*************************************************************************
       /// Index operator.
       //*************************************************************************
-      char& operator[](int i)
+      unsigned char& operator[](int i)
       {
         return storage[i];
       }
@@ -204,14 +204,14 @@ namespace etl
       //*************************************************************************
       /// Const index operator.
       //*************************************************************************
-      ETL_CONSTEXPR const char& operator[](int i) const
+      ETL_CONSTEXPR const unsigned char& operator[](int i) const
       {
         return storage[i];
       }
 
     protected:
 
-      char storage[Size];
+      unsigned char storage[Size];
     };
   }
 
@@ -362,19 +362,19 @@ namespace etl
     struct unaligned_copy<U, 1U>
     {
       //*******************************
-      static ETL_CONSTEXPR14 void copy(T value, char* store)
+      static ETL_CONSTEXPR14 void copy(T value, unsigned char* store)
       {
         store[0] = static_cast<char>(value);
       }
 
       //*******************************
-      static ETL_CONSTEXPR14 void copy(const char* store, T& value)
+      static ETL_CONSTEXPR14 void copy(const unsigned char* store, T& value)
       {
         value = static_cast<T>(store[0]);
       }
 
       //*******************************
-      static ETL_CONSTEXPR14 void copy(const char* src, int /*endian_src*/, char* dst)
+      static ETL_CONSTEXPR14 void copy(const unsigned char* src, int /*endian_src*/, unsigned char* dst)
       {
         dst[0] = src[0];
       }
@@ -387,37 +387,37 @@ namespace etl
     struct unaligned_copy<U, 2U>
     {
       //*******************************
-      static ETL_CONSTEXPR14 void copy(T value, char* store)
+      static ETL_CONSTEXPR14 void copy(T value, unsigned char* store)
       {
         if (Endian == etl::endianness::value())
         {
-          store[0] = static_cast<char>(value);
-          store[1] = static_cast<char>(value >> (1U * CHAR_BIT));
+          store[0] = static_cast<unsigned char>(value);
+          store[1] = static_cast<unsigned char>(value >> (1U * CHAR_BIT));
         }
         else
         {
-          store[1] = static_cast<char>(value);
-          store[0] = static_cast<char>(value >> (1U * CHAR_BIT));
+          store[1] = static_cast<unsigned char>(value);
+          store[0] = static_cast<unsigned char>(value >> (1U * CHAR_BIT));
         }
       }
 
       //*******************************
-      static ETL_CONSTEXPR14 void copy(const char* store, T& value)
+      static ETL_CONSTEXPR14 void copy(const unsigned char* store, T& value)
       {
         if (Endian == etl::endianness::value())
         {
-          value  = static_cast<T>(static_cast<unsigned char>(store[0]));
-          value |= static_cast<T>(static_cast<unsigned char>(store[1])) << (1U * CHAR_BIT);
+          value  = static_cast<T>(store[0]);
+          value |= static_cast<T>(store[1]) << (1U * CHAR_BIT);
         }
         else
         {
-          value  = static_cast<T>(static_cast<unsigned char>(store[1]));
-          value |= static_cast<T>(static_cast<unsigned char>(store[0])) << (1U * CHAR_BIT);
+          value  = static_cast<T>(store[1]);
+          value |= static_cast<T>(store[0]) << (1U * CHAR_BIT);
         }
       }
 
       //*******************************
-      static ETL_CONSTEXPR14 void copy(const char* src, int endian_src, char* dst)
+      static ETL_CONSTEXPR14 void copy(const unsigned char* src, int endian_src, unsigned char* dst)
       {
         if (Endian == endian_src)
         {
@@ -438,21 +438,21 @@ namespace etl
     template <typename U>
     struct unaligned_copy<U, 4U>
     {
-      static ETL_CONSTEXPR14 void copy(T value, char* store)
+      static ETL_CONSTEXPR14 void copy(T value, unsigned char* store)
       {
         if (Endian == etl::endianness::value())
         {
-          store[0] = static_cast<char>(value);
-          store[1] = static_cast<char>(value >> (1U * CHAR_BIT));
-          store[2] = static_cast<char>(value >> (2U * CHAR_BIT));
-          store[3] = static_cast<char>(value >> (3U * CHAR_BIT));
+          store[0] = static_cast<unsigned char>(value);
+          store[1] = static_cast<unsigned char>(value >> (1U * CHAR_BIT));
+          store[2] = static_cast<unsigned char>(value >> (2U * CHAR_BIT));
+          store[3] = static_cast<unsigned char>(value >> (3U * CHAR_BIT));
         }
         else
         {
-          store[3] = static_cast<char>(value);
-          store[2] = static_cast<char>(value >> (1U * CHAR_BIT));
-          store[1] = static_cast<char>(value >> (2U * CHAR_BIT));
-          store[0] = static_cast<char>(value >> (3U * CHAR_BIT));
+          store[3] = static_cast<unsigned char>(value);
+          store[2] = static_cast<unsigned char>(value >> (1U * CHAR_BIT));
+          store[1] = static_cast<unsigned char>(value >> (2U * CHAR_BIT));
+          store[0] = static_cast<unsigned char>(value >> (3U * CHAR_BIT));
         }
       }
 
@@ -461,22 +461,22 @@ namespace etl
       {
         if (Endian == etl::endianness::value())
         {
-          value  = static_cast<T>(static_cast<unsigned char>(store[0]));
-          value |= static_cast<T>(static_cast<unsigned char>(store[1])) << (1U * CHAR_BIT);
-          value |= static_cast<T>(static_cast<unsigned char>(store[2])) << (2U * CHAR_BIT);
-          value |= static_cast<T>(static_cast<unsigned char>(store[3])) << (3U * CHAR_BIT);
+          value  = static_cast<T>(store[0]);
+          value |= static_cast<T>(store[1]) << (1U * CHAR_BIT);
+          value |= static_cast<T>(store[2]) << (2U * CHAR_BIT);
+          value |= static_cast<T>(store[3]) << (3U * CHAR_BIT);
         }
         else
         {
-          value  = static_cast<T>(static_cast<unsigned char>(store[3]));
-          value |= static_cast<T>(static_cast<unsigned char>(store[2])) << (1U * CHAR_BIT);
-          value |= static_cast<T>(static_cast<unsigned char>(store[1])) << (2U * CHAR_BIT);
-          value |= static_cast<T>(static_cast<unsigned char>(store[0])) << (3U * CHAR_BIT);
+          value  = static_cast<T>(store[3]);
+          value |= static_cast<T>(store[2]) << (1U * CHAR_BIT);
+          value |= static_cast<T>(store[1]) << (2U * CHAR_BIT);
+          value |= static_cast<T>(store[0]) << (3U * CHAR_BIT);
         }
       }
 
       //*******************************
-      static ETL_CONSTEXPR14 void copy(const char* src, int endian_src, char* dst)
+      static ETL_CONSTEXPR14 void copy(const unsigned char* src, int endian_src, unsigned char* dst)
       {
         if (Endian == endian_src)
         {
@@ -501,61 +501,61 @@ namespace etl
     template <typename U>
     struct unaligned_copy<U, 8U>
     {
-      static ETL_CONSTEXPR14 void copy(T value, char* store)
+      static ETL_CONSTEXPR14 void copy(T value, unsigned char* store)
       {
         if (Endian == etl::endianness::value())
         {
-          store[0] = static_cast<char>(value);
-          store[1] = static_cast<char>(value >> (1U * CHAR_BIT));
-          store[2] = static_cast<char>(value >> (2U * CHAR_BIT));
-          store[3] = static_cast<char>(value >> (3U * CHAR_BIT));
-          store[4] = static_cast<char>(value >> (4U * CHAR_BIT));
-          store[5] = static_cast<char>(value >> (5U * CHAR_BIT));
-          store[6] = static_cast<char>(value >> (6U * CHAR_BIT));
-          store[7] = static_cast<char>(value >> (7U * CHAR_BIT));
+          store[0] = static_cast<unsigned char>(value);
+          store[1] = static_cast<unsigned char>(value >> (1U * CHAR_BIT));
+          store[2] = static_cast<unsigned char>(value >> (2U * CHAR_BIT));
+          store[3] = static_cast<unsigned char>(value >> (3U * CHAR_BIT));
+          store[4] = static_cast<unsigned char>(value >> (4U * CHAR_BIT));
+          store[5] = static_cast<unsigned char>(value >> (5U * CHAR_BIT));
+          store[6] = static_cast<unsigned char>(value >> (6U * CHAR_BIT));
+          store[7] = static_cast<unsigned char>(value >> (7U * CHAR_BIT));
         }
         else
         {
-          store[7] = static_cast<char>(value);
-          store[6] = static_cast<char>(value >> (1U * CHAR_BIT));
-          store[5] = static_cast<char>(value >> (2U * CHAR_BIT));
-          store[4] = static_cast<char>(value >> (3U * CHAR_BIT));
-          store[3] = static_cast<char>(value >> (4U * CHAR_BIT));
-          store[2] = static_cast<char>(value >> (5U * CHAR_BIT));
-          store[1] = static_cast<char>(value >> (6U * CHAR_BIT));
-          store[0] = static_cast<char>(value >> (7U * CHAR_BIT));
+          store[7] = static_cast<unsigned char>(value);
+          store[6] = static_cast<unsigned char>(value >> (1U * CHAR_BIT));
+          store[5] = static_cast<unsigned char>(value >> (2U * CHAR_BIT));
+          store[4] = static_cast<unsigned char>(value >> (3U * CHAR_BIT));
+          store[3] = static_cast<unsigned char>(value >> (4U * CHAR_BIT));
+          store[2] = static_cast<unsigned char>(value >> (5U * CHAR_BIT));
+          store[1] = static_cast<unsigned char>(value >> (6U * CHAR_BIT));
+          store[0] = static_cast<unsigned char>(value >> (7U * CHAR_BIT));
         }
       }
 
       //*******************************
-      static ETL_CONSTEXPR14 void copy(const char* store, T& value)
+      static ETL_CONSTEXPR14 void copy(const unsigned char* store, T& value)
       {
         if (Endian == etl::endianness::value())
         {
-          value  = static_cast<T>(static_cast<unsigned char>(store[0]));
-          value |= static_cast<T>(static_cast<unsigned char>(store[1])) << (1U * CHAR_BIT);
-          value |= static_cast<T>(static_cast<unsigned char>(store[2])) << (2U * CHAR_BIT);
-          value |= static_cast<T>(static_cast<unsigned char>(store[3])) << (3U * CHAR_BIT);
-          value |= static_cast<T>(static_cast<unsigned char>(store[4])) << (4U * CHAR_BIT);
-          value |= static_cast<T>(static_cast<unsigned char>(store[5])) << (5U * CHAR_BIT);
-          value |= static_cast<T>(static_cast<unsigned char>(store[6])) << (6U * CHAR_BIT);
-          value |= static_cast<T>(static_cast<unsigned char>(store[7])) << (7U * CHAR_BIT);
+          value  = static_cast<T>(store[0]);
+          value |= static_cast<T>(store[1]) << (1U * CHAR_BIT);
+          value |= static_cast<T>(store[2]) << (2U * CHAR_BIT);
+          value |= static_cast<T>(store[3]) << (3U * CHAR_BIT);
+          value |= static_cast<T>(store[4]) << (4U * CHAR_BIT);
+          value |= static_cast<T>(store[5]) << (5U * CHAR_BIT);
+          value |= static_cast<T>(store[6]) << (6U * CHAR_BIT);
+          value |= static_cast<T>(store[7]) << (7U * CHAR_BIT);
         }
         else
         {
-          value  = static_cast<T>(static_cast<unsigned char>(store[7]));
-          value |= static_cast<T>(static_cast<unsigned char>(store[6])) << (1U * CHAR_BIT);
-          value |= static_cast<T>(static_cast<unsigned char>(store[5])) << (2U * CHAR_BIT);
-          value |= static_cast<T>(static_cast<unsigned char>(store[4])) << (3U * CHAR_BIT);
-          value |= static_cast<T>(static_cast<unsigned char>(store[3])) << (4U * CHAR_BIT);
-          value |= static_cast<T>(static_cast<unsigned char>(store[2])) << (5U * CHAR_BIT);
-          value |= static_cast<T>(static_cast<unsigned char>(store[1])) << (6U * CHAR_BIT);
-          value |= static_cast<T>(static_cast<unsigned char>(store[0])) << (7U * CHAR_BIT);
+          value  = static_cast<T>(store[7]);
+          value |= static_cast<T>(store[6]) << (1U * CHAR_BIT);
+          value |= static_cast<T>(store[5]) << (2U * CHAR_BIT);
+          value |= static_cast<T>(store[4]) << (3U * CHAR_BIT);
+          value |= static_cast<T>(store[3]) << (4U * CHAR_BIT);
+          value |= static_cast<T>(store[2]) << (5U * CHAR_BIT);
+          value |= static_cast<T>(store[1]) << (6U * CHAR_BIT);
+          value |= static_cast<T>(store[0]) << (7U * CHAR_BIT);
         }
       }
 
       //*******************************
-      static ETL_CONSTEXPR14 void copy(const char* src, int endian_src, char* dst)
+      static ETL_CONSTEXPR14 void copy(const unsigned char* src, int endian_src, unsigned char* dst)
       {
         if (Endian == endian_src)
         {


### PR DESCRIPTION
The storage type should either be always unsigned, or signed only when the template type is signed. The latter is implemented by this change, not necessarily in the nicest way, so do review first.