### PR TITLE
Only build tests if top level project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,9 +73,9 @@ if(${CMAKE_PROJECT_NAME} STREQUAL ${PROJECT_NAME})
         "${PROJECT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"
         DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/${PROJECT_NAME}/cmake)
     install(DIRECTORY ${PROJECT_SOURCE_DIR}/include/etl DESTINATION include)
-endif()
-
-if (BUILD_TESTS)
-  enable_testing()
-  add_subdirectory(test) 
+    
+    if (BUILD_TESTS)
+        enable_testing()
+        add_subdirectory(test) 
+    endif()
 endif()


### PR DESCRIPTION
Currently if included in another project that enables the building tests with the standard option `BUILD_TESTS` the tests of ETL are also build and this cannot be changed from the parent project.

With this change it is possible to only build tests from the parent project.