### PR TITLE
parameter_pack: Fix C++17 pedantic build

### DIFF
--- a/include/etl/parameter_pack.h
+++ b/include/etl/parameter_pack.h
@@ -129,14 +129,14 @@ namespace etl
   template <typename... TTypes>
   constexpr size_t parameter_pack<TTypes...>::size;
 
+#if ETL_USING_CPP17
+  template <typename T, typename... TTypes>
+  inline constexpr size_t parameter_pack_v = etl::parameter_pack<TTypes...>::template index_of_type<T>::value;
+#else
   //***********************************
   template <typename... TTypes>
   template <typename T>
   constexpr size_t parameter_pack<TTypes...>::template index_of_type<T>::value;
-
-#if ETL_USING_CPP17
-  template <typename T, typename... TTypes>
-  inline constexpr size_t parameter_pack_v = etl::parameter_pack<TTypes...>::template index_of_type<T>::value;
 #endif
 }
 #endif


### PR DESCRIPTION
Getting this error with `gcc (Ubuntu 10.3.0-1ubuntu1~20.04) 10.3.0` and `-std=c++17`

```
../subprojects/etl-20.36.1/include/etl/private/../parameter_pack.h:135:56: error: keyword ‘template’ not allowed in declarator-id [-Werror=pedantic]
  135 |   constexpr size_t parameter_pack<TTypes...>::template index_of_type<T>::value;
```

Disclaimer: Not familiar with the `ETL_USING_CPPxx` macros intended usage.