### PR TITLE
fix(minmax): fix bug in minmax include mismatch detection

### DIFF
--- a/include/etl/private/minmax_pop.h
+++ b/include/etl/private/minmax_pop.h
@@ -46,9 +46,10 @@ SOFTWARE.
         #undef ETL_RESTORE_MAX
       #endif
     #endif
-    
-    #undef ETL_PUSHED_MIN_MAX
   #endif
+    
+  #undef ETL_PUSHED_MIN_MAX
+
 #else
   #error minmax_pop without matching push
 #endif

--- a/include/etl/private/minmax_push.h
+++ b/include/etl/private/minmax_push.h
@@ -50,9 +50,10 @@ SOFTWARE.
       #endif
       #undef max
     #endif
-
-    #define ETL_PUSHED_MIN_MAX
   #endif
+
+  #define ETL_PUSHED_MIN_MAX
+  
 #else
   #error minmax_push without matching pop
 #endif


### PR DESCRIPTION
This pull request fixes a bug in the include mismatch detection of the minmax headers.

When using Green Hills, IAR or TASKING compiler the define 'ETL_PUSHED_MIN_MAX' is not set in 'minmax_push.h'. Therefore the include of 'minmax_pop.h' always leads to a compilation error (minmax_pop without matching push).

Related to #731 and 24272d99c093c01e195f4df3e4accd319c8530d1.