### PR TITLE
Added sanitization fix for MinGW

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -323,16 +323,24 @@ target_link_libraries(etl_tests PRIVATE UnitTestpp)
 if ((CMAKE_CXX_COMPILER_ID MATCHES "GNU") OR (CMAKE_CXX_COMPILER_ID MATCHES "Clang"))
 	target_compile_options(etl_tests
 			PRIVATE
-			-fsanitize=address,undefined,bounds
 			-fno-omit-frame-pointer
 			-Wall
 			-Wextra
 			-Werror
 			)
-	target_link_options(etl_tests
+	
+	# MinGW doesn't presently support sanitization
+	if (NOT MINGW)
+		target_compile_options(etl_tests
 			PRIVATE
 			-fsanitize=address,undefined,bounds
 			)
+
+		target_link_options(etl_tests
+			PRIVATE
+			-fsanitize=address,undefined,bounds
+			)	
+	endif()
 endif ()
 
 # Enable the 'make test' CMake target using the executable defined above


### PR DESCRIPTION
MinGW doesn't presently support sanitization.  So in order to support compiling unit tests in MinGW, a check has been added 
so that the sanitization options are only added if the compiler **isn't** MinGW.