### PR TITLE
Revert "Fixed move parameter in notify_observers"

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Embedded Template Library (ETL)
 [![Build status](https://ci.appveyor.com/api/projects/status/b7jgecv7unqjw4u0/branch/master?svg=true)](https://ci.appveyor.com/project/jwellbelove/etl/branch/master)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/3c14cd918ccf40008d0bcd7b083d5946)](https://www.codacy.com/manual/jwellbelove/etl?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=ETLCPP/etl&amp;utm_campaign=Badge_Grade)
 
+[![](https://img.shields.io/static/v1?label=Sponsor&message=%E2%9D%A4&logo=GitHub&color=%23fe8e86)](https://github.com/sponsors/jwellbelove)
+
 ## Motivation
 
 C++ is a great language to use for embedded applications and templates are a powerful aspect. The standard library can offer a great deal of well tested functionality,  but there are some parts of the standard library that do not fit well with deterministic behaviour and limited resource requirements. These limitations usually preclude the use of dynamically allocated memory and containers with open ended sizes.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ Embedded Template Library (ETL)
 ![GitHub release (latest by date)](https://img.shields.io/github/v/release/jwellbelove/etl)
 [![Standard](https://img.shields.io/badge/c%2B%2B-98/03/11/14/17-blue.svg)](https://en.wikipedia.org/wiki/C%2B%2B#Standardization)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](https://opensource.org/licenses/MIT)
-[![Sponsors](https://img.shields.io/github/sponsors/ETLCPP)](https://img.shields.io/github/sponsors/ETLCPP)
 
 ![CI](https://github.com/ETLCPP/etl/workflows/vs2019/badge.svg)
 ![CI](https://github.com/ETLCPP/etl/workflows/gcc/badge.svg)
@@ -13,7 +12,7 @@ Embedded Template Library (ETL)
 [![Build status](https://ci.appveyor.com/api/projects/status/b7jgecv7unqjw4u0/branch/master?svg=true)](https://ci.appveyor.com/project/jwellbelove/etl/branch/master)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/3c14cd918ccf40008d0bcd7b083d5946)](https://www.codacy.com/manual/jwellbelove/etl?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=ETLCPP/etl&amp;utm_campaign=Badge_Grade)
 
-[![](https://img.shields.io/static/v1?label=Sponsor&message=%E2%9D%A4&logo=GitHub&color=%23fe8e86)](https://github.com/sponsors/jwellbelove)
+[![](https://img.shields.io/static/v1?label=Sponsor&message=%E2%9D%A4&logo=GitHub&color=%23fe8e86)](https://github.com/sponsors/ETLCPP)
 
 ## Motivation
 

--- a/include/etl/observer.h
+++ b/include/etl/observer.h
@@ -232,9 +232,31 @@ namespace etl
       return observer_list.size();
     }
 
+#if ETL_USING_CPP11 && !defined(ETL_OBSERVER_FORCE_CPP03_IMPLEMENTATION)
     //*****************************************************************
     /// Notify all of the observers, sending them the notification.
-    ///\tparam TNotification The notification type.
+    ///\tparam TNotification the notification type.
+    ///\param n The notification.
+    //*****************************************************************
+    template <typename TNotification>
+    void notify_observers(TNotification&& n)
+    {
+      typename Observer_List::iterator i_observer_item = observer_list.begin();
+
+      while (i_observer_item != observer_list.end())
+      {
+        if (i_observer_item->enabled)
+        {
+          i_observer_item->p_observer->notification(etl::forward<TNotification>(n));
+        }
+
+        ++i_observer_item;
+      }
+    }
+#else
+    //*****************************************************************
+    /// Notify all of the observers, sending them the notification.
+    ///\tparam TNotification the notification type.
     ///\param n The notification.
     //*****************************************************************
     template <typename TNotification>
@@ -252,6 +274,7 @@ namespace etl
         ++i_observer_item;
       }
     }
+#endif
 
   protected:
 

--- a/include/etl/platform.h
+++ b/include/etl/platform.h
@@ -344,7 +344,8 @@ SOFTWARE.
 // Determine if the ETL should support atomics.
 #if defined(ETL_NO_ATOMICS) || \
     defined(ETL_TARGET_DEVICE_ARM_CORTEX_M0) || \
-    defined(ETL_TARGET_DEVICE_ARM_CORTEX_M0_PLUS)
+    defined(ETL_TARGET_DEVICE_ARM_CORTEX_M0_PLUS) || \
+    defined(__STDC_NO_ATOMICS__)
   #define ETL_HAS_ATOMIC 0
 #else
   #if ((ETL_USING_CPP11 && (ETL_USING_STL || defined(ETL_IN_UNIT_TEST))) || \

--- a/test/test_observer.cpp
+++ b/test/test_observer.cpp
@@ -30,46 +30,43 @@ SOFTWARE.
 
 #include "etl/observer.h"
 
-namespace
+//*****************************************************************************
+// Notification1
+//*****************************************************************************
+struct Notification1
 {
-  //*****************************************************************************
-  // Notification1
-  //*****************************************************************************
-  struct Notification1
-  {
-  };
+};
 
-  //*****************************************************************************
-  // Notification2
-  //*****************************************************************************
-  struct Notification2
-  {
-  };
+//*****************************************************************************
+// Notification2
+//*****************************************************************************
+struct Notification2
+{
+};
 
-  //*****************************************************************************
-  // Notification3
-  //*****************************************************************************
-  struct Notification3
-  {
-  };
+//*****************************************************************************
+// Notification3
+//*****************************************************************************
+struct Notification3
+{
+};
 
-  //*****************************************************************************
-  // Generic notification.
-  //*****************************************************************************
-  template <const int ID>
-  struct Notification
-  {
-  };
+//*****************************************************************************
+// Generic notification.
+//*****************************************************************************
+template <const int ID>
+struct Notification
+{
+};
 
-  //*****************************************************************************
-  // The observer base type.
-  // Declare what notifications you want to observe and how they are passed to 'notification'.
-  // The Notification1 is passed by value.
-  // The Notification2 is passed by reference.
-  // The Notification3 is passed by const reference.
-  //*****************************************************************************
-  typedef etl::observer<Notification1, Notification2&, const Notification3&> ObserverType;
-}
+//*****************************************************************************
+// The observer base type.
+// Declare what notifications you want to observe and how they are passed to 'notification'.
+// The Notification1 is passed by value.
+// The Notification2 is passed by reference.
+// The Notification3 is passed by const reference.
+//*****************************************************************************
+typedef etl::observer<Notification1, Notification2&, const Notification3&> ObserverType;
 
 //*****************************************************************************
 // The concrete observable 1 class.
@@ -80,14 +77,13 @@ public:
 
 	Notification1 data1;
 	Notification2 data2;
-  Notification1& data3 = data1;
 
   //*********************************
   // Notify all of the observers.
   //*********************************
 	void send_notifications()
 	{
-		notify_observers(data3);
+		notify_observers(data1);
     notify_observers(data2);
 	}
 };


### PR DESCRIPTION
This reverts commit fa7f6dc9d7187fb246af920b3c3dcfe75bdb7bbf.

The functionality removed in the previous commit was using the universal reference and was not a move parameter.  This is important to keep because it allows having values that are const and still using the nofity_observer pattern with them.  See [https://www.justsoftwaresolutions.co.uk/cplusplus/rvalue_references_and_perfect_forwarding.html](https://www.justsoftwaresolutions.co.uk/cplusplus/rvalue_references_and_perfect_forwarding.html) for a better explanation. 