### PR TITLE
fixed etl::optional emplace

### DIFF
--- a/include/etl/optional.h
+++ b/include/etl/optional.h
@@ -539,7 +539,7 @@ namespace etl
       //*******************************
       template <typename... TArgs>
       ETL_CONSTEXPR20_STL
-      void construct(TArgs... args)
+      void construct(TArgs&&... args)
       {
         destroy();
         etl::construct_at(&u.value, etl::forward<TArgs>(args)...);


### PR DESCRIPTION
Hi,

I've had compile issues with etl::optional after upgrading to version >= 20.35.13.
I think the cause was a missing forwarding reference in optional::storage::construct, hope this is correct.

Regards,
Manuel