### PR TITLE
optional::operator=(nullopt_t) sets valid to false

### DIFF
--- a/include/etl/optional.h
+++ b/include/etl/optional.h
@@ -720,6 +720,7 @@ namespace etl
     //***************************************************************************
     ETL_CONSTEXPR14 optional& operator =(etl::nullopt_t)
     {
+      valid = false;
       return *this;
     }
 

--- a/test/test_optional.cpp
+++ b/test/test_optional.cpp
@@ -493,6 +493,15 @@ namespace
       CHECK_TRUE(result.has_value());
       CHECK_EQUAL(2, result.value());
     }
+
+    //*************************************************************************
+    TEST(test_optional_pod_assign_bug_714)
+    {
+      etl::optional<int> o = 42;
+      o = etl::nullopt;
+
+      CHECK_EQUAL(false, o.has_value());
+    }
   };
 }
 


### PR DESCRIPTION
Fixes https://github.com/ETLCPP/etl/issues/714