### PR TITLE
Allow manipulation of etl::array in constexpr function

### DIFF
--- a/include/etl/array.h
+++ b/include/etl/array.h
@@ -137,7 +137,7 @@ namespace etl
     /// Returns a reference to the value at index 'i'.
     ///\param i The index of the element to access.
     //*************************************************************************
-    reference operator[](size_t i)
+    ETL_CONSTEXPR14 reference operator[](size_t i)
     {
       return _buffer[i];
     }
@@ -155,7 +155,7 @@ namespace etl
     //*************************************************************************
     /// Returns a reference to the first element.
     //*************************************************************************
-    reference front()
+    ETL_CONSTEXPR14 reference front()
     {
       return _buffer[0];
     }
@@ -171,7 +171,7 @@ namespace etl
     //*************************************************************************
     /// Returns a reference to the last element.
     //*************************************************************************
-    reference back()
+    ETL_CONSTEXPR14 reference back()
     {
       return _buffer[SIZE - 1];
     }
@@ -187,7 +187,7 @@ namespace etl
     //*************************************************************************
     /// Returns a pointer to the first element of the internal buffer.
     //*************************************************************************
-    pointer data() ETL_NOEXCEPT
+    ETL_CONSTEXPR14 pointer data() ETL_NOEXCEPT
     {
       return &_buffer[0];
     }
@@ -207,7 +207,7 @@ namespace etl
     //*************************************************************************
     /// Returns an iterator to the beginning of the array.
     //*************************************************************************
-    iterator begin() ETL_NOEXCEPT
+    ETL_CONSTEXPR14 iterator begin() ETL_NOEXCEPT
     {
       return &_buffer[0];
     }
@@ -231,7 +231,7 @@ namespace etl
     //*************************************************************************
     /// Returns an iterator to the end of the array.
     //*************************************************************************
-    iterator end() ETL_NOEXCEPT
+    ETL_CONSTEXPR14 iterator end() ETL_NOEXCEPT
     {
       return _buffer + SIZE;
     }
@@ -255,7 +255,7 @@ namespace etl
     //*************************************************************************
     // Returns an reverse iterator to the reverse beginning of the array.
     //*************************************************************************
-    reverse_iterator rbegin() ETL_NOEXCEPT
+    ETL_CONSTEXPR14 reverse_iterator rbegin() ETL_NOEXCEPT
     {
       return reverse_iterator(end());
     }
@@ -279,7 +279,7 @@ namespace etl
     //*************************************************************************
     /// Returns a reverse iterator to the end of the array.
     //*************************************************************************
-    reverse_iterator rend() ETL_NOEXCEPT
+    ETL_CONSTEXPR14 reverse_iterator rend() ETL_NOEXCEPT
     {
       return reverse_iterator(begin());
     }
@@ -336,7 +336,7 @@ namespace etl
     /// Fills the array with the specified value.
     ///\param value The value to fill the array with.
     //*************************************************************************
-    void fill(parameter_t value)
+    ETL_CONSTEXPR14 void fill(parameter_t value)
     {
       etl::fill(begin(), end(), value);
     }

--- a/include/etl/numeric.h
+++ b/include/etl/numeric.h
@@ -54,7 +54,7 @@ namespace etl
   ///\ingroup numeric
   //***************************************************************************
   template <typename TIterator, typename T>
-  void iota(TIterator first, TIterator last, T value)
+  ETL_CONSTEXPR14 void iota(TIterator first, TIterator last, T value)
   {
     while (first != last)
     {


### PR DESCRIPTION
This is mainly usefull for creating constexpr arrays  in C++14 and up.

Example:
```c++
template <size_t SIZE>
constexpr etl::array<int, SIZE> x_squared(int start_x) {
  etl::array<int, SIZE> out{};
  etl::iota(out.begin(), out.end(), start_x);
  for (int& elem : out) {
    elem = elem * elem;
  }
  return out;
}

// Contains [25,16,9,4,1,0,1,4,9,16,25]
constexpr etl::array compile_time_array = x_squared<11>(-5);

// Contains [35,26,19,14,11,10,11,14,19,26,35]
constexpr etl::array lambda_generated_array = []() constexpr {
  etl::array out{compile_time_array};
  for (size_t i = 0; i < out.size(); ++i) {
    out[i] = out[i] + 10;
  }
  return out;
}();
```