### PR TITLE
Remove some unreachable code in bitset_new.h

### DIFF
--- a/include/etl/private/bitset_new.h
+++ b/include/etl/private/bitset_new.h
@@ -1318,8 +1318,6 @@ namespace etl
 
       const element_type mask = element_type(element_type(1) << position);
       return (buffer & mask) != 0U;
-
-      return false;
     }
 
     //*************************************************************************
@@ -3032,8 +3030,6 @@ namespace etl
 
       const element_type mask = element_type(element_type(1) << position);
       return (*pbuffer & mask) != 0U;
-
-      return false;
     }
 
     //*************************************************************************


### PR DESCRIPTION
To get rid of the compiler warnings:

    Warning[Pe111]: statement is unreachable