### PR TITLE
Fixed: move assignment not working for non-empty containers

### DIFF
--- a/include/etl/multiset.h
+++ b/include/etl/multiset.h
@@ -1448,6 +1448,8 @@ namespace etl
       // Skip if doing self assignment
       if (this != &rhs)
       {
+        clear();
+
         typename etl::imultiset<TKey, TCompare>::iterator from = rhs.begin();
 
         while (from != rhs.end())

--- a/include/etl/priority_queue.h
+++ b/include/etl/priority_queue.h
@@ -399,6 +399,7 @@ namespace etl
     {
       if (&rhs != this)
       {
+        clear();
         move(etl::move(rhs));
       }
 
@@ -535,6 +536,7 @@ namespace etl
     {
       if (&rhs != this)
       {
+        etl::ipriority_queue<T, TContainer, TCompare>::clear();
         etl::ipriority_queue<T, TContainer, TCompare>::move(etl::move(rhs));
       }
 

--- a/include/etl/set.h
+++ b/include/etl/set.h
@@ -815,6 +815,8 @@ namespace etl
       // Skip if doing self assignment
       if (this != &rhs)
       {
+        this->clear();
+
         typename etl::iset<TKey, TCompare>::iterator from = rhs.begin();
 
         while (from != rhs.end())
@@ -2603,6 +2605,8 @@ namespace etl
       // Skip if doing self assignment
       if (this != &rhs)
       {
+        this->clear();
+
         typename etl::iset<TKey, TCompare>::iterator from = rhs.begin();
 
         while (from != rhs.end())

--- a/test/test_deque.cpp
+++ b/test/test_deque.cpp
@@ -254,6 +254,7 @@ namespace
       std::unique_ptr<uint32_t> p2(new uint32_t(2U));
       std::unique_ptr<uint32_t> p3(new uint32_t(3U));
       std::unique_ptr<uint32_t> p4(new uint32_t(4U));
+      std::unique_ptr<uint32_t> p5(new uint32_t(5U));
 
       Data deque1;
       deque1.push_back(std::move(p1));
@@ -262,6 +263,7 @@ namespace
       deque1.push_back(std::move(p4));
 
       Data deque2;
+      deque2.push_back(std::move(p5));
       deque2 = std::move(deque1);
 
       CHECK_EQUAL(4U, deque2.size());
@@ -298,6 +300,7 @@ namespace
       std::unique_ptr<uint32_t> p2(new uint32_t(2U));
       std::unique_ptr<uint32_t> p3(new uint32_t(3U));
       std::unique_ptr<uint32_t> p4(new uint32_t(4U));
+      std::unique_ptr<uint32_t> p5(new uint32_t(5U));
 
       Data deque1;
       deque1.push_back(std::move(p1));
@@ -306,6 +309,7 @@ namespace
       deque1.push_back(std::move(p4));
 
       Data deque2;
+      deque2.push_back(std::move(p5));
 
       IData& ideque1 = deque1;
       IData& ideque2 = deque2;

--- a/test/test_forward_list.cpp
+++ b/test/test_forward_list.cpp
@@ -241,6 +241,7 @@ namespace
       data1.push_front(std::move(p4));
 
       DataM data2;
+      data2.push_front(ItemM(5U));
       data2 = std::move(data1);
 
       CHECK_EQUAL(0U, data1.size());
@@ -269,6 +270,7 @@ namespace
       data1.push_front(std::move(p4));
 
       DataM data2;
+      data2.push_front(ItemM(5U));
 
       IDataM& idata1 = data1;
       IDataM& idata2 = data2;

--- a/test/test_indirect_vector.cpp
+++ b/test/test_indirect_vector.cpp
@@ -312,6 +312,7 @@ namespace
       std::unique_ptr<uint32_t> p2(new uint32_t(2U));
       std::unique_ptr<uint32_t> p3(new uint32_t(3U));
       std::unique_ptr<uint32_t> p4(new uint32_t(4U));
+      std::unique_ptr<uint32_t> p5(new uint32_t(5U));
 
       Data data1;
       data1.push_back(std::move(p1));
@@ -325,6 +326,7 @@ namespace
       CHECK(!bool(p4));
 
       Data data2;
+      data2.push_back(std::move(p5));
       data2 = std::move(data1);
 
       CHECK_EQUAL(0U, data1.size());

--- a/test/test_indirect_vector_external_buffer.cpp
+++ b/test/test_indirect_vector_external_buffer.cpp
@@ -364,6 +364,7 @@ namespace
       std::unique_ptr<uint32_t> p2(new uint32_t(2U));
       std::unique_ptr<uint32_t> p3(new uint32_t(3U));
       std::unique_ptr<uint32_t> p4(new uint32_t(4U));
+      std::unique_ptr<uint32_t> p5(new uint32_t(5U));
 
       Data data1(lookup1, pool1);
       data1.push_back(std::move(p1));
@@ -377,6 +378,7 @@ namespace
       CHECK(!bool(p4));
 
       Data data2(lookup2, pool2);
+      data2.push_back(std::move(p5));
       data2 = std::move(data1);
 
       CHECK_EQUAL(0U, data1.size());
@@ -428,6 +430,7 @@ namespace
       std::unique_ptr<uint32_t> p2(new uint32_t(2U));
       std::unique_ptr<uint32_t> p3(new uint32_t(3U));
       std::unique_ptr<uint32_t> p4(new uint32_t(4U));
+      std::unique_ptr<uint32_t> p5(new uint32_t(5U));
 
       Data data1(lookup1, pool1);
       data1.push_back(std::move(p1));
@@ -436,6 +439,7 @@ namespace
       data1.push_back(std::move(p4));
 
       Data data2(lookup2, pool2);
+      data2.push_back(std::move(p5));
 
       IData& idata1 = data1;
       IData& idata2 = data2;

--- a/test/test_list.cpp
+++ b/test/test_list.cpp
@@ -1228,6 +1228,7 @@ namespace
       data1.push_back(std::move(p4));
 
       DataM data2;
+      data2.push_back(ItemM(5U));
       data2 = std::move(data1);
 
       CHECK_EQUAL(0U, data1.size());
@@ -1275,6 +1276,7 @@ namespace
       data1.push_back(std::move(p4));
 
       DataM data2;
+      data2.push_back(ItemM(5U));
 
       IDataM& idata1 = data1;
       IDataM& idata2 = data2;

--- a/test/test_map.cpp
+++ b/test/test_map.cpp
@@ -389,6 +389,7 @@ namespace
       data1.insert(DataM::value_type(std::string("3"), etl::move(d3)));
       data1.insert(DataM::value_type(std::string("4"), ItemM(4)));
 
+      data2.insert(DataM::value_type(std::string("5"), ItemM(5)));
       data2 = std::move(data1);
 
       CHECK(1 == data2.at("1").value);

--- a/test/test_multimap.cpp
+++ b/test/test_multimap.cpp
@@ -388,6 +388,7 @@ namespace
       data1.insert(DataM::value_type(std::string("3"), etl::move(d3)));
       data1.insert(DataM::value_type(std::string("4"), ItemM(4)));
 
+      data2.insert(DataM::value_type(std::string("5"), ItemM(5)));
       data2 = std::move(data1);
 
       CHECK(1 == data2.find("1")->second.value);

--- a/test/test_multiset.cpp
+++ b/test/test_multiset.cpp
@@ -391,6 +391,7 @@ namespace
       data1.insert(ItemM(4));
 
       DataM data2;
+      data2.insert(ItemM(5));
 
       data2 = std::move(data1);
 

--- a/test/test_priority_queue.cpp
+++ b/test/test_priority_queue.cpp
@@ -527,6 +527,7 @@ namespace
       priority_queue.push(std::move(b));
 
       etl::priority_queue<ItemM, SIZE> priority_queue2;
+      priority_queue2.push(ItemM("E"));
 
       priority_queue2 = std::move(priority_queue);
 

--- a/test/test_set.cpp
+++ b/test/test_set.cpp
@@ -356,6 +356,7 @@ namespace
       data1.insert(ItemM(4));
 
       DataM data2;
+      data2.insert(ItemM(5));
 
       data2 = std::move(data1);
 

--- a/test/test_unordered_map.cpp
+++ b/test/test_unordered_map.cpp
@@ -462,6 +462,7 @@ namespace
       data1.insert(DataM::value_type(std::string("3"), etl::move(d3)));
       data1.insert(DataM::value_type(std::string("4"), ItemM(4)));
 
+      data2.insert(DataM::value_type(std::string("5"), ItemM(5)));
       data2 = std::move(data1);
 
       CHECK_EQUAL(1, data2.at("1").value);

--- a/test/test_unordered_multimap.cpp
+++ b/test/test_unordered_multimap.cpp
@@ -414,6 +414,7 @@ namespace
       data1.insert(DataM::value_type(std::string("4"), ItemM(4)));
 
       data2 = std::move(data1);
+      data2.insert(DataM::value_type(std::string("5"), ItemM(5)));
 
       CHECK_EQUAL(1, data2.find("1")->second.value);
       CHECK_EQUAL(2, data2.find("2")->second.value);

--- a/test/test_unordered_multiset.cpp
+++ b/test/test_unordered_multiset.cpp
@@ -357,6 +357,7 @@ namespace
       data1.insert(ItemM(4));
 
       DataM data2;
+      data2.insert(ItemM(5));
 
       data2 = std::move(data1);
 

--- a/test/test_unordered_set.cpp
+++ b/test/test_unordered_set.cpp
@@ -341,6 +341,7 @@ namespace
       data1.insert(ItemM(4));
 
       DataM data2;
+      data2.insert(ItemM(5));
 
       data2 = std::move(data1);
 

--- a/test/test_vector.cpp
+++ b/test/test_vector.cpp
@@ -216,6 +216,7 @@ namespace
     {
       Data data(initial_data.begin(), initial_data.end());
       Data other_data;
+      other_data.push_back(1);
 
       other_data = std::move(data);
 

--- a/test/test_vector_pointer.cpp
+++ b/test/test_vector_pointer.cpp
@@ -360,6 +360,7 @@ namespace
     {
       Data data(initial_data.begin(), initial_data.end());
       Data other_data;
+      other_data.push_back(nullptr);
 
       other_data = std::move(data);
 


### PR DESCRIPTION
The move assignment was not working properly for some container types if the target is not empty.
Affected container types: priority_queue, set, multiset.
Solution: clear() called in these move assignment functions before adding the new elements to the target container.
Unit tests modified for all containers types (even the ones that implemented the move assignment correctly) to prevent future regressions.