### PR TITLE
Added HFSM-specific start() and reset()

### DIFF
--- a/include/etl/fsm.h
+++ b/include/etl/fsm.h
@@ -346,7 +346,7 @@ namespace etl
     /// Subsequent calls will do nothing.
     ///\param call_on_enter_state If true will call on_enter_state() for the first state. Default = true.
     //*******************************************
-    void start(bool call_on_enter_state = true)
+    virtual void start(bool call_on_enter_state = true)
     {
       // Can only be started once.
       if (p_state == ETL_NULLPTR)
@@ -451,7 +451,7 @@ namespace etl
     /// Reset the FSM to pre-started state.
     ///\param call_on_exit_state If true will call on_exit_state() for the current state. Default = false.
     //*******************************************
-    void reset(bool call_on_exit_state = false)
+    virtual void reset(bool call_on_exit_state = false)
     {
       if ((p_state != ETL_NULLPTR) && call_on_exit_state)
       {

--- a/include/etl/generators/fsm_generator.h
+++ b/include/etl/generators/fsm_generator.h
@@ -372,7 +372,7 @@ namespace etl
     /// Subsequent calls will do nothing.
     ///\param call_on_enter_state If true will call on_enter_state() for the first state. Default = true.
     //*******************************************
-    void start(bool call_on_enter_state = true)
+    virtual void start(bool call_on_enter_state = true)
     {
       // Can only be started once.
       if (p_state == ETL_NULLPTR)
@@ -477,7 +477,7 @@ namespace etl
     /// Reset the FSM to pre-started state.
     ///\param call_on_exit_state If true will call on_exit_state() for the current state. Default = false.
     //*******************************************
-    void reset(bool call_on_exit_state = false)
+    virtual void reset(bool call_on_exit_state = false)
     {
       if ((p_state != ETL_NULLPTR) && call_on_exit_state)
       {

--- a/include/etl/hfsm.h
+++ b/include/etl/hfsm.h
@@ -50,6 +50,41 @@ namespace etl
     {
     }
 
+    //*******************************************
+    /// Starts the HFSM.
+    /// Can only be called once.
+    /// Subsequent calls will do nothing.
+    ///\param call_on_enter_state If true will call on_enter_state() for the first state. Default = true.
+    //*******************************************
+    void start(bool call_on_enter_state = true) ETL_OVERRIDE
+    {
+      // Can only be started once.
+      if (p_state == ETL_NULLPTR)
+      {
+        p_state = state_list[0];
+        ETL_ASSERT(p_state != ETL_NULLPTR, ETL_ERROR(etl::fsm_null_state_exception));
+
+        if (call_on_enter_state)
+        {
+            do_enters(ETL_NULLPTR, p_state, true);
+        }
+      }
+    }
+
+    //*******************************************
+    /// Reset the HFSM to pre-started state.
+    ///\param call_on_exit_state If true will call on_exit_state() for the current state. Default = false.
+    //*******************************************
+    virtual void reset(bool call_on_exit_state = false) ETL_OVERRIDE
+    {
+      if ((p_state != ETL_NULLPTR) && call_on_exit_state)
+      {
+        do_exits(ETL_NULLPTR, p_state);
+      }
+
+      p_state = ETL_NULLPTR;
+    }
+
     using fsm::receive;
 
     //*******************************************


### PR DESCRIPTION
The FSM implementation of `start()` method only performs the first 'enter' if `call_on_enter_state` is set to `true`.  This can be problematic in the HFSM since the initial state might be hierarchal.  The same goes for `reset()` when the `call_on_exit_state` parameter is set to `true`.

This new implementation will service the 'enter' event for all states within the initial state's hierarchy (starting with the outermost parent state first and working all the way into the initial child state).