### PR TITLE
Optional(POD) operator bool explicit

### DIFF
--- a/include/etl/optional.h
+++ b/include/etl/optional.h
@@ -763,7 +763,8 @@ namespace etl
     //***************************************************************************
     /// Bool conversion operator.
     //***************************************************************************
-    ETL_CONSTEXPR14 operator bool() const
+    ETL_CONSTEXPR14 
+    ETL_EXPLICIT operator bool() const
     {
       return valid;
     }


### PR DESCRIPTION
Hi,

I propose to make `operator bool()` for `etl::optional` (POD specialization) explicit.
This would align it with the non-POD specialization and prevent some nasty bugs if one (like me) forgets to dereference an optional.

Regards,
Manuel