### PR TITLE
Feature/#646 improve type traits

### DIFF
--- a/include/etl/generators/type_traits_generator.h
+++ b/include/etl/generators/type_traits_generator.h
@@ -714,7 +714,7 @@ namespace etl
   //***************************************************************************
   /// is_enum
   ///\ingroup type_traits
-  /// Implemented by checking if type is convertable to an integer thru static_cast
+  /// Implemented by checking if type is convertible to an integer through static_cast
 
   namespace private_type_traits 
   {
@@ -1988,13 +1988,40 @@ namespace etl
   };
 
 #if ETL_USING_CPP11
+  //***************************************************************************
+  /// is_constructible
+  namespace private_type_traits 
+  {
+    template <class, class T, class... Args>
+    struct is_constructible_ : etl::false_type {};
+
+    template <class T, class... Args>
+    struct is_constructible_<void_t<decltype(T(etl::declval<Args>()...))>, T, Args...> : etl::true_type {};
+  };
+
+
   //*********************************************
   // is_constructible
-  template <typename T, typename... TArgs>
-  struct is_constructible : public etl::bool_constant<etl::is_arithmetic<T>::value || etl::is_pointer<T>::value>
-  {
-  };
-#endif
+  template <class T, class... Args>
+  using is_constructible = private_type_traits::is_constructible_<void_t<>, T, Args...>;
+
+  //*********************************************
+  // is_copy_constructible
+  template <class T> struct is_copy_constructible : public is_constructible<T,  typename etl::add_lvalue_reference<typename etl::add_const<T>::type>::type>{};
+  template <> struct is_copy_constructible<void> : public false_type{};
+  template <> struct is_copy_constructible<void const> : public false_type{};
+  template <> struct is_copy_constructible<void volatile> : public false_type{};
+  template <> struct is_copy_constructible<void const volatile> : public false_type{};
+
+  //*********************************************
+  // is_move_constructible
+  template <typename T> struct is_move_constructible: public is_constructible<T, typename etl::add_rvalue_reference<T>::type>{};
+  template <> struct is_move_constructible<void> : public false_type{};
+  template <> struct is_move_constructible<void const> : public false_type{};
+  template <> struct is_move_constructible<void volatile> : public false_type{};
+  template <> struct is_move_constructible<void const volatile> : public false_type{};
+
+#else
 
   //*********************************************
   // is_copy_constructible
@@ -2009,6 +2036,7 @@ namespace etl
   struct is_move_constructible : public etl::bool_constant<etl::is_arithmetic<T>::value || etl::is_pointer<T>::value>
   {
   };
+#endif
 
   //*********************************************
   // is_trivially_constructible

--- a/include/etl/type_traits.h
+++ b/include/etl/type_traits.h
@@ -702,7 +702,7 @@ namespace etl
   //***************************************************************************
   /// is_enum
   ///\ingroup type_traits
-  /// Implemented by checking if type is convertable to an integer thru static_cast
+  /// Implemented by checking if type is convertible to an integer through static_cast
 
   namespace private_type_traits 
   {
@@ -1981,13 +1981,40 @@ namespace etl
   };
 
 #if ETL_USING_CPP11
+  //***************************************************************************
+  /// is_constructible
+  namespace private_type_traits 
+  {
+    template <class, class T, class... Args>
+    struct is_constructible_ : etl::false_type {};
+
+    template <class T, class... Args>
+    struct is_constructible_<void_t<decltype(T(etl::declval<Args>()...))>, T, Args...> : etl::true_type {};
+  };
+
+
   //*********************************************
   // is_constructible
-  template <typename T, typename... TArgs>
-  struct is_constructible : public etl::bool_constant<etl::is_arithmetic<T>::value || etl::is_pointer<T>::value>
-  {
-  };
-#endif
+  template <class T, class... Args>
+  using is_constructible = private_type_traits::is_constructible_<void_t<>, T, Args...>;
+
+  //*********************************************
+  // is_copy_constructible
+  template <class T> struct is_copy_constructible : public is_constructible<T,  typename etl::add_lvalue_reference<typename etl::add_const<T>::type>::type>{};
+  template <> struct is_copy_constructible<void> : public false_type{};
+  template <> struct is_copy_constructible<void const> : public false_type{};
+  template <> struct is_copy_constructible<void volatile> : public false_type{};
+  template <> struct is_copy_constructible<void const volatile> : public false_type{};
+
+  //*********************************************
+  // is_move_constructible
+  template <typename T> struct is_move_constructible: public is_constructible<T, typename etl::add_rvalue_reference<T>::type>{};
+  template <> struct is_move_constructible<void> : public false_type{};
+  template <> struct is_move_constructible<void const> : public false_type{};
+  template <> struct is_move_constructible<void volatile> : public false_type{};
+  template <> struct is_move_constructible<void const volatile> : public false_type{};
+
+#else
 
   //*********************************************
   // is_copy_constructible
@@ -2002,6 +2029,7 @@ namespace etl
   struct is_move_constructible : public etl::bool_constant<etl::is_arithmetic<T>::value || etl::is_pointer<T>::value>
   {
   };
+#endif
 
   //*********************************************
   // is_trivially_constructible

--- a/test/test_type_traits.cpp
+++ b/test/test_type_traits.cpp
@@ -128,11 +128,6 @@ struct etl::is_assignable<Copyable, Copyable> : public etl::true_type
 };
 
 template <>
-struct etl::is_constructible<Copyable> : public etl::true_type
-{
-};
-
-template <>
 struct etl::is_copy_constructible<Copyable> : public etl::true_type
 {
 };
@@ -149,11 +144,6 @@ struct etl::is_assignable<Moveable, Moveable> : public etl::true_type
 };
 
 template <>
-struct etl::is_constructible<Moveable> : public etl::true_type
-{
-};
-
-template <>
 struct etl::is_copy_constructible<Moveable> : public etl::false_type
 {
 };
@@ -166,11 +156,6 @@ struct etl::is_move_constructible<Moveable> : public etl::true_type
 //*************************
 template <>
 struct etl::is_assignable<MoveableCopyable, MoveableCopyable> : public etl::true_type
-{
-};
-
-template <>
-struct etl::is_constructible<MoveableCopyable> : public etl::true_type
 {
 };
 


### PR DESCRIPTION
add #646 requirements

I'll elaborate on the importance of this addition. this causes `variant` of classes/structs to have a move ctor that doesn't do anything and thus causes `result` to have a move ctor that does nothing but can change type from result to error. 

These are two undefined behaviors I've found more might be the result of this