### PR TITLE
Update delegate_cpp11.h

### DIFF
--- a/include/etl/private/delegate_cpp11.h
+++ b/include/etl/private/delegate_cpp11.h
@@ -94,6 +94,10 @@ namespace etl
   template <typename TReturn, typename... TParams>
   class delegate<TReturn(TParams...)> final
   {
+  private:
+
+    using stub_type = TReturn(*)(void* object, TParams...);
+
   public:
 
     //*************************************************************************
@@ -425,9 +429,12 @@ namespace etl
       return is_valid();
     }
 
-  private:
+    stub_type get_invocation_element_stub() const
+    {
+      return invocation.stub;
+    }
 
-    using stub_type = TReturn(*)(void* object, TParams...);
+  private:
 
     //*************************************************************************
     /// The internal invocation object.


### PR DESCRIPTION
Add get method for invocation element stub member.

In current project we have a need to track a content of a container of delegates on a particular event.
I propose this change as it will allow a safe way to access a function pointer behind delegate and it will allow to store and identify what delegate was in the container later during device memory examination.