### PR TITLE
Don't warn on tag missing when subproject (#653)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/helpers.cmake)
 set(MSG_PREFIX "etl |")
 determine_version_with_git(${GIT_DIR_LOOKUP_POLICY})
 if(NOT ETL_VERSION)
-    determine_version("version.txt")
+    determine_version_with_file("version.txt")
 endif()
 
 project(etl VERSION ${ETL_VERSION} LANGUAGES CXX)

--- a/cmake/helpers.cmake
+++ b/cmake/helpers.cmake
@@ -1,4 +1,4 @@
-function(determine_version VER_FILE_NAME)
+function(determine_version_with_file VER_FILE_NAME)
     file(READ ${VER_FILE_NAME} ETL_VERSION_RAW)
     # Remove trailing whitespaces and/or newline
     string(STRIP ${ETL_VERSION_RAW} ETL_VERSION)
@@ -13,7 +13,11 @@ function(determine_version_with_git)
     git_describe(VERSION ${ARGN})
     string(FIND ${VERSION} "." VALID_VERSION)
     if(VALID_VERSION EQUAL -1)
-        message(WARNING "Version string ${VERSION} retrieved with git describe is invalid")
+        if(PROJECT_IS_TOP_LEVEL)
+            # only warn if this is the top-level project, since we may be
+            # building from a tarball as a subproject
+            message(WARNING "Version string ${VERSION} retrieved with git describe is invalid")
+        endif()
         return()
     endif()
     message(STATUS "${MSG_PREFIX} Version string determined with git describe: ${VERSION}")


### PR DESCRIPTION
Different solution than proposed in the issue, since that proposed solution would given unexpected results when an intermediate (untagged) commit is checked out.

This change simply skips warning about a missing git version when this is a subproject, and uses the original version calculation logic.

I've also renamed `determine_version` to `determine_version_with_file`. I'd originally done this in an intermediate version of this PR, but I think that keeping the renaming is clearer code.