### PR TITLE
Update a \param in basic_string.h

### DIFF
--- a/include/etl/basic_string.h
+++ b/include/etl/basic_string.h
@@ -1315,7 +1315,7 @@ namespace etl
 
     //*********************************************************************
     /// Copies a portion of a string.
-    ///\param s     Pointer to the string to copy.
+    ///\param dest  Pointer to the destination buffer.
     ///\param count The number of characters to copy.
     ///\param pos   The position to start copying from.
     //*********************************************************************


### PR DESCRIPTION
The comment for `\param s` didn't make sense here. Updated it to refer to `dest`, and mention the 'destination', not the 'source'.