### PR TITLE
Conditionally explicit etl::expected constructors that work in C++11

### DIFF
--- a/include/etl/expected.h
+++ b/include/etl/expected.h
@@ -312,25 +312,41 @@ namespace etl
     }
 #endif
 
+#if ETL_USING_CPP11
     //*******************************************
     /// Copy construct from unexpected type.
     //*******************************************
-    template <typename G>
-    ETL_CONSTEXPR14
-    ETL_EXPLICIT_EXPR(!etl::is_convertible_v<const G&, TError>)
-    expected(const etl::unexpected<G>& ue)
+    template <typename G, typename etl::enable_if<!etl::is_convertible<const G&, TError>::value, bool>::type = false>
+    ETL_CONSTEXPR14 explicit expected(const etl::unexpected<G>& ue)
       : storage(etl::in_place_index_t<Error_Type>(), ue.error())
     {
     }
+
+    template <typename G, typename etl::enable_if<etl::is_convertible<const G&, TError>::value, bool>::type = false>
+    ETL_CONSTEXPR14 expected(const etl::unexpected<G>& ue)
+      : storage(etl::in_place_index_t<Error_Type>(), ue.error())
+    {
+    }
+#else
+    template <typename G>
+    explicit expected(const etl::unexpected<G>& ue)
+      : storage(etl::in_place_index_t<Error_Type>(), ue.error())
+    {
+    }
+#endif
 
 #if ETL_USING_CPP11
     //*******************************************
     /// Move construct from unexpected type.
     //*******************************************
-    template <typename G>
-    ETL_CONSTEXPR14
-    ETL_EXPLICIT_EXPR(!etl::is_convertible_v<G, TError>)
-    expected(etl::unexpected<G>&& ue)
+    template <typename G, typename etl::enable_if<!etl::is_convertible<const G&, TError>::value, bool>::type = false>
+    ETL_CONSTEXPR14 explicit expected(etl::unexpected<G>&& ue)
+      : storage(etl::in_place_index_t<Error_Type>(), etl::move(ue.error()))
+    {
+    }
+
+    template <typename G, typename etl::enable_if<etl::is_convertible<const G&, TError>::value, bool>::type = false>
+    ETL_CONSTEXPR14 expected(etl::unexpected<G>&& ue)
       : storage(etl::in_place_index_t<Error_Type>(), etl::move(ue.error()))
     {
     }


### PR DESCRIPTION
Using `etl::expected` can be annoying below C++20 because constructors from `etl::unexpected` are always explicit.
Because of this it is not possible to use `return etl::unexpected()` in functions that return `etl::expected`.
This is my attempt at making the constructor conditionally explicit for C++11 and up.