### PR TITLE
Update scheduler.h

### DIFF
--- a/include/etl/scheduler.h
+++ b/include/etl/scheduler.h
@@ -311,7 +311,6 @@ namespace etl
       {
         ETL_ASSERT((p_tasks[i] != ETL_NULLPTR), ETL_ERROR(etl::scheduler_null_task_exception));
         add_task(*(p_tasks[i]));
-        p_tasks[i]->on_task_added();
       }
     }
 


### PR DESCRIPTION
Removed extra call to task.on_task_added() when adding a task list. This function is already called during task.add_task() which results in a duplicated call.