### PR TITLE
fix missing class key with friend

### DIFF
--- a/include/etl/fsm.h
+++ b/include/etl/fsm.h
@@ -325,7 +325,7 @@ namespace etl
   {
   public:
 
-    friend etl::hfsm;
+    friend class etl::hfsm;
     using imessage_router::receive;
 
     //*******************************************


### PR DESCRIPTION
With `c++0x` a compiler error is generated due to missing class key in [fsm.h:L328](https://github.com/ETLCPP/etl/blob/ac236c9b98f999fbfc52b81cc854a755a1796a3d/include/etl/fsm.h#L328)

```
/path/to/etl-arduino-master/src/etl/fsm.h:309:5: error: a class-key must be used when declaring a friend
/path/to/etl-arduino-master/src/etl/fsm.h:309:5: error: friend declaration does not name a class or function
```

This PR adds `class` to avoid the compile issue.