### PR TITLE
Automatically set ETL_HAS_ATOMIC if __STDC_NO_ATOMICS__ defined

### DIFF
--- a/include/etl/platform.h
+++ b/include/etl/platform.h
@@ -344,7 +344,8 @@ SOFTWARE.
 // Determine if the ETL should support atomics.
 #if defined(ETL_NO_ATOMICS) || \
     defined(ETL_TARGET_DEVICE_ARM_CORTEX_M0) || \
-    defined(ETL_TARGET_DEVICE_ARM_CORTEX_M0_PLUS)
+    defined(ETL_TARGET_DEVICE_ARM_CORTEX_M0_PLUS) || \
+    defined(__STDC_NO_ATOMICS__)
   #define ETL_HAS_ATOMIC 0
 #else
   #if ((ETL_USING_CPP11 && (ETL_USING_STL || defined(ETL_IN_UNIT_TEST))) || \


### PR DESCRIPTION
`Atomic.h` is not implemented by IAR on the STM32G0 series processors (an M0+ core).  This can be manually addressed by defining ETL_NO_ATOMICS in `etl_profile.h`, however I've observed that for some programmers, decrypting the compiler errors can be a challenging exercise (in our case, a `message_bus` (which I believe includes `shared_message_bus.h`) was getting a compiler error due to that linkage).  Our initial workaround was to add the `#define`, but I now realize that the C++ standard (>C++11) offers an indicator of the support for `atomic.h` in `__STDC_NO_ATOMICS__`.  Reference: https://en.cppreference.com/w/c/atomic.  This seems like a nice improvement to ease the process of not trying to include `atomic.h` in cases when it will generate a compiler error if attempted.