### PR TITLE
Avoid 'missing return statement at end of non-void function' in `etl::visit<>()`.

### DIFF
--- a/include/etl/private/variant_legacy.h
+++ b/include/etl/private/variant_legacy.h
@@ -968,6 +968,7 @@ namespace etl
       case 6: return static_cast<TReturn>(visitor(get<6>(variant)));             \
       case 7: return static_cast<TReturn>(visitor(get<7>(variant)));             \
       default: ETL_ASSERT(false, ETL_ERROR(bad_variant_access));                 \
+               return TReturn();                                                 \
     }                                                                            \
   }
 

--- a/include/etl/private/variant_legacy.h
+++ b/include/etl/private/variant_legacy.h
@@ -953,23 +953,22 @@ namespace etl
       return get<typename variant_alternative<tIndex, TVariant>::type>(variant);
     }
 
-#define ETL_GEN_LEGACY_VISIT(VISITQUAL, VARIANTQUAL)                             \
-  template <typename TReturn, typename TVisitor, typename TVariant>              \
-  static TReturn visit(TVisitor VISITQUAL visitor, TVariant VARIANTQUAL variant) \
-  {                                                                              \
-    switch (variant.index())                                                     \
-    {                                                                            \
-      case 0: return static_cast<TReturn>(visitor(get<0>(variant)));             \
-      case 1: return static_cast<TReturn>(visitor(get<1>(variant)));             \
-      case 2: return static_cast<TReturn>(visitor(get<2>(variant)));             \
-      case 3: return static_cast<TReturn>(visitor(get<3>(variant)));             \
-      case 4: return static_cast<TReturn>(visitor(get<4>(variant)));             \
-      case 5: return static_cast<TReturn>(visitor(get<5>(variant)));             \
-      case 6: return static_cast<TReturn>(visitor(get<6>(variant)));             \
-      case 7: return static_cast<TReturn>(visitor(get<7>(variant)));             \
-      default: ETL_ASSERT(false, ETL_ERROR(bad_variant_access));                 \
-               return TReturn();                                                 \
-    }                                                                            \
+#define ETL_GEN_LEGACY_VISIT(VISITQUAL, VARIANTQUAL)                                       \
+  template <typename TReturn, typename TVisitor, typename TVariant>                        \
+  static TReturn visit(TVisitor VISITQUAL visitor, TVariant VARIANTQUAL variant)           \
+  {                                                                                        \
+    switch (variant.index())                                                               \
+    {                                                                                      \
+      case 0: return static_cast<TReturn>(visitor(get<0>(variant)));                       \
+      case 1: return static_cast<TReturn>(visitor(get<1>(variant)));                       \
+      case 2: return static_cast<TReturn>(visitor(get<2>(variant)));                       \
+      case 3: return static_cast<TReturn>(visitor(get<3>(variant)));                       \
+      case 4: return static_cast<TReturn>(visitor(get<4>(variant)));                       \
+      case 5: return static_cast<TReturn>(visitor(get<5>(variant)));                       \
+      case 6: return static_cast<TReturn>(visitor(get<6>(variant)));                       \
+      case 7: return static_cast<TReturn>(visitor(get<7>(variant)));                       \
+      default: ETL_ASSERT_FAIL_AND_RETURN_VALUE(ETL_ERROR(bad_variant_access), TReturn()); \
+    }                                                                                      \
   }
 
     ETL_GEN_LEGACY_VISIT(&, &)


### PR DESCRIPTION
For some definitions of `ETL_ASSERT()` there may be no return statement in case of an invalid type.
This results in undefined behavior.

> ```
> Warning[Pe940]: missing return statement at end of non-void function "etl::visit<TReturn,TVisitor,TVariant>(TVisitor &, TVariant const &) include\etl\private\variant_legacy.h 976
> ``` 