### PR TITLE
Make "private" includes relativ

### DIFF
--- a/include/etl/generators/message_packet_generator.h
+++ b/include/etl/generators/message_packet_generator.h
@@ -100,17 +100,17 @@ namespace etl
   public:
 
     //********************************************
-#include "etl/private/diagnostic_uninitialized_push.h"
+#include "private/diagnostic_uninitialized_push.h"
     message_packet()
       : valid(false)
     {
     }
-#include "etl/private/diagnostic_pop.h"
+#include "private/diagnostic_pop.h"
 
     //********************************************
-    /// 
+    ///
     //********************************************
-#include "etl/private/diagnostic_uninitialized_push.h"
+#include "private/diagnostic_uninitialized_push.h"
     template <typename T>
     explicit message_packet(T&& msg)
       : valid(true)
@@ -142,7 +142,7 @@ namespace etl
         ETL_STATIC_ASSERT(IsInMessageList<T>, "Message not in packet type list");
       }
     }
-#include "etl/private/diagnostic_pop.h"
+#include "private/diagnostic_pop.h"
 
     //**********************************************
     void copy(const message_packet& other)
@@ -167,7 +167,7 @@ namespace etl
     }
 
     //**********************************************
-#include "etl/private/diagnostic_uninitialized_push.h"
+#include "private/diagnostic_uninitialized_push.h"
     message_packet& operator =(const message_packet& rhs)
     {
       delete_current_message();
@@ -179,10 +179,10 @@ namespace etl
 
       return *this;
     }
-#include "etl/private/diagnostic_pop.h"
+#include "private/diagnostic_pop.h"
 
     //**********************************************
-#include "etl/private/diagnostic_uninitialized_push.h"
+#include "private/diagnostic_uninitialized_push.h"
     message_packet& operator =(message_packet&& rhs)
     {
       delete_current_message();
@@ -194,7 +194,7 @@ namespace etl
 
       return *this;
     }
-#include "etl/private/diagnostic_pop.h"
+#include "private/diagnostic_pop.h"
 
     //********************************************
     ~message_packet()
@@ -271,7 +271,7 @@ namespace etl
     }
 
     //********************************************
-#include "etl/private/diagnostic_uninitialized_push.h"
+#include "private/diagnostic_uninitialized_push.h"
     void delete_current_message()
     {
       if (valid)
@@ -281,7 +281,7 @@ namespace etl
         pmsg->~imessage();
       }
     }
-#include "etl/private/diagnostic_pop.h"
+#include "private/diagnostic_pop.h"
 
     //********************************************
     void add_new_message(const etl::imessage& msg)
@@ -295,7 +295,7 @@ namespace etl
       (add_new_message_type<TMessageTypes>(etl::move(msg)) || ...);
     }
 
-#include "etl/private/diagnostic_uninitialized_push.h"
+#include "private/diagnostic_uninitialized_push.h"
     //********************************************
     /// Only enabled for types that are in the typelist.
     //********************************************
@@ -306,9 +306,9 @@ namespace etl
       void* p = data;
       new (p) etl::remove_reference_t<TMessage>((etl::forward<TMessage>(msg)));
     }
-#include "etl/private/diagnostic_pop.h"
+#include "private/diagnostic_pop.h"
 
-#include "etl/private/diagnostic_uninitialized_push.h"
+#include "private/diagnostic_uninitialized_push.h"
     //********************************************
     template <typename TType>
     bool add_new_message_type(const etl::imessage& msg)
@@ -324,7 +324,7 @@ namespace etl
         return false;
       }
     }
-#include "etl/private/diagnostic_pop.h"
+#include "private/diagnostic_pop.h"
 
     //********************************************
     template <typename TType>
@@ -398,9 +398,9 @@ namespace etl
         cog.out("                                 etl::is_one_of<typename etl::remove_cvref<TMessage>::type,")
         for i in range(1, n):
             cog.out("T%d, " % i)
-        cog.outl("T%s>::value);" % n)      
+        cog.outl("T%s>::value);" % n)
         cog.outl("")
-        cog.outl("    ETL_STATIC_ASSERT(Enabled, \"Message not in packet type list\");")   
+        cog.outl("    ETL_STATIC_ASSERT(Enabled, \"Message not in packet type list\");")
 
     ################################################
     def generate_static_assert_cpp11(n):
@@ -436,15 +436,15 @@ namespace etl
     cog.outl("public:")
     cog.outl("")
     cog.outl("  //********************************************")
-    cog.outl("#include \"etl/private/diagnostic_uninitialized_push.h\"")
+    cog.outl("#include \"private/diagnostic_uninitialized_push.h\"")
     cog.outl("  message_packet()")
     cog.outl("    : valid(false)")
     cog.outl("  {")
     cog.outl("  }")
-    cog.outl("#include \"etl/private/diagnostic_pop.h\"")
+    cog.outl("#include \"private/diagnostic_pop.h\"")
     cog.outl("")
     cog.outl("  //********************************************")
-    cog.outl("#include \"etl/private/diagnostic_uninitialized_push.h\"")
+    cog.outl("#include \"private/diagnostic_uninitialized_push.h\"")
     cog.outl("  explicit message_packet(const etl::imessage& msg)")
     cog.outl("  {")
     cog.outl("    if (accepts(msg))")
@@ -459,11 +459,11 @@ namespace etl
     cog.outl("")
     cog.outl("    ETL_ASSERT(valid, ETL_ERROR(unhandled_message_exception));")
     cog.outl("  }")
-    cog.outl("#include \"etl/private/diagnostic_pop.h\"")
+    cog.outl("#include \"private/diagnostic_pop.h\"")
     cog.outl("")
     cog.outl("#if ETL_USING_CPP11 && !defined(ETL_MESSAGE_PACKET_FORCE_CPP03_IMPLEMENTATION)")
     cog.outl("  //********************************************")
-    cog.outl("#include \"etl/private/diagnostic_uninitialized_push.h\"")
+    cog.outl("#include \"private/diagnostic_uninitialized_push.h\"")
     cog.outl("  explicit message_packet(etl::imessage&& msg)")
     cog.outl("  {")
     cog.outl("    if (accepts(msg))")
@@ -478,12 +478,12 @@ namespace etl
     cog.outl("")
     cog.outl("    ETL_ASSERT(valid, ETL_ERROR(unhandled_message_exception));")
     cog.outl("  }")
-    cog.outl("#include \"etl/private/diagnostic_pop.h\"")
+    cog.outl("#include \"private/diagnostic_pop.h\"")
     cog.outl("#endif")
     cog.outl("")
     cog.outl("#if ETL_USING_CPP11 && !defined(ETL_MESSAGE_PACKET_FORCE_CPP03_IMPLEMENTATION) && !defined(ETL_COMPILER_GREEN_HILLS)")
     cog.outl("  //********************************************")
-    cog.outl("#include \"etl/private/diagnostic_uninitialized_push.h\"")
+    cog.outl("#include \"private/diagnostic_uninitialized_push.h\"")
     cog.out("  template <typename TMessage, typename = typename etl::enable_if<!etl::is_same<typename etl::remove_cvref<TMessage>::type, etl::message_packet<")
     for n in range(1, int(Handlers)):
         cog.out("T%s, " % n)
@@ -498,10 +498,10 @@ namespace etl
     cog.outl("  {")
     generate_static_assert_cpp11(int(Handlers))
     cog.outl("  }")
-    cog.outl("#include \"etl/private/diagnostic_pop.h\"")
+    cog.outl("#include \"private/diagnostic_pop.h\"")
     cog.outl("#else")
     cog.outl("  //********************************************")
-    cog.outl("#include \"etl/private/diagnostic_uninitialized_push.h\"")
+    cog.outl("#include \"private/diagnostic_uninitialized_push.h\"")
     cog.outl("  template <typename TMessage>")
     cog.out("  explicit message_packet(const TMessage& /*msg*/, typename etl::enable_if<!etl::is_same<typename etl::remove_cvref<TMessage>::type, etl::message_packet<")
     for n in range(1, int(Handlers)):
@@ -516,11 +516,11 @@ namespace etl
     cog.outl("  {")
     generate_static_assert_cpp03(int(Handlers))
     cog.outl("  }")
-    cog.outl("#include \"etl/private/diagnostic_pop.h\"")
+    cog.outl("#include \"private/diagnostic_pop.h\"")
     cog.outl("#endif")
     cog.outl("")
     cog.outl("  //**********************************************")
-    cog.outl("#include \"etl/private/diagnostic_uninitialized_push.h\"")
+    cog.outl("#include \"private/diagnostic_uninitialized_push.h\"")
     cog.outl("  message_packet(const message_packet& other)")
     cog.outl("    : valid(other.is_valid())")
     cog.outl("  {")
@@ -529,11 +529,11 @@ namespace etl
     cog.outl("      add_new_message(other.get());")
     cog.outl("    }")
     cog.outl("  }")
-    cog.outl("#include \"etl/private/diagnostic_pop.h\"")
+    cog.outl("#include \"private/diagnostic_pop.h\"")
     cog.outl("")
     cog.outl("#if ETL_USING_CPP11 && !defined(ETL_MESSAGE_PACKET_FORCE_CPP03_IMPLEMENTATION)")
     cog.outl("  //**********************************************")
-    cog.outl("#include \"etl/private/diagnostic_uninitialized_push.h\"")
+    cog.outl("#include \"private/diagnostic_uninitialized_push.h\"")
     cog.outl("  message_packet(message_packet&& other)")
     cog.outl("    : valid(other.is_valid())")
     cog.outl("  {")
@@ -542,11 +542,11 @@ namespace etl
     cog.outl("      add_new_message(etl::move(other.get()));")
     cog.outl("    }")
     cog.outl("  }")
-    cog.outl("#include \"etl/private/diagnostic_pop.h\"")
+    cog.outl("#include \"private/diagnostic_pop.h\"")
     cog.outl("#endif")
     cog.outl("")
     cog.outl("  //**********************************************")
-    cog.outl("#include \"etl/private/diagnostic_uninitialized_push.h\"")
+    cog.outl("#include \"private/diagnostic_uninitialized_push.h\"")
     cog.outl("  message_packet& operator =(const message_packet& rhs)")
     cog.outl("  {")
     cog.outl("    delete_current_message();")
@@ -558,11 +558,11 @@ namespace etl
     cog.outl("")
     cog.outl("    return *this;")
     cog.outl("  }")
-    cog.outl("#include \"etl/private/diagnostic_pop.h\"")
+    cog.outl("#include \"private/diagnostic_pop.h\"")
     cog.outl("")
     cog.outl("#if ETL_USING_CPP11 && !defined(ETL_MESSAGE_PACKET_FORCE_CPP03_IMPLEMENTATION)")
     cog.outl("  //**********************************************")
-    cog.outl("#include \"etl/private/diagnostic_uninitialized_push.h\"")
+    cog.outl("#include \"private/diagnostic_uninitialized_push.h\"")
     cog.outl("  message_packet& operator =(message_packet&& rhs)")
     cog.outl("  {")
     cog.outl("    delete_current_message();")
@@ -574,7 +574,7 @@ namespace etl
     cog.outl("")
     cog.outl("    return *this;")
     cog.outl("  }")
-    cog.outl("#include \"etl/private/diagnostic_pop.h\"")
+    cog.outl("#include \"private/diagnostic_pop.h\"")
     cog.outl("#endif")
     cog.outl("")
     cog.outl("  //********************************************")
@@ -628,7 +628,7 @@ namespace etl
     cog.outl("  {")
     generate_accepts_return_compile_time_TMessage(int(Handlers))
     cog.outl("  }")
-    cog.outl("")  
+    cog.outl("")
     cog.outl("  enum")
     cog.outl("  {")
     cog.out("    SIZE      = etl::largest<")
@@ -644,7 +644,7 @@ namespace etl
     cog.outl("private:")
     cog.outl("")
     cog.outl("  //********************************************")
-    cog.outl("  #include \"etl/private/diagnostic_uninitialized_push.h\"")
+    cog.outl("  #include \"private/diagnostic_uninitialized_push.h\"")
     cog.outl("  void delete_current_message()")
     cog.outl("  {")
     cog.outl("    if (valid)")
@@ -654,7 +654,7 @@ namespace etl
     cog.outl("      pmsg->~imessage();")
     cog.outl("    }")
     cog.outl("  }")
-    cog.outl("  #include \"etl/private/diagnostic_pop.h\"")
+    cog.outl("  #include \"private/diagnostic_pop.h\"")
     cog.outl("")
     cog.outl("  //********************************************")
     cog.outl("  void add_new_message(const etl::imessage& msg)")
@@ -724,15 +724,15 @@ namespace etl
         cog.outl("public:")
         cog.outl("")
         cog.outl("  //********************************************")
-        cog.outl("#include \"etl/private/diagnostic_uninitialized_push.h\"")
+        cog.outl("#include \"private/diagnostic_uninitialized_push.h\"")
         cog.outl("  message_packet()")
         cog.outl("    : valid(false)")
         cog.outl("  {")
         cog.outl("  }")
-        cog.outl("#include \"etl/private/diagnostic_pop.h\"")
+        cog.outl("#include \"private/diagnostic_pop.h\"")
         cog.outl("")
         cog.outl("  //********************************************")
-        cog.outl("#include \"etl/private/diagnostic_uninitialized_push.h\"")
+        cog.outl("#include \"private/diagnostic_uninitialized_push.h\"")
         cog.outl("  explicit message_packet(const etl::imessage& msg)")
         cog.outl("  {")
         cog.outl("    if (accepts(msg))")
@@ -747,11 +747,11 @@ namespace etl
         cog.outl("")
         cog.outl("    ETL_ASSERT(valid, ETL_ERROR(unhandled_message_exception));")
         cog.outl("  }")
-        cog.outl("#include \"etl/private/diagnostic_pop.h\"")
+        cog.outl("#include \"private/diagnostic_pop.h\"")
         cog.outl("")
         cog.outl("#if ETL_USING_CPP11 && !defined(ETL_MESSAGE_PACKET_FORCE_CPP03_IMPLEMENTATION)")
         cog.outl("  //********************************************")
-        cog.outl("#include \"etl/private/diagnostic_uninitialized_push.h\"")
+        cog.outl("#include \"private/diagnostic_uninitialized_push.h\"")
         cog.outl("  explicit message_packet(etl::imessage&& msg)")
         cog.outl("  {")
         cog.outl("    if (accepts(msg))")
@@ -766,12 +766,12 @@ namespace etl
         cog.outl("")
         cog.outl("    ETL_ASSERT(valid, ETL_ERROR(unhandled_message_exception));")
         cog.outl("  }")
-        cog.outl("#include \"etl/private/diagnostic_pop.h\"")
+        cog.outl("#include \"private/diagnostic_pop.h\"")
         cog.outl("#endif")
         cog.outl("")
         cog.outl("#if ETL_USING_CPP11 && !defined(ETL_MESSAGE_PACKET_FORCE_CPP03_IMPLEMENTATION) && !defined(ETL_COMPILER_GREEN_HILLS)")
         cog.outl("  //********************************************")
-        cog.outl("#include \"etl/private/diagnostic_uninitialized_push.h\"")
+        cog.outl("#include \"private/diagnostic_uninitialized_push.h\"")
         cog.out("  template <typename TMessage, typename = typename etl::enable_if<!etl::is_same<typename etl::remove_cvref<TMessage>::type, etl::message_packet<")
         for t in range(1, n):
             cog.out("T%s, " % t)
@@ -786,10 +786,10 @@ namespace etl
         cog.outl("  {")
         generate_static_assert_cpp11(n)
         cog.outl("  }")
-        cog.outl("#include \"etl/private/diagnostic_pop.h\"")
+        cog.outl("#include \"private/diagnostic_pop.h\"")
         cog.outl("#else")
         cog.outl("  //********************************************")
-        cog.outl("#include \"etl/private/diagnostic_uninitialized_push.h\"")
+        cog.outl("#include \"private/diagnostic_uninitialized_push.h\"")
         cog.outl("  template <typename TMessage>")
         cog.out("  explicit message_packet(const TMessage& /*msg*/, typename etl::enable_if<!etl::is_same<typename etl::remove_cvref<TMessage>::type, etl::message_packet<")
         for t in range(1, n):
@@ -804,11 +804,11 @@ namespace etl
         cog.outl("  {")
         generate_static_assert_cpp03(n)
         cog.outl("  }")
-        cog.outl("#include \"etl/private/diagnostic_pop.h\"")
+        cog.outl("#include \"private/diagnostic_pop.h\"")
         cog.outl("#endif")
         cog.outl("")
         cog.outl("  //**********************************************")
-        cog.outl("#include \"etl/private/diagnostic_uninitialized_push.h\"")
+        cog.outl("#include \"private/diagnostic_uninitialized_push.h\"")
         cog.outl("  message_packet(const message_packet& other)")
         cog.outl("    : valid(other.is_valid())")
         cog.outl("  {")
@@ -817,11 +817,11 @@ namespace etl
         cog.outl("      add_new_message(other.get());")
         cog.outl("    }")
         cog.outl("  }")
-        cog.outl("#include \"etl/private/diagnostic_pop.h\"")
+        cog.outl("#include \"private/diagnostic_pop.h\"")
         cog.outl("")
         cog.outl("#if ETL_USING_CPP11 && !defined(ETL_MESSAGE_PACKET_FORCE_CPP03_IMPLEMENTATION)")
         cog.outl("  //**********************************************")
-        cog.outl("#include \"etl/private/diagnostic_uninitialized_push.h\"")
+        cog.outl("#include \"private/diagnostic_uninitialized_push.h\"")
         cog.outl("  message_packet(message_packet&& other)")
         cog.outl("    : valid(other.is_valid())")
         cog.outl("  {")
@@ -830,11 +830,11 @@ namespace etl
         cog.outl("      add_new_message(etl::move(other.get()));")
         cog.outl("    }")
         cog.outl("  }")
-        cog.outl("#include \"etl/private/diagnostic_pop.h\"")
+        cog.outl("#include \"private/diagnostic_pop.h\"")
         cog.outl("#endif")
         cog.outl("")
         cog.outl("  //**********************************************")
-        cog.outl("#include \"etl/private/diagnostic_uninitialized_push.h\"")
+        cog.outl("#include \"private/diagnostic_uninitialized_push.h\"")
         cog.outl("  message_packet& operator =(const message_packet& rhs)")
         cog.outl("  {")
         cog.outl("    delete_current_message();")
@@ -846,11 +846,11 @@ namespace etl
         cog.outl("")
         cog.outl("    return *this;")
         cog.outl("  }")
-        cog.outl("#include \"etl/private/diagnostic_pop.h\"")
+        cog.outl("#include \"private/diagnostic_pop.h\"")
         cog.outl("")
         cog.outl("#if ETL_USING_CPP11 && !defined(ETL_MESSAGE_PACKET_FORCE_CPP03_IMPLEMENTATION)")
         cog.outl("  //**********************************************")
-        cog.outl("#include \"etl/private/diagnostic_uninitialized_push.h\"")
+        cog.outl("#include \"private/diagnostic_uninitialized_push.h\"")
         cog.outl("  message_packet& operator =(message_packet&& rhs)")
         cog.outl("  {")
         cog.outl("    delete_current_message();")
@@ -862,7 +862,7 @@ namespace etl
         cog.outl("")
         cog.outl("    return *this;")
         cog.outl("  }")
-        cog.outl("#include \"etl/private/diagnostic_pop.h\"")
+        cog.outl("#include \"private/diagnostic_pop.h\"")
         cog.outl("#endif")
         cog.outl("")
         cog.outl("  //********************************************")
@@ -932,7 +932,7 @@ namespace etl
         cog.outl("private:")
         cog.outl("")
         cog.outl("  //********************************************")
-        cog.outl("  #include \"etl/private/diagnostic_uninitialized_push.h\"")
+        cog.outl("  #include \"private/diagnostic_uninitialized_push.h\"")
         cog.outl("  void delete_current_message()")
         cog.outl("  {")
         cog.outl("    if (valid)")
@@ -942,7 +942,7 @@ namespace etl
         cog.outl("      pmsg->~imessage();")
         cog.outl("    }")
         cog.outl("  }")
-        cog.outl("  #include \"etl/private/diagnostic_pop.h\"")
+        cog.outl("  #include \"private/diagnostic_pop.h\"")
         cog.outl("")
         cog.outl("  //********************************************")
         cog.outl("  void add_new_message(const etl::imessage& msg)")

--- a/include/etl/message_packet.h
+++ b/include/etl/message_packet.h
@@ -88,17 +88,17 @@ namespace etl
   public:
 
     //********************************************
-#include "etl/private/diagnostic_uninitialized_push.h"
+#include "private/diagnostic_uninitialized_push.h"
     message_packet()
       : valid(false)
     {
     }
-#include "etl/private/diagnostic_pop.h"
+#include "private/diagnostic_pop.h"
 
     //********************************************
-    /// 
+    ///
     //********************************************
-#include "etl/private/diagnostic_uninitialized_push.h"
+#include "private/diagnostic_uninitialized_push.h"
     template <typename T>
     explicit message_packet(T&& msg)
       : valid(true)
@@ -130,7 +130,7 @@ namespace etl
         ETL_STATIC_ASSERT(IsInMessageList<T>, "Message not in packet type list");
       }
     }
-#include "etl/private/diagnostic_pop.h"
+#include "private/diagnostic_pop.h"
 
     //**********************************************
     void copy(const message_packet& other)
@@ -155,7 +155,7 @@ namespace etl
     }
 
     //**********************************************
-#include "etl/private/diagnostic_uninitialized_push.h"
+#include "private/diagnostic_uninitialized_push.h"
     message_packet& operator =(const message_packet& rhs)
     {
       delete_current_message();
@@ -167,10 +167,10 @@ namespace etl
 
       return *this;
     }
-#include "etl/private/diagnostic_pop.h"
+#include "private/diagnostic_pop.h"
 
     //**********************************************
-#include "etl/private/diagnostic_uninitialized_push.h"
+#include "private/diagnostic_uninitialized_push.h"
     message_packet& operator =(message_packet&& rhs)
     {
       delete_current_message();
@@ -182,7 +182,7 @@ namespace etl
 
       return *this;
     }
-#include "etl/private/diagnostic_pop.h"
+#include "private/diagnostic_pop.h"
 
     //********************************************
     ~message_packet()
@@ -259,7 +259,7 @@ namespace etl
     }
 
     //********************************************
-#include "etl/private/diagnostic_uninitialized_push.h"
+#include "private/diagnostic_uninitialized_push.h"
     void delete_current_message()
     {
       if (valid)
@@ -269,7 +269,7 @@ namespace etl
         pmsg->~imessage();
       }
     }
-#include "etl/private/diagnostic_pop.h"
+#include "private/diagnostic_pop.h"
 
     //********************************************
     void add_new_message(const etl::imessage& msg)
@@ -283,7 +283,7 @@ namespace etl
       (add_new_message_type<TMessageTypes>(etl::move(msg)) || ...);
     }
 
-#include "etl/private/diagnostic_uninitialized_push.h"
+#include "private/diagnostic_uninitialized_push.h"
     //********************************************
     /// Only enabled for types that are in the typelist.
     //********************************************
@@ -294,9 +294,9 @@ namespace etl
       void* p = data;
       new (p) etl::remove_reference_t<TMessage>((etl::forward<TMessage>(msg)));
     }
-#include "etl/private/diagnostic_pop.h"
+#include "private/diagnostic_pop.h"
 
-#include "etl/private/diagnostic_uninitialized_push.h"
+#include "private/diagnostic_uninitialized_push.h"
     //********************************************
     template <typename TType>
     bool add_new_message_type(const etl::imessage& msg)
@@ -312,7 +312,7 @@ namespace etl
         return false;
       }
     }
-#include "etl/private/diagnostic_pop.h"
+#include "private/diagnostic_pop.h"
 
     //********************************************
     template <typename TType>
@@ -339,24 +339,24 @@ namespace etl
   //***************************************************************************
   // The definition for all 16 message types.
   //***************************************************************************
-  template <typename T1, typename T2 = void, typename T3 = void, typename T4 = void, 
-            typename T5 = void, typename T6 = void, typename T7 = void, typename T8 = void, 
-            typename T9 = void, typename T10 = void, typename T11 = void, typename T12 = void, 
+  template <typename T1, typename T2 = void, typename T3 = void, typename T4 = void,
+            typename T5 = void, typename T6 = void, typename T7 = void, typename T8 = void,
+            typename T9 = void, typename T10 = void, typename T11 = void, typename T12 = void,
             typename T13 = void, typename T14 = void, typename T15 = void, typename T16 = void>
   class message_packet
   {
   public:
 
     //********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     message_packet()
       : valid(false)
     {
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
 
     //********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     explicit message_packet(const etl::imessage& msg)
     {
       if (accepts(msg))
@@ -371,11 +371,11 @@ namespace etl
 
       ETL_ASSERT(valid, ETL_ERROR(unhandled_message_exception));
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
 
   #if ETL_USING_CPP11 && !defined(ETL_MESSAGE_PACKET_FORCE_CPP03_IMPLEMENTATION)
     //********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     explicit message_packet(etl::imessage&& msg)
     {
       if (accepts(msg))
@@ -390,12 +390,12 @@ namespace etl
 
       ETL_ASSERT(valid, ETL_ERROR(unhandled_message_exception));
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
   #endif
 
   #if ETL_USING_CPP11 && !defined(ETL_MESSAGE_PACKET_FORCE_CPP03_IMPLEMENTATION) && !defined(ETL_COMPILER_GREEN_HILLS)
     //********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     template <typename TMessage, typename = typename etl::enable_if<!etl::is_same<typename etl::remove_cvref<TMessage>::type, etl::message_packet<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> >::value &&
                                                                     !etl::is_same<typename etl::remove_cvref<TMessage>::type, etl::imessage>::value &&
                                                                     !etl::is_one_of<typename etl::remove_cvref<TMessage>::type, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>::value, int>::type>
@@ -409,10 +409,10 @@ namespace etl
 
       ETL_STATIC_ASSERT(Enabled, "Message not in packet type list");
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
   #else
     //********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     template <typename TMessage>
     explicit message_packet(const TMessage& /*msg*/, typename etl::enable_if<!etl::is_same<typename etl::remove_cvref<TMessage>::type, etl::message_packet<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> >::value &&
                                                                          !etl::is_same<typename etl::remove_cvref<TMessage>::type, etl::imessage>::value &&
@@ -426,11 +426,11 @@ namespace etl
 
       ETL_STATIC_ASSERT(Enabled, "Message not in packet type list");
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
   #endif
 
     //**********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     message_packet(const message_packet& other)
       : valid(other.is_valid())
     {
@@ -439,11 +439,11 @@ namespace etl
         add_new_message(other.get());
       }
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
 
   #if ETL_USING_CPP11 && !defined(ETL_MESSAGE_PACKET_FORCE_CPP03_IMPLEMENTATION)
     //**********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     message_packet(message_packet&& other)
       : valid(other.is_valid())
     {
@@ -452,11 +452,11 @@ namespace etl
         add_new_message(etl::move(other.get()));
       }
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
   #endif
 
     //**********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     message_packet& operator =(const message_packet& rhs)
     {
       delete_current_message();
@@ -468,11 +468,11 @@ namespace etl
 
       return *this;
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
 
   #if ETL_USING_CPP11 && !defined(ETL_MESSAGE_PACKET_FORCE_CPP03_IMPLEMENTATION)
     //**********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     message_packet& operator =(message_packet&& rhs)
     {
       delete_current_message();
@@ -484,7 +484,7 @@ namespace etl
 
       return *this;
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
   #endif
 
     //********************************************
@@ -557,7 +557,7 @@ namespace etl
   private:
 
     //********************************************
-    #include "etl/private/diagnostic_uninitialized_push.h"
+    #include "private/diagnostic_uninitialized_push.h"
     void delete_current_message()
     {
       if (valid)
@@ -567,7 +567,7 @@ namespace etl
         pmsg->~imessage();
       }
     }
-    #include "etl/private/diagnostic_pop.h"
+    #include "private/diagnostic_pop.h"
 
     //********************************************
     void add_new_message(const etl::imessage& msg)
@@ -634,24 +634,24 @@ namespace etl
   //***************************************************************************
   // Specialisation for 15 message types.
   //***************************************************************************
-  template <typename T1, typename T2, typename T3, typename T4, 
-            typename T5, typename T6, typename T7, typename T8, 
-            typename T9, typename T10, typename T11, typename T12, 
+  template <typename T1, typename T2, typename T3, typename T4,
+            typename T5, typename T6, typename T7, typename T8,
+            typename T9, typename T10, typename T11, typename T12,
             typename T13, typename T14, typename T15>
   class message_packet<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, void>
   {
   public:
 
     //********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     message_packet()
       : valid(false)
     {
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
 
     //********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     explicit message_packet(const etl::imessage& msg)
     {
       if (accepts(msg))
@@ -666,11 +666,11 @@ namespace etl
 
       ETL_ASSERT(valid, ETL_ERROR(unhandled_message_exception));
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
 
   #if ETL_USING_CPP11 && !defined(ETL_MESSAGE_PACKET_FORCE_CPP03_IMPLEMENTATION)
     //********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     explicit message_packet(etl::imessage&& msg)
     {
       if (accepts(msg))
@@ -685,12 +685,12 @@ namespace etl
 
       ETL_ASSERT(valid, ETL_ERROR(unhandled_message_exception));
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
   #endif
 
   #if ETL_USING_CPP11 && !defined(ETL_MESSAGE_PACKET_FORCE_CPP03_IMPLEMENTATION) && !defined(ETL_COMPILER_GREEN_HILLS)
     //********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     template <typename TMessage, typename = typename etl::enable_if<!etl::is_same<typename etl::remove_cvref<TMessage>::type, etl::message_packet<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> >::value &&
                                                                     !etl::is_same<typename etl::remove_cvref<TMessage>::type, etl::imessage>::value &&
                                                                     !etl::is_one_of<typename etl::remove_cvref<TMessage>::type, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>::value, int>::type>
@@ -704,10 +704,10 @@ namespace etl
 
       ETL_STATIC_ASSERT(Enabled, "Message not in packet type list");
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
   #else
     //********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     template <typename TMessage>
     explicit message_packet(const TMessage& /*msg*/, typename etl::enable_if<!etl::is_same<typename etl::remove_cvref<TMessage>::type, etl::message_packet<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> >::value &&
                                                                          !etl::is_same<typename etl::remove_cvref<TMessage>::type, etl::imessage>::value &&
@@ -721,11 +721,11 @@ namespace etl
 
       ETL_STATIC_ASSERT(Enabled, "Message not in packet type list");
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
   #endif
 
     //**********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     message_packet(const message_packet& other)
       : valid(other.is_valid())
     {
@@ -734,11 +734,11 @@ namespace etl
         add_new_message(other.get());
       }
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
 
   #if ETL_USING_CPP11 && !defined(ETL_MESSAGE_PACKET_FORCE_CPP03_IMPLEMENTATION)
     //**********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     message_packet(message_packet&& other)
       : valid(other.is_valid())
     {
@@ -747,11 +747,11 @@ namespace etl
         add_new_message(etl::move(other.get()));
       }
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
   #endif
 
     //**********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     message_packet& operator =(const message_packet& rhs)
     {
       delete_current_message();
@@ -763,11 +763,11 @@ namespace etl
 
       return *this;
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
 
   #if ETL_USING_CPP11 && !defined(ETL_MESSAGE_PACKET_FORCE_CPP03_IMPLEMENTATION)
     //**********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     message_packet& operator =(message_packet&& rhs)
     {
       delete_current_message();
@@ -779,7 +779,7 @@ namespace etl
 
       return *this;
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
   #endif
 
     //********************************************
@@ -852,7 +852,7 @@ namespace etl
   private:
 
     //********************************************
-    #include "etl/private/diagnostic_uninitialized_push.h"
+    #include "private/diagnostic_uninitialized_push.h"
     void delete_current_message()
     {
       if (valid)
@@ -862,7 +862,7 @@ namespace etl
         pmsg->~imessage();
       }
     }
-    #include "etl/private/diagnostic_pop.h"
+    #include "private/diagnostic_pop.h"
 
     //********************************************
     void add_new_message(const etl::imessage& msg)
@@ -927,24 +927,24 @@ namespace etl
   //***************************************************************************
   // Specialisation for 14 message types.
   //***************************************************************************
-  template <typename T1, typename T2, typename T3, typename T4, 
-            typename T5, typename T6, typename T7, typename T8, 
-            typename T9, typename T10, typename T11, typename T12, 
+  template <typename T1, typename T2, typename T3, typename T4,
+            typename T5, typename T6, typename T7, typename T8,
+            typename T9, typename T10, typename T11, typename T12,
             typename T13, typename T14>
   class message_packet<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, void, void>
   {
   public:
 
     //********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     message_packet()
       : valid(false)
     {
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
 
     //********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     explicit message_packet(const etl::imessage& msg)
     {
       if (accepts(msg))
@@ -959,11 +959,11 @@ namespace etl
 
       ETL_ASSERT(valid, ETL_ERROR(unhandled_message_exception));
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
 
   #if ETL_USING_CPP11 && !defined(ETL_MESSAGE_PACKET_FORCE_CPP03_IMPLEMENTATION)
     //********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     explicit message_packet(etl::imessage&& msg)
     {
       if (accepts(msg))
@@ -978,12 +978,12 @@ namespace etl
 
       ETL_ASSERT(valid, ETL_ERROR(unhandled_message_exception));
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
   #endif
 
   #if ETL_USING_CPP11 && !defined(ETL_MESSAGE_PACKET_FORCE_CPP03_IMPLEMENTATION) && !defined(ETL_COMPILER_GREEN_HILLS)
     //********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     template <typename TMessage, typename = typename etl::enable_if<!etl::is_same<typename etl::remove_cvref<TMessage>::type, etl::message_packet<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> >::value &&
                                                                     !etl::is_same<typename etl::remove_cvref<TMessage>::type, etl::imessage>::value &&
                                                                     !etl::is_one_of<typename etl::remove_cvref<TMessage>::type, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>::value, int>::type>
@@ -997,10 +997,10 @@ namespace etl
 
       ETL_STATIC_ASSERT(Enabled, "Message not in packet type list");
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
   #else
     //********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     template <typename TMessage>
     explicit message_packet(const TMessage& /*msg*/, typename etl::enable_if<!etl::is_same<typename etl::remove_cvref<TMessage>::type, etl::message_packet<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> >::value &&
                                                                          !etl::is_same<typename etl::remove_cvref<TMessage>::type, etl::imessage>::value &&
@@ -1014,11 +1014,11 @@ namespace etl
 
       ETL_STATIC_ASSERT(Enabled, "Message not in packet type list");
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
   #endif
 
     //**********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     message_packet(const message_packet& other)
       : valid(other.is_valid())
     {
@@ -1027,11 +1027,11 @@ namespace etl
         add_new_message(other.get());
       }
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
 
   #if ETL_USING_CPP11 && !defined(ETL_MESSAGE_PACKET_FORCE_CPP03_IMPLEMENTATION)
     //**********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     message_packet(message_packet&& other)
       : valid(other.is_valid())
     {
@@ -1040,11 +1040,11 @@ namespace etl
         add_new_message(etl::move(other.get()));
       }
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
   #endif
 
     //**********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     message_packet& operator =(const message_packet& rhs)
     {
       delete_current_message();
@@ -1056,11 +1056,11 @@ namespace etl
 
       return *this;
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
 
   #if ETL_USING_CPP11 && !defined(ETL_MESSAGE_PACKET_FORCE_CPP03_IMPLEMENTATION)
     //**********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     message_packet& operator =(message_packet&& rhs)
     {
       delete_current_message();
@@ -1072,7 +1072,7 @@ namespace etl
 
       return *this;
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
   #endif
 
     //********************************************
@@ -1145,7 +1145,7 @@ namespace etl
   private:
 
     //********************************************
-    #include "etl/private/diagnostic_uninitialized_push.h"
+    #include "private/diagnostic_uninitialized_push.h"
     void delete_current_message()
     {
       if (valid)
@@ -1155,7 +1155,7 @@ namespace etl
         pmsg->~imessage();
       }
     }
-    #include "etl/private/diagnostic_pop.h"
+    #include "private/diagnostic_pop.h"
 
     //********************************************
     void add_new_message(const etl::imessage& msg)
@@ -1218,24 +1218,24 @@ namespace etl
   //***************************************************************************
   // Specialisation for 13 message types.
   //***************************************************************************
-  template <typename T1, typename T2, typename T3, typename T4, 
-            typename T5, typename T6, typename T7, typename T8, 
-            typename T9, typename T10, typename T11, typename T12, 
+  template <typename T1, typename T2, typename T3, typename T4,
+            typename T5, typename T6, typename T7, typename T8,
+            typename T9, typename T10, typename T11, typename T12,
             typename T13>
   class message_packet<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, void, void, void>
   {
   public:
 
     //********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     message_packet()
       : valid(false)
     {
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
 
     //********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     explicit message_packet(const etl::imessage& msg)
     {
       if (accepts(msg))
@@ -1250,11 +1250,11 @@ namespace etl
 
       ETL_ASSERT(valid, ETL_ERROR(unhandled_message_exception));
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
 
   #if ETL_USING_CPP11 && !defined(ETL_MESSAGE_PACKET_FORCE_CPP03_IMPLEMENTATION)
     //********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     explicit message_packet(etl::imessage&& msg)
     {
       if (accepts(msg))
@@ -1269,12 +1269,12 @@ namespace etl
 
       ETL_ASSERT(valid, ETL_ERROR(unhandled_message_exception));
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
   #endif
 
   #if ETL_USING_CPP11 && !defined(ETL_MESSAGE_PACKET_FORCE_CPP03_IMPLEMENTATION) && !defined(ETL_COMPILER_GREEN_HILLS)
     //********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     template <typename TMessage, typename = typename etl::enable_if<!etl::is_same<typename etl::remove_cvref<TMessage>::type, etl::message_packet<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> >::value &&
                                                                     !etl::is_same<typename etl::remove_cvref<TMessage>::type, etl::imessage>::value &&
                                                                     !etl::is_one_of<typename etl::remove_cvref<TMessage>::type, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>::value, int>::type>
@@ -1288,10 +1288,10 @@ namespace etl
 
       ETL_STATIC_ASSERT(Enabled, "Message not in packet type list");
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
   #else
     //********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     template <typename TMessage>
     explicit message_packet(const TMessage& /*msg*/, typename etl::enable_if<!etl::is_same<typename etl::remove_cvref<TMessage>::type, etl::message_packet<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> >::value &&
                                                                          !etl::is_same<typename etl::remove_cvref<TMessage>::type, etl::imessage>::value &&
@@ -1305,11 +1305,11 @@ namespace etl
 
       ETL_STATIC_ASSERT(Enabled, "Message not in packet type list");
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
   #endif
 
     //**********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     message_packet(const message_packet& other)
       : valid(other.is_valid())
     {
@@ -1318,11 +1318,11 @@ namespace etl
         add_new_message(other.get());
       }
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
 
   #if ETL_USING_CPP11 && !defined(ETL_MESSAGE_PACKET_FORCE_CPP03_IMPLEMENTATION)
     //**********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     message_packet(message_packet&& other)
       : valid(other.is_valid())
     {
@@ -1331,11 +1331,11 @@ namespace etl
         add_new_message(etl::move(other.get()));
       }
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
   #endif
 
     //**********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     message_packet& operator =(const message_packet& rhs)
     {
       delete_current_message();
@@ -1347,11 +1347,11 @@ namespace etl
 
       return *this;
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
 
   #if ETL_USING_CPP11 && !defined(ETL_MESSAGE_PACKET_FORCE_CPP03_IMPLEMENTATION)
     //**********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     message_packet& operator =(message_packet&& rhs)
     {
       delete_current_message();
@@ -1363,7 +1363,7 @@ namespace etl
 
       return *this;
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
   #endif
 
     //********************************************
@@ -1436,7 +1436,7 @@ namespace etl
   private:
 
     //********************************************
-    #include "etl/private/diagnostic_uninitialized_push.h"
+    #include "private/diagnostic_uninitialized_push.h"
     void delete_current_message()
     {
       if (valid)
@@ -1446,7 +1446,7 @@ namespace etl
         pmsg->~imessage();
       }
     }
-    #include "etl/private/diagnostic_pop.h"
+    #include "private/diagnostic_pop.h"
 
     //********************************************
     void add_new_message(const etl::imessage& msg)
@@ -1507,23 +1507,23 @@ namespace etl
   //***************************************************************************
   // Specialisation for 12 message types.
   //***************************************************************************
-  template <typename T1, typename T2, typename T3, typename T4, 
-            typename T5, typename T6, typename T7, typename T8, 
+  template <typename T1, typename T2, typename T3, typename T4,
+            typename T5, typename T6, typename T7, typename T8,
             typename T9, typename T10, typename T11, typename T12>
   class message_packet<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, void, void, void, void>
   {
   public:
 
     //********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     message_packet()
       : valid(false)
     {
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
 
     //********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     explicit message_packet(const etl::imessage& msg)
     {
       if (accepts(msg))
@@ -1538,11 +1538,11 @@ namespace etl
 
       ETL_ASSERT(valid, ETL_ERROR(unhandled_message_exception));
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
 
   #if ETL_USING_CPP11 && !defined(ETL_MESSAGE_PACKET_FORCE_CPP03_IMPLEMENTATION)
     //********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     explicit message_packet(etl::imessage&& msg)
     {
       if (accepts(msg))
@@ -1557,12 +1557,12 @@ namespace etl
 
       ETL_ASSERT(valid, ETL_ERROR(unhandled_message_exception));
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
   #endif
 
   #if ETL_USING_CPP11 && !defined(ETL_MESSAGE_PACKET_FORCE_CPP03_IMPLEMENTATION) && !defined(ETL_COMPILER_GREEN_HILLS)
     //********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     template <typename TMessage, typename = typename etl::enable_if<!etl::is_same<typename etl::remove_cvref<TMessage>::type, etl::message_packet<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> >::value &&
                                                                     !etl::is_same<typename etl::remove_cvref<TMessage>::type, etl::imessage>::value &&
                                                                     !etl::is_one_of<typename etl::remove_cvref<TMessage>::type, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>::value, int>::type>
@@ -1576,10 +1576,10 @@ namespace etl
 
       ETL_STATIC_ASSERT(Enabled, "Message not in packet type list");
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
   #else
     //********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     template <typename TMessage>
     explicit message_packet(const TMessage& /*msg*/, typename etl::enable_if<!etl::is_same<typename etl::remove_cvref<TMessage>::type, etl::message_packet<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> >::value &&
                                                                          !etl::is_same<typename etl::remove_cvref<TMessage>::type, etl::imessage>::value &&
@@ -1593,11 +1593,11 @@ namespace etl
 
       ETL_STATIC_ASSERT(Enabled, "Message not in packet type list");
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
   #endif
 
     //**********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     message_packet(const message_packet& other)
       : valid(other.is_valid())
     {
@@ -1606,11 +1606,11 @@ namespace etl
         add_new_message(other.get());
       }
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
 
   #if ETL_USING_CPP11 && !defined(ETL_MESSAGE_PACKET_FORCE_CPP03_IMPLEMENTATION)
     //**********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     message_packet(message_packet&& other)
       : valid(other.is_valid())
     {
@@ -1619,11 +1619,11 @@ namespace etl
         add_new_message(etl::move(other.get()));
       }
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
   #endif
 
     //**********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     message_packet& operator =(const message_packet& rhs)
     {
       delete_current_message();
@@ -1635,11 +1635,11 @@ namespace etl
 
       return *this;
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
 
   #if ETL_USING_CPP11 && !defined(ETL_MESSAGE_PACKET_FORCE_CPP03_IMPLEMENTATION)
     //**********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     message_packet& operator =(message_packet&& rhs)
     {
       delete_current_message();
@@ -1651,7 +1651,7 @@ namespace etl
 
       return *this;
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
   #endif
 
     //********************************************
@@ -1721,7 +1721,7 @@ namespace etl
   private:
 
     //********************************************
-    #include "etl/private/diagnostic_uninitialized_push.h"
+    #include "private/diagnostic_uninitialized_push.h"
     void delete_current_message()
     {
       if (valid)
@@ -1731,7 +1731,7 @@ namespace etl
         pmsg->~imessage();
       }
     }
-    #include "etl/private/diagnostic_pop.h"
+    #include "private/diagnostic_pop.h"
 
     //********************************************
     void add_new_message(const etl::imessage& msg)
@@ -1790,23 +1790,23 @@ namespace etl
   //***************************************************************************
   // Specialisation for 11 message types.
   //***************************************************************************
-  template <typename T1, typename T2, typename T3, typename T4, 
-            typename T5, typename T6, typename T7, typename T8, 
+  template <typename T1, typename T2, typename T3, typename T4,
+            typename T5, typename T6, typename T7, typename T8,
             typename T9, typename T10, typename T11>
   class message_packet<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, void, void, void, void, void>
   {
   public:
 
     //********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     message_packet()
       : valid(false)
     {
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
 
     //********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     explicit message_packet(const etl::imessage& msg)
     {
       if (accepts(msg))
@@ -1821,11 +1821,11 @@ namespace etl
 
       ETL_ASSERT(valid, ETL_ERROR(unhandled_message_exception));
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
 
   #if ETL_USING_CPP11 && !defined(ETL_MESSAGE_PACKET_FORCE_CPP03_IMPLEMENTATION)
     //********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     explicit message_packet(etl::imessage&& msg)
     {
       if (accepts(msg))
@@ -1840,12 +1840,12 @@ namespace etl
 
       ETL_ASSERT(valid, ETL_ERROR(unhandled_message_exception));
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
   #endif
 
   #if ETL_USING_CPP11 && !defined(ETL_MESSAGE_PACKET_FORCE_CPP03_IMPLEMENTATION) && !defined(ETL_COMPILER_GREEN_HILLS)
     //********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     template <typename TMessage, typename = typename etl::enable_if<!etl::is_same<typename etl::remove_cvref<TMessage>::type, etl::message_packet<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> >::value &&
                                                                     !etl::is_same<typename etl::remove_cvref<TMessage>::type, etl::imessage>::value &&
                                                                     !etl::is_one_of<typename etl::remove_cvref<TMessage>::type, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>::value, int>::type>
@@ -1859,10 +1859,10 @@ namespace etl
 
       ETL_STATIC_ASSERT(Enabled, "Message not in packet type list");
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
   #else
     //********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     template <typename TMessage>
     explicit message_packet(const TMessage& /*msg*/, typename etl::enable_if<!etl::is_same<typename etl::remove_cvref<TMessage>::type, etl::message_packet<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> >::value &&
                                                                          !etl::is_same<typename etl::remove_cvref<TMessage>::type, etl::imessage>::value &&
@@ -1876,11 +1876,11 @@ namespace etl
 
       ETL_STATIC_ASSERT(Enabled, "Message not in packet type list");
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
   #endif
 
     //**********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     message_packet(const message_packet& other)
       : valid(other.is_valid())
     {
@@ -1889,11 +1889,11 @@ namespace etl
         add_new_message(other.get());
       }
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
 
   #if ETL_USING_CPP11 && !defined(ETL_MESSAGE_PACKET_FORCE_CPP03_IMPLEMENTATION)
     //**********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     message_packet(message_packet&& other)
       : valid(other.is_valid())
     {
@@ -1902,11 +1902,11 @@ namespace etl
         add_new_message(etl::move(other.get()));
       }
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
   #endif
 
     //**********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     message_packet& operator =(const message_packet& rhs)
     {
       delete_current_message();
@@ -1918,11 +1918,11 @@ namespace etl
 
       return *this;
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
 
   #if ETL_USING_CPP11 && !defined(ETL_MESSAGE_PACKET_FORCE_CPP03_IMPLEMENTATION)
     //**********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     message_packet& operator =(message_packet&& rhs)
     {
       delete_current_message();
@@ -1934,7 +1934,7 @@ namespace etl
 
       return *this;
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
   #endif
 
     //********************************************
@@ -2004,7 +2004,7 @@ namespace etl
   private:
 
     //********************************************
-    #include "etl/private/diagnostic_uninitialized_push.h"
+    #include "private/diagnostic_uninitialized_push.h"
     void delete_current_message()
     {
       if (valid)
@@ -2014,7 +2014,7 @@ namespace etl
         pmsg->~imessage();
       }
     }
-    #include "etl/private/diagnostic_pop.h"
+    #include "private/diagnostic_pop.h"
 
     //********************************************
     void add_new_message(const etl::imessage& msg)
@@ -2071,23 +2071,23 @@ namespace etl
   //***************************************************************************
   // Specialisation for 10 message types.
   //***************************************************************************
-  template <typename T1, typename T2, typename T3, typename T4, 
-            typename T5, typename T6, typename T7, typename T8, 
+  template <typename T1, typename T2, typename T3, typename T4,
+            typename T5, typename T6, typename T7, typename T8,
             typename T9, typename T10>
   class message_packet<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, void, void, void, void, void, void>
   {
   public:
 
     //********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     message_packet()
       : valid(false)
     {
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
 
     //********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     explicit message_packet(const etl::imessage& msg)
     {
       if (accepts(msg))
@@ -2102,11 +2102,11 @@ namespace etl
 
       ETL_ASSERT(valid, ETL_ERROR(unhandled_message_exception));
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
 
   #if ETL_USING_CPP11 && !defined(ETL_MESSAGE_PACKET_FORCE_CPP03_IMPLEMENTATION)
     //********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     explicit message_packet(etl::imessage&& msg)
     {
       if (accepts(msg))
@@ -2121,12 +2121,12 @@ namespace etl
 
       ETL_ASSERT(valid, ETL_ERROR(unhandled_message_exception));
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
   #endif
 
   #if ETL_USING_CPP11 && !defined(ETL_MESSAGE_PACKET_FORCE_CPP03_IMPLEMENTATION) && !defined(ETL_COMPILER_GREEN_HILLS)
     //********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     template <typename TMessage, typename = typename etl::enable_if<!etl::is_same<typename etl::remove_cvref<TMessage>::type, etl::message_packet<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> >::value &&
                                                                     !etl::is_same<typename etl::remove_cvref<TMessage>::type, etl::imessage>::value &&
                                                                     !etl::is_one_of<typename etl::remove_cvref<TMessage>::type, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>::value, int>::type>
@@ -2140,10 +2140,10 @@ namespace etl
 
       ETL_STATIC_ASSERT(Enabled, "Message not in packet type list");
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
   #else
     //********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     template <typename TMessage>
     explicit message_packet(const TMessage& /*msg*/, typename etl::enable_if<!etl::is_same<typename etl::remove_cvref<TMessage>::type, etl::message_packet<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> >::value &&
                                                                          !etl::is_same<typename etl::remove_cvref<TMessage>::type, etl::imessage>::value &&
@@ -2157,11 +2157,11 @@ namespace etl
 
       ETL_STATIC_ASSERT(Enabled, "Message not in packet type list");
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
   #endif
 
     //**********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     message_packet(const message_packet& other)
       : valid(other.is_valid())
     {
@@ -2170,11 +2170,11 @@ namespace etl
         add_new_message(other.get());
       }
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
 
   #if ETL_USING_CPP11 && !defined(ETL_MESSAGE_PACKET_FORCE_CPP03_IMPLEMENTATION)
     //**********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     message_packet(message_packet&& other)
       : valid(other.is_valid())
     {
@@ -2183,11 +2183,11 @@ namespace etl
         add_new_message(etl::move(other.get()));
       }
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
   #endif
 
     //**********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     message_packet& operator =(const message_packet& rhs)
     {
       delete_current_message();
@@ -2199,11 +2199,11 @@ namespace etl
 
       return *this;
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
 
   #if ETL_USING_CPP11 && !defined(ETL_MESSAGE_PACKET_FORCE_CPP03_IMPLEMENTATION)
     //**********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     message_packet& operator =(message_packet&& rhs)
     {
       delete_current_message();
@@ -2215,7 +2215,7 @@ namespace etl
 
       return *this;
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
   #endif
 
     //********************************************
@@ -2285,7 +2285,7 @@ namespace etl
   private:
 
     //********************************************
-    #include "etl/private/diagnostic_uninitialized_push.h"
+    #include "private/diagnostic_uninitialized_push.h"
     void delete_current_message()
     {
       if (valid)
@@ -2295,7 +2295,7 @@ namespace etl
         pmsg->~imessage();
       }
     }
-    #include "etl/private/diagnostic_pop.h"
+    #include "private/diagnostic_pop.h"
 
     //********************************************
     void add_new_message(const etl::imessage& msg)
@@ -2350,23 +2350,23 @@ namespace etl
   //***************************************************************************
   // Specialisation for 9 message types.
   //***************************************************************************
-  template <typename T1, typename T2, typename T3, typename T4, 
-            typename T5, typename T6, typename T7, typename T8, 
+  template <typename T1, typename T2, typename T3, typename T4,
+            typename T5, typename T6, typename T7, typename T8,
             typename T9>
   class message_packet<T1, T2, T3, T4, T5, T6, T7, T8, T9, void, void, void, void, void, void, void>
   {
   public:
 
     //********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     message_packet()
       : valid(false)
     {
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
 
     //********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     explicit message_packet(const etl::imessage& msg)
     {
       if (accepts(msg))
@@ -2381,11 +2381,11 @@ namespace etl
 
       ETL_ASSERT(valid, ETL_ERROR(unhandled_message_exception));
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
 
   #if ETL_USING_CPP11 && !defined(ETL_MESSAGE_PACKET_FORCE_CPP03_IMPLEMENTATION)
     //********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     explicit message_packet(etl::imessage&& msg)
     {
       if (accepts(msg))
@@ -2400,12 +2400,12 @@ namespace etl
 
       ETL_ASSERT(valid, ETL_ERROR(unhandled_message_exception));
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
   #endif
 
   #if ETL_USING_CPP11 && !defined(ETL_MESSAGE_PACKET_FORCE_CPP03_IMPLEMENTATION) && !defined(ETL_COMPILER_GREEN_HILLS)
     //********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     template <typename TMessage, typename = typename etl::enable_if<!etl::is_same<typename etl::remove_cvref<TMessage>::type, etl::message_packet<T1, T2, T3, T4, T5, T6, T7, T8, T9> >::value &&
                                                                     !etl::is_same<typename etl::remove_cvref<TMessage>::type, etl::imessage>::value &&
                                                                     !etl::is_one_of<typename etl::remove_cvref<TMessage>::type, T1, T2, T3, T4, T5, T6, T7, T8, T9>::value, int>::type>
@@ -2419,10 +2419,10 @@ namespace etl
 
       ETL_STATIC_ASSERT(Enabled, "Message not in packet type list");
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
   #else
     //********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     template <typename TMessage>
     explicit message_packet(const TMessage& /*msg*/, typename etl::enable_if<!etl::is_same<typename etl::remove_cvref<TMessage>::type, etl::message_packet<T1, T2, T3, T4, T5, T6, T7, T8, T9> >::value &&
                                                                          !etl::is_same<typename etl::remove_cvref<TMessage>::type, etl::imessage>::value &&
@@ -2436,11 +2436,11 @@ namespace etl
 
       ETL_STATIC_ASSERT(Enabled, "Message not in packet type list");
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
   #endif
 
     //**********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     message_packet(const message_packet& other)
       : valid(other.is_valid())
     {
@@ -2449,11 +2449,11 @@ namespace etl
         add_new_message(other.get());
       }
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
 
   #if ETL_USING_CPP11 && !defined(ETL_MESSAGE_PACKET_FORCE_CPP03_IMPLEMENTATION)
     //**********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     message_packet(message_packet&& other)
       : valid(other.is_valid())
     {
@@ -2462,11 +2462,11 @@ namespace etl
         add_new_message(etl::move(other.get()));
       }
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
   #endif
 
     //**********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     message_packet& operator =(const message_packet& rhs)
     {
       delete_current_message();
@@ -2478,11 +2478,11 @@ namespace etl
 
       return *this;
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
 
   #if ETL_USING_CPP11 && !defined(ETL_MESSAGE_PACKET_FORCE_CPP03_IMPLEMENTATION)
     //**********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     message_packet& operator =(message_packet&& rhs)
     {
       delete_current_message();
@@ -2494,7 +2494,7 @@ namespace etl
 
       return *this;
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
   #endif
 
     //********************************************
@@ -2564,7 +2564,7 @@ namespace etl
   private:
 
     //********************************************
-    #include "etl/private/diagnostic_uninitialized_push.h"
+    #include "private/diagnostic_uninitialized_push.h"
     void delete_current_message()
     {
       if (valid)
@@ -2574,7 +2574,7 @@ namespace etl
         pmsg->~imessage();
       }
     }
-    #include "etl/private/diagnostic_pop.h"
+    #include "private/diagnostic_pop.h"
 
     //********************************************
     void add_new_message(const etl::imessage& msg)
@@ -2627,22 +2627,22 @@ namespace etl
   //***************************************************************************
   // Specialisation for 8 message types.
   //***************************************************************************
-  template <typename T1, typename T2, typename T3, typename T4, 
+  template <typename T1, typename T2, typename T3, typename T4,
             typename T5, typename T6, typename T7, typename T8>
   class message_packet<T1, T2, T3, T4, T5, T6, T7, T8, void, void, void, void, void, void, void, void>
   {
   public:
 
     //********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     message_packet()
       : valid(false)
     {
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
 
     //********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     explicit message_packet(const etl::imessage& msg)
     {
       if (accepts(msg))
@@ -2657,11 +2657,11 @@ namespace etl
 
       ETL_ASSERT(valid, ETL_ERROR(unhandled_message_exception));
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
 
   #if ETL_USING_CPP11 && !defined(ETL_MESSAGE_PACKET_FORCE_CPP03_IMPLEMENTATION)
     //********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     explicit message_packet(etl::imessage&& msg)
     {
       if (accepts(msg))
@@ -2676,12 +2676,12 @@ namespace etl
 
       ETL_ASSERT(valid, ETL_ERROR(unhandled_message_exception));
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
   #endif
 
   #if ETL_USING_CPP11 && !defined(ETL_MESSAGE_PACKET_FORCE_CPP03_IMPLEMENTATION) && !defined(ETL_COMPILER_GREEN_HILLS)
     //********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     template <typename TMessage, typename = typename etl::enable_if<!etl::is_same<typename etl::remove_cvref<TMessage>::type, etl::message_packet<T1, T2, T3, T4, T5, T6, T7, T8> >::value &&
                                                                     !etl::is_same<typename etl::remove_cvref<TMessage>::type, etl::imessage>::value &&
                                                                     !etl::is_one_of<typename etl::remove_cvref<TMessage>::type, T1, T2, T3, T4, T5, T6, T7, T8>::value, int>::type>
@@ -2695,10 +2695,10 @@ namespace etl
 
       ETL_STATIC_ASSERT(Enabled, "Message not in packet type list");
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
   #else
     //********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     template <typename TMessage>
     explicit message_packet(const TMessage& /*msg*/, typename etl::enable_if<!etl::is_same<typename etl::remove_cvref<TMessage>::type, etl::message_packet<T1, T2, T3, T4, T5, T6, T7, T8> >::value &&
                                                                          !etl::is_same<typename etl::remove_cvref<TMessage>::type, etl::imessage>::value &&
@@ -2712,11 +2712,11 @@ namespace etl
 
       ETL_STATIC_ASSERT(Enabled, "Message not in packet type list");
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
   #endif
 
     //**********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     message_packet(const message_packet& other)
       : valid(other.is_valid())
     {
@@ -2725,11 +2725,11 @@ namespace etl
         add_new_message(other.get());
       }
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
 
   #if ETL_USING_CPP11 && !defined(ETL_MESSAGE_PACKET_FORCE_CPP03_IMPLEMENTATION)
     //**********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     message_packet(message_packet&& other)
       : valid(other.is_valid())
     {
@@ -2738,11 +2738,11 @@ namespace etl
         add_new_message(etl::move(other.get()));
       }
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
   #endif
 
     //**********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     message_packet& operator =(const message_packet& rhs)
     {
       delete_current_message();
@@ -2754,11 +2754,11 @@ namespace etl
 
       return *this;
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
 
   #if ETL_USING_CPP11 && !defined(ETL_MESSAGE_PACKET_FORCE_CPP03_IMPLEMENTATION)
     //**********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     message_packet& operator =(message_packet&& rhs)
     {
       delete_current_message();
@@ -2770,7 +2770,7 @@ namespace etl
 
       return *this;
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
   #endif
 
     //********************************************
@@ -2837,7 +2837,7 @@ namespace etl
   private:
 
     //********************************************
-    #include "etl/private/diagnostic_uninitialized_push.h"
+    #include "private/diagnostic_uninitialized_push.h"
     void delete_current_message()
     {
       if (valid)
@@ -2847,7 +2847,7 @@ namespace etl
         pmsg->~imessage();
       }
     }
-    #include "etl/private/diagnostic_pop.h"
+    #include "private/diagnostic_pop.h"
 
     //********************************************
     void add_new_message(const etl::imessage& msg)
@@ -2898,22 +2898,22 @@ namespace etl
   //***************************************************************************
   // Specialisation for 7 message types.
   //***************************************************************************
-  template <typename T1, typename T2, typename T3, typename T4, 
+  template <typename T1, typename T2, typename T3, typename T4,
             typename T5, typename T6, typename T7>
   class message_packet<T1, T2, T3, T4, T5, T6, T7, void, void, void, void, void, void, void, void, void>
   {
   public:
 
     //********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     message_packet()
       : valid(false)
     {
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
 
     //********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     explicit message_packet(const etl::imessage& msg)
     {
       if (accepts(msg))
@@ -2928,11 +2928,11 @@ namespace etl
 
       ETL_ASSERT(valid, ETL_ERROR(unhandled_message_exception));
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
 
   #if ETL_USING_CPP11 && !defined(ETL_MESSAGE_PACKET_FORCE_CPP03_IMPLEMENTATION)
     //********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     explicit message_packet(etl::imessage&& msg)
     {
       if (accepts(msg))
@@ -2947,12 +2947,12 @@ namespace etl
 
       ETL_ASSERT(valid, ETL_ERROR(unhandled_message_exception));
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
   #endif
 
   #if ETL_USING_CPP11 && !defined(ETL_MESSAGE_PACKET_FORCE_CPP03_IMPLEMENTATION) && !defined(ETL_COMPILER_GREEN_HILLS)
     //********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     template <typename TMessage, typename = typename etl::enable_if<!etl::is_same<typename etl::remove_cvref<TMessage>::type, etl::message_packet<T1, T2, T3, T4, T5, T6, T7> >::value &&
                                                                     !etl::is_same<typename etl::remove_cvref<TMessage>::type, etl::imessage>::value &&
                                                                     !etl::is_one_of<typename etl::remove_cvref<TMessage>::type, T1, T2, T3, T4, T5, T6, T7>::value, int>::type>
@@ -2966,10 +2966,10 @@ namespace etl
 
       ETL_STATIC_ASSERT(Enabled, "Message not in packet type list");
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
   #else
     //********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     template <typename TMessage>
     explicit message_packet(const TMessage& /*msg*/, typename etl::enable_if<!etl::is_same<typename etl::remove_cvref<TMessage>::type, etl::message_packet<T1, T2, T3, T4, T5, T6, T7> >::value &&
                                                                          !etl::is_same<typename etl::remove_cvref<TMessage>::type, etl::imessage>::value &&
@@ -2983,11 +2983,11 @@ namespace etl
 
       ETL_STATIC_ASSERT(Enabled, "Message not in packet type list");
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
   #endif
 
     //**********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     message_packet(const message_packet& other)
       : valid(other.is_valid())
     {
@@ -2996,11 +2996,11 @@ namespace etl
         add_new_message(other.get());
       }
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
 
   #if ETL_USING_CPP11 && !defined(ETL_MESSAGE_PACKET_FORCE_CPP03_IMPLEMENTATION)
     //**********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     message_packet(message_packet&& other)
       : valid(other.is_valid())
     {
@@ -3009,11 +3009,11 @@ namespace etl
         add_new_message(etl::move(other.get()));
       }
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
   #endif
 
     //**********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     message_packet& operator =(const message_packet& rhs)
     {
       delete_current_message();
@@ -3025,11 +3025,11 @@ namespace etl
 
       return *this;
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
 
   #if ETL_USING_CPP11 && !defined(ETL_MESSAGE_PACKET_FORCE_CPP03_IMPLEMENTATION)
     //**********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     message_packet& operator =(message_packet&& rhs)
     {
       delete_current_message();
@@ -3041,7 +3041,7 @@ namespace etl
 
       return *this;
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
   #endif
 
     //********************************************
@@ -3108,7 +3108,7 @@ namespace etl
   private:
 
     //********************************************
-    #include "etl/private/diagnostic_uninitialized_push.h"
+    #include "private/diagnostic_uninitialized_push.h"
     void delete_current_message()
     {
       if (valid)
@@ -3118,7 +3118,7 @@ namespace etl
         pmsg->~imessage();
       }
     }
-    #include "etl/private/diagnostic_pop.h"
+    #include "private/diagnostic_pop.h"
 
     //********************************************
     void add_new_message(const etl::imessage& msg)
@@ -3167,22 +3167,22 @@ namespace etl
   //***************************************************************************
   // Specialisation for 6 message types.
   //***************************************************************************
-  template <typename T1, typename T2, typename T3, typename T4, 
+  template <typename T1, typename T2, typename T3, typename T4,
             typename T5, typename T6>
   class message_packet<T1, T2, T3, T4, T5, T6, void, void, void, void, void, void, void, void, void, void>
   {
   public:
 
     //********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     message_packet()
       : valid(false)
     {
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
 
     //********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     explicit message_packet(const etl::imessage& msg)
     {
       if (accepts(msg))
@@ -3197,11 +3197,11 @@ namespace etl
 
       ETL_ASSERT(valid, ETL_ERROR(unhandled_message_exception));
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
 
   #if ETL_USING_CPP11 && !defined(ETL_MESSAGE_PACKET_FORCE_CPP03_IMPLEMENTATION)
     //********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     explicit message_packet(etl::imessage&& msg)
     {
       if (accepts(msg))
@@ -3216,12 +3216,12 @@ namespace etl
 
       ETL_ASSERT(valid, ETL_ERROR(unhandled_message_exception));
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
   #endif
 
   #if ETL_USING_CPP11 && !defined(ETL_MESSAGE_PACKET_FORCE_CPP03_IMPLEMENTATION) && !defined(ETL_COMPILER_GREEN_HILLS)
     //********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     template <typename TMessage, typename = typename etl::enable_if<!etl::is_same<typename etl::remove_cvref<TMessage>::type, etl::message_packet<T1, T2, T3, T4, T5, T6> >::value &&
                                                                     !etl::is_same<typename etl::remove_cvref<TMessage>::type, etl::imessage>::value &&
                                                                     !etl::is_one_of<typename etl::remove_cvref<TMessage>::type, T1, T2, T3, T4, T5, T6>::value, int>::type>
@@ -3235,10 +3235,10 @@ namespace etl
 
       ETL_STATIC_ASSERT(Enabled, "Message not in packet type list");
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
   #else
     //********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     template <typename TMessage>
     explicit message_packet(const TMessage& /*msg*/, typename etl::enable_if<!etl::is_same<typename etl::remove_cvref<TMessage>::type, etl::message_packet<T1, T2, T3, T4, T5, T6> >::value &&
                                                                          !etl::is_same<typename etl::remove_cvref<TMessage>::type, etl::imessage>::value &&
@@ -3252,11 +3252,11 @@ namespace etl
 
       ETL_STATIC_ASSERT(Enabled, "Message not in packet type list");
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
   #endif
 
     //**********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     message_packet(const message_packet& other)
       : valid(other.is_valid())
     {
@@ -3265,11 +3265,11 @@ namespace etl
         add_new_message(other.get());
       }
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
 
   #if ETL_USING_CPP11 && !defined(ETL_MESSAGE_PACKET_FORCE_CPP03_IMPLEMENTATION)
     //**********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     message_packet(message_packet&& other)
       : valid(other.is_valid())
     {
@@ -3278,11 +3278,11 @@ namespace etl
         add_new_message(etl::move(other.get()));
       }
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
   #endif
 
     //**********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     message_packet& operator =(const message_packet& rhs)
     {
       delete_current_message();
@@ -3294,11 +3294,11 @@ namespace etl
 
       return *this;
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
 
   #if ETL_USING_CPP11 && !defined(ETL_MESSAGE_PACKET_FORCE_CPP03_IMPLEMENTATION)
     //**********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     message_packet& operator =(message_packet&& rhs)
     {
       delete_current_message();
@@ -3310,7 +3310,7 @@ namespace etl
 
       return *this;
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
   #endif
 
     //********************************************
@@ -3377,7 +3377,7 @@ namespace etl
   private:
 
     //********************************************
-    #include "etl/private/diagnostic_uninitialized_push.h"
+    #include "private/diagnostic_uninitialized_push.h"
     void delete_current_message()
     {
       if (valid)
@@ -3387,7 +3387,7 @@ namespace etl
         pmsg->~imessage();
       }
     }
-    #include "etl/private/diagnostic_pop.h"
+    #include "private/diagnostic_pop.h"
 
     //********************************************
     void add_new_message(const etl::imessage& msg)
@@ -3434,22 +3434,22 @@ namespace etl
   //***************************************************************************
   // Specialisation for 5 message types.
   //***************************************************************************
-  template <typename T1, typename T2, typename T3, typename T4, 
+  template <typename T1, typename T2, typename T3, typename T4,
             typename T5>
   class message_packet<T1, T2, T3, T4, T5, void, void, void, void, void, void, void, void, void, void, void>
   {
   public:
 
     //********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     message_packet()
       : valid(false)
     {
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
 
     //********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     explicit message_packet(const etl::imessage& msg)
     {
       if (accepts(msg))
@@ -3464,11 +3464,11 @@ namespace etl
 
       ETL_ASSERT(valid, ETL_ERROR(unhandled_message_exception));
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
 
   #if ETL_USING_CPP11 && !defined(ETL_MESSAGE_PACKET_FORCE_CPP03_IMPLEMENTATION)
     //********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     explicit message_packet(etl::imessage&& msg)
     {
       if (accepts(msg))
@@ -3483,12 +3483,12 @@ namespace etl
 
       ETL_ASSERT(valid, ETL_ERROR(unhandled_message_exception));
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
   #endif
 
   #if ETL_USING_CPP11 && !defined(ETL_MESSAGE_PACKET_FORCE_CPP03_IMPLEMENTATION) && !defined(ETL_COMPILER_GREEN_HILLS)
     //********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     template <typename TMessage, typename = typename etl::enable_if<!etl::is_same<typename etl::remove_cvref<TMessage>::type, etl::message_packet<T1, T2, T3, T4, T5> >::value &&
                                                                     !etl::is_same<typename etl::remove_cvref<TMessage>::type, etl::imessage>::value &&
                                                                     !etl::is_one_of<typename etl::remove_cvref<TMessage>::type, T1, T2, T3, T4, T5>::value, int>::type>
@@ -3502,10 +3502,10 @@ namespace etl
 
       ETL_STATIC_ASSERT(Enabled, "Message not in packet type list");
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
   #else
     //********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     template <typename TMessage>
     explicit message_packet(const TMessage& /*msg*/, typename etl::enable_if<!etl::is_same<typename etl::remove_cvref<TMessage>::type, etl::message_packet<T1, T2, T3, T4, T5> >::value &&
                                                                          !etl::is_same<typename etl::remove_cvref<TMessage>::type, etl::imessage>::value &&
@@ -3519,11 +3519,11 @@ namespace etl
 
       ETL_STATIC_ASSERT(Enabled, "Message not in packet type list");
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
   #endif
 
     //**********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     message_packet(const message_packet& other)
       : valid(other.is_valid())
     {
@@ -3532,11 +3532,11 @@ namespace etl
         add_new_message(other.get());
       }
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
 
   #if ETL_USING_CPP11 && !defined(ETL_MESSAGE_PACKET_FORCE_CPP03_IMPLEMENTATION)
     //**********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     message_packet(message_packet&& other)
       : valid(other.is_valid())
     {
@@ -3545,11 +3545,11 @@ namespace etl
         add_new_message(etl::move(other.get()));
       }
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
   #endif
 
     //**********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     message_packet& operator =(const message_packet& rhs)
     {
       delete_current_message();
@@ -3561,11 +3561,11 @@ namespace etl
 
       return *this;
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
 
   #if ETL_USING_CPP11 && !defined(ETL_MESSAGE_PACKET_FORCE_CPP03_IMPLEMENTATION)
     //**********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     message_packet& operator =(message_packet&& rhs)
     {
       delete_current_message();
@@ -3577,7 +3577,7 @@ namespace etl
 
       return *this;
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
   #endif
 
     //********************************************
@@ -3644,7 +3644,7 @@ namespace etl
   private:
 
     //********************************************
-    #include "etl/private/diagnostic_uninitialized_push.h"
+    #include "private/diagnostic_uninitialized_push.h"
     void delete_current_message()
     {
       if (valid)
@@ -3654,7 +3654,7 @@ namespace etl
         pmsg->~imessage();
       }
     }
-    #include "etl/private/diagnostic_pop.h"
+    #include "private/diagnostic_pop.h"
 
     //********************************************
     void add_new_message(const etl::imessage& msg)
@@ -3705,15 +3705,15 @@ namespace etl
   public:
 
     //********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     message_packet()
       : valid(false)
     {
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
 
     //********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     explicit message_packet(const etl::imessage& msg)
     {
       if (accepts(msg))
@@ -3728,11 +3728,11 @@ namespace etl
 
       ETL_ASSERT(valid, ETL_ERROR(unhandled_message_exception));
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
 
   #if ETL_USING_CPP11 && !defined(ETL_MESSAGE_PACKET_FORCE_CPP03_IMPLEMENTATION)
     //********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     explicit message_packet(etl::imessage&& msg)
     {
       if (accepts(msg))
@@ -3747,12 +3747,12 @@ namespace etl
 
       ETL_ASSERT(valid, ETL_ERROR(unhandled_message_exception));
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
   #endif
 
   #if ETL_USING_CPP11 && !defined(ETL_MESSAGE_PACKET_FORCE_CPP03_IMPLEMENTATION) && !defined(ETL_COMPILER_GREEN_HILLS)
     //********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     template <typename TMessage, typename = typename etl::enable_if<!etl::is_same<typename etl::remove_cvref<TMessage>::type, etl::message_packet<T1, T2, T3, T4> >::value &&
                                                                     !etl::is_same<typename etl::remove_cvref<TMessage>::type, etl::imessage>::value &&
                                                                     !etl::is_one_of<typename etl::remove_cvref<TMessage>::type, T1, T2, T3, T4>::value, int>::type>
@@ -3766,10 +3766,10 @@ namespace etl
 
       ETL_STATIC_ASSERT(Enabled, "Message not in packet type list");
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
   #else
     //********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     template <typename TMessage>
     explicit message_packet(const TMessage& /*msg*/, typename etl::enable_if<!etl::is_same<typename etl::remove_cvref<TMessage>::type, etl::message_packet<T1, T2, T3, T4> >::value &&
                                                                          !etl::is_same<typename etl::remove_cvref<TMessage>::type, etl::imessage>::value &&
@@ -3783,11 +3783,11 @@ namespace etl
 
       ETL_STATIC_ASSERT(Enabled, "Message not in packet type list");
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
   #endif
 
     //**********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     message_packet(const message_packet& other)
       : valid(other.is_valid())
     {
@@ -3796,11 +3796,11 @@ namespace etl
         add_new_message(other.get());
       }
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
 
   #if ETL_USING_CPP11 && !defined(ETL_MESSAGE_PACKET_FORCE_CPP03_IMPLEMENTATION)
     //**********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     message_packet(message_packet&& other)
       : valid(other.is_valid())
     {
@@ -3809,11 +3809,11 @@ namespace etl
         add_new_message(etl::move(other.get()));
       }
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
   #endif
 
     //**********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     message_packet& operator =(const message_packet& rhs)
     {
       delete_current_message();
@@ -3825,11 +3825,11 @@ namespace etl
 
       return *this;
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
 
   #if ETL_USING_CPP11 && !defined(ETL_MESSAGE_PACKET_FORCE_CPP03_IMPLEMENTATION)
     //**********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     message_packet& operator =(message_packet&& rhs)
     {
       delete_current_message();
@@ -3841,7 +3841,7 @@ namespace etl
 
       return *this;
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
   #endif
 
     //********************************************
@@ -3905,7 +3905,7 @@ namespace etl
   private:
 
     //********************************************
-    #include "etl/private/diagnostic_uninitialized_push.h"
+    #include "private/diagnostic_uninitialized_push.h"
     void delete_current_message()
     {
       if (valid)
@@ -3915,7 +3915,7 @@ namespace etl
         pmsg->~imessage();
       }
     }
-    #include "etl/private/diagnostic_pop.h"
+    #include "private/diagnostic_pop.h"
 
     //********************************************
     void add_new_message(const etl::imessage& msg)
@@ -3964,15 +3964,15 @@ namespace etl
   public:
 
     //********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     message_packet()
       : valid(false)
     {
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
 
     //********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     explicit message_packet(const etl::imessage& msg)
     {
       if (accepts(msg))
@@ -3987,11 +3987,11 @@ namespace etl
 
       ETL_ASSERT(valid, ETL_ERROR(unhandled_message_exception));
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
 
   #if ETL_USING_CPP11 && !defined(ETL_MESSAGE_PACKET_FORCE_CPP03_IMPLEMENTATION)
     //********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     explicit message_packet(etl::imessage&& msg)
     {
       if (accepts(msg))
@@ -4006,12 +4006,12 @@ namespace etl
 
       ETL_ASSERT(valid, ETL_ERROR(unhandled_message_exception));
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
   #endif
 
   #if ETL_USING_CPP11 && !defined(ETL_MESSAGE_PACKET_FORCE_CPP03_IMPLEMENTATION) && !defined(ETL_COMPILER_GREEN_HILLS)
     //********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     template <typename TMessage, typename = typename etl::enable_if<!etl::is_same<typename etl::remove_cvref<TMessage>::type, etl::message_packet<T1, T2, T3> >::value &&
                                                                     !etl::is_same<typename etl::remove_cvref<TMessage>::type, etl::imessage>::value &&
                                                                     !etl::is_one_of<typename etl::remove_cvref<TMessage>::type, T1, T2, T3>::value, int>::type>
@@ -4025,10 +4025,10 @@ namespace etl
 
       ETL_STATIC_ASSERT(Enabled, "Message not in packet type list");
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
   #else
     //********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     template <typename TMessage>
     explicit message_packet(const TMessage& /*msg*/, typename etl::enable_if<!etl::is_same<typename etl::remove_cvref<TMessage>::type, etl::message_packet<T1, T2, T3> >::value &&
                                                                          !etl::is_same<typename etl::remove_cvref<TMessage>::type, etl::imessage>::value &&
@@ -4042,11 +4042,11 @@ namespace etl
 
       ETL_STATIC_ASSERT(Enabled, "Message not in packet type list");
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
   #endif
 
     //**********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     message_packet(const message_packet& other)
       : valid(other.is_valid())
     {
@@ -4055,11 +4055,11 @@ namespace etl
         add_new_message(other.get());
       }
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
 
   #if ETL_USING_CPP11 && !defined(ETL_MESSAGE_PACKET_FORCE_CPP03_IMPLEMENTATION)
     //**********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     message_packet(message_packet&& other)
       : valid(other.is_valid())
     {
@@ -4068,11 +4068,11 @@ namespace etl
         add_new_message(etl::move(other.get()));
       }
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
   #endif
 
     //**********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     message_packet& operator =(const message_packet& rhs)
     {
       delete_current_message();
@@ -4084,11 +4084,11 @@ namespace etl
 
       return *this;
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
 
   #if ETL_USING_CPP11 && !defined(ETL_MESSAGE_PACKET_FORCE_CPP03_IMPLEMENTATION)
     //**********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     message_packet& operator =(message_packet&& rhs)
     {
       delete_current_message();
@@ -4100,7 +4100,7 @@ namespace etl
 
       return *this;
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
   #endif
 
     //********************************************
@@ -4164,7 +4164,7 @@ namespace etl
   private:
 
     //********************************************
-    #include "etl/private/diagnostic_uninitialized_push.h"
+    #include "private/diagnostic_uninitialized_push.h"
     void delete_current_message()
     {
       if (valid)
@@ -4174,7 +4174,7 @@ namespace etl
         pmsg->~imessage();
       }
     }
-    #include "etl/private/diagnostic_pop.h"
+    #include "private/diagnostic_pop.h"
 
     //********************************************
     void add_new_message(const etl::imessage& msg)
@@ -4221,15 +4221,15 @@ namespace etl
   public:
 
     //********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     message_packet()
       : valid(false)
     {
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
 
     //********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     explicit message_packet(const etl::imessage& msg)
     {
       if (accepts(msg))
@@ -4244,11 +4244,11 @@ namespace etl
 
       ETL_ASSERT(valid, ETL_ERROR(unhandled_message_exception));
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
 
   #if ETL_USING_CPP11 && !defined(ETL_MESSAGE_PACKET_FORCE_CPP03_IMPLEMENTATION)
     //********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     explicit message_packet(etl::imessage&& msg)
     {
       if (accepts(msg))
@@ -4263,12 +4263,12 @@ namespace etl
 
       ETL_ASSERT(valid, ETL_ERROR(unhandled_message_exception));
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
   #endif
 
   #if ETL_USING_CPP11 && !defined(ETL_MESSAGE_PACKET_FORCE_CPP03_IMPLEMENTATION) && !defined(ETL_COMPILER_GREEN_HILLS)
     //********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     template <typename TMessage, typename = typename etl::enable_if<!etl::is_same<typename etl::remove_cvref<TMessage>::type, etl::message_packet<T1, T2> >::value &&
                                                                     !etl::is_same<typename etl::remove_cvref<TMessage>::type, etl::imessage>::value &&
                                                                     !etl::is_one_of<typename etl::remove_cvref<TMessage>::type, T1, T2>::value, int>::type>
@@ -4282,10 +4282,10 @@ namespace etl
 
       ETL_STATIC_ASSERT(Enabled, "Message not in packet type list");
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
   #else
     //********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     template <typename TMessage>
     explicit message_packet(const TMessage& /*msg*/, typename etl::enable_if<!etl::is_same<typename etl::remove_cvref<TMessage>::type, etl::message_packet<T1, T2> >::value &&
                                                                          !etl::is_same<typename etl::remove_cvref<TMessage>::type, etl::imessage>::value &&
@@ -4299,11 +4299,11 @@ namespace etl
 
       ETL_STATIC_ASSERT(Enabled, "Message not in packet type list");
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
   #endif
 
     //**********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     message_packet(const message_packet& other)
       : valid(other.is_valid())
     {
@@ -4312,11 +4312,11 @@ namespace etl
         add_new_message(other.get());
       }
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
 
   #if ETL_USING_CPP11 && !defined(ETL_MESSAGE_PACKET_FORCE_CPP03_IMPLEMENTATION)
     //**********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     message_packet(message_packet&& other)
       : valid(other.is_valid())
     {
@@ -4325,11 +4325,11 @@ namespace etl
         add_new_message(etl::move(other.get()));
       }
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
   #endif
 
     //**********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     message_packet& operator =(const message_packet& rhs)
     {
       delete_current_message();
@@ -4341,11 +4341,11 @@ namespace etl
 
       return *this;
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
 
   #if ETL_USING_CPP11 && !defined(ETL_MESSAGE_PACKET_FORCE_CPP03_IMPLEMENTATION)
     //**********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     message_packet& operator =(message_packet&& rhs)
     {
       delete_current_message();
@@ -4357,7 +4357,7 @@ namespace etl
 
       return *this;
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
   #endif
 
     //********************************************
@@ -4421,7 +4421,7 @@ namespace etl
   private:
 
     //********************************************
-    #include "etl/private/diagnostic_uninitialized_push.h"
+    #include "private/diagnostic_uninitialized_push.h"
     void delete_current_message()
     {
       if (valid)
@@ -4431,7 +4431,7 @@ namespace etl
         pmsg->~imessage();
       }
     }
-    #include "etl/private/diagnostic_pop.h"
+    #include "private/diagnostic_pop.h"
 
     //********************************************
     void add_new_message(const etl::imessage& msg)
@@ -4476,15 +4476,15 @@ namespace etl
   public:
 
     //********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     message_packet()
       : valid(false)
     {
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
 
     //********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     explicit message_packet(const etl::imessage& msg)
     {
       if (accepts(msg))
@@ -4499,11 +4499,11 @@ namespace etl
 
       ETL_ASSERT(valid, ETL_ERROR(unhandled_message_exception));
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
 
   #if ETL_USING_CPP11 && !defined(ETL_MESSAGE_PACKET_FORCE_CPP03_IMPLEMENTATION)
     //********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     explicit message_packet(etl::imessage&& msg)
     {
       if (accepts(msg))
@@ -4518,12 +4518,12 @@ namespace etl
 
       ETL_ASSERT(valid, ETL_ERROR(unhandled_message_exception));
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
   #endif
 
   #if ETL_USING_CPP11 && !defined(ETL_MESSAGE_PACKET_FORCE_CPP03_IMPLEMENTATION) && !defined(ETL_COMPILER_GREEN_HILLS)
     //********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     template <typename TMessage, typename = typename etl::enable_if<!etl::is_same<typename etl::remove_cvref<TMessage>::type, etl::message_packet<T1> >::value &&
                                                                     !etl::is_same<typename etl::remove_cvref<TMessage>::type, etl::imessage>::value &&
                                                                     !etl::is_one_of<typename etl::remove_cvref<TMessage>::type, T1>::value, int>::type>
@@ -4537,10 +4537,10 @@ namespace etl
 
       ETL_STATIC_ASSERT(Enabled, "Message not in packet type list");
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
   #else
     //********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     template <typename TMessage>
     explicit message_packet(const TMessage& /*msg*/, typename etl::enable_if<!etl::is_same<typename etl::remove_cvref<TMessage>::type, etl::message_packet<T1> >::value &&
                                                                          !etl::is_same<typename etl::remove_cvref<TMessage>::type, etl::imessage>::value &&
@@ -4554,11 +4554,11 @@ namespace etl
 
       ETL_STATIC_ASSERT(Enabled, "Message not in packet type list");
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
   #endif
 
     //**********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     message_packet(const message_packet& other)
       : valid(other.is_valid())
     {
@@ -4567,11 +4567,11 @@ namespace etl
         add_new_message(other.get());
       }
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
 
   #if ETL_USING_CPP11 && !defined(ETL_MESSAGE_PACKET_FORCE_CPP03_IMPLEMENTATION)
     //**********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     message_packet(message_packet&& other)
       : valid(other.is_valid())
     {
@@ -4580,11 +4580,11 @@ namespace etl
         add_new_message(etl::move(other.get()));
       }
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
   #endif
 
     //**********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     message_packet& operator =(const message_packet& rhs)
     {
       delete_current_message();
@@ -4596,11 +4596,11 @@ namespace etl
 
       return *this;
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
 
   #if ETL_USING_CPP11 && !defined(ETL_MESSAGE_PACKET_FORCE_CPP03_IMPLEMENTATION)
     //**********************************************
-  #include "etl/private/diagnostic_uninitialized_push.h"
+  #include "private/diagnostic_uninitialized_push.h"
     message_packet& operator =(message_packet&& rhs)
     {
       delete_current_message();
@@ -4612,7 +4612,7 @@ namespace etl
 
       return *this;
     }
-  #include "etl/private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
   #endif
 
     //********************************************
@@ -4676,7 +4676,7 @@ namespace etl
   private:
 
     //********************************************
-    #include "etl/private/diagnostic_uninitialized_push.h"
+    #include "private/diagnostic_uninitialized_push.h"
     void delete_current_message()
     {
       if (valid)
@@ -4686,7 +4686,7 @@ namespace etl
         pmsg->~imessage();
       }
     }
-    #include "etl/private/diagnostic_pop.h"
+    #include "private/diagnostic_pop.h"
 
     //********************************************
     void add_new_message(const etl::imessage& msg)

--- a/include/etl/optional.h
+++ b/include/etl/optional.h
@@ -135,7 +135,7 @@ namespace etl
     {
     }
 
-#include "etl/private/diagnostic_uninitialized_push.h"
+#include "private/diagnostic_uninitialized_push.h"
     //***************************************************************************
     /// Copy constructor.
     //***************************************************************************
@@ -147,7 +147,7 @@ namespace etl
         storage.construct(other.value());
       }
     }
-#include "etl/private/diagnostic_pop.h"
+#include "private/diagnostic_pop.h"
 
 #if ETL_USING_CPP11
     //***************************************************************************
@@ -481,7 +481,7 @@ namespace etl
     //*************************************************************************
     /// Emplaces a value.
     ///\param args The arguments to construct with.
-    //*************************************************************************   
+    //*************************************************************************
     template <typename ... TArgs>
     ETL_CONSTEXPR20_STL
     void emplace(TArgs&& ... args)
@@ -890,7 +890,7 @@ namespace etl
     //***************************************************************************
     /// Bool conversion operator.
     //***************************************************************************
-    ETL_CONSTEXPR14 
+    ETL_CONSTEXPR14
     ETL_EXPLICIT operator bool() const
     {
       return valid;
@@ -1110,7 +1110,7 @@ namespace etl
     storage_type storage;
   };
 
-#include "etl/private/diagnostic_uninitialized_push.h"
+#include "private/diagnostic_uninitialized_push.h"
 
   //***************************************************************************
   /// Equality operator. cppreference 1
@@ -1404,7 +1404,7 @@ namespace etl
     return rhs.has_value() ? lhs >= rhs.value() : true;
   }
 
-#include "etl/private/diagnostic_pop.h"
+#include "private/diagnostic_pop.h"
 
   //***************************************************************************
   /// Make an optional.

--- a/include/etl/private/variant_legacy.h
+++ b/include/etl/private/variant_legacy.h
@@ -460,12 +460,12 @@ namespace etl
       /// Default constructor.
       /// Sets the state of the instance to containing no valid data.
       //***************************************************************************
-#include "etl/private/diagnostic_uninitialized_push.h"
+#include "diagnostic_uninitialized_push.h"
       variant()
         : type_id(UNSUPPORTED_TYPE_ID)
       {
       }
-#include "etl/private/diagnostic_pop.h"
+#include "diagnostic_pop.h"
 
       //***************************************************************************
       /// Constructor that catches any types that are not supported.
@@ -484,7 +484,7 @@ namespace etl
       /// Copy constructor.
       ///\param other The other variant object to copy.
       //***************************************************************************
-#include "etl/private/diagnostic_uninitialized_push.h"
+#include "diagnostic_uninitialized_push.h"
       variant(const variant& other)
       {
         switch (other.type_id)
@@ -502,7 +502,7 @@ namespace etl
 
         type_id = other.type_id;
       }
-#include "etl/private/diagnostic_pop.h"
+#include "diagnostic_pop.h"
 
 #if ETL_USING_CPP11 && ETL_NOT_USING_STLPORT && !defined(ETL_VARIANT_FORCE_CPP03_IMPLEMENTATION)
       //*************************************************************************
@@ -869,8 +869,7 @@ namespace etl
       }
 
     private:
-
-#include "etl/private/diagnostic_uninitialized_push.h"
+#include "diagnostic_uninitialized_push.h"
       //***************************************************************************
       /// Destruct the current occupant of the variant.
       //***************************************************************************
@@ -891,7 +890,7 @@ namespace etl
 
         type_id = UNSUPPORTED_TYPE_ID;
       }
-#include "etl/private/diagnostic_pop.h"
+#include "diagnostic_pop.h"
 
       //***************************************************************************
       /// The internal storage.
@@ -1010,4 +1009,3 @@ namespace etl
   }
 #endif
 }
-

--- a/include/etl/private/variant_variadic.h
+++ b/include/etl/private/variant_variadic.h
@@ -430,7 +430,7 @@ namespace etl
   /// 'Bad variant access' exception for the variant class.
   ///\ingroup variant
   //***************************************************************************
-  class bad_variant_access : public variant_exception 
+  class bad_variant_access : public variant_exception
   {
   public:
     bad_variant_access(string_type file_name_, numeric_type line_number_)
@@ -524,7 +524,7 @@ namespace etl
     /// Default constructor.
     /// Sets the state of the instance to containing no valid data.
     //***************************************************************************
-#include "etl/private/diagnostic_uninitialized_push.h"
+#include "diagnostic_uninitialized_push.h"
     ETL_CONSTEXPR14 variant()
     {
       using type = typename etl::private_variant::parameter_pack<TTypes...>::template type_from_index<0U>::type;
@@ -533,12 +533,12 @@ namespace etl
       operation = operation_type<type, etl::is_copy_constructible<type>::value, etl::is_move_constructible<type>::value>::do_operation;
       type_id   = 0U;
     }
-#include "etl/private/diagnostic_pop.h"
+#include "diagnostic_pop.h"
 
     //***************************************************************************
     /// Construct from a value.
     //***************************************************************************
-#include "etl/private/diagnostic_uninitialized_push.h"
+#include "diagnostic_uninitialized_push.h"
     template <typename T, etl::enable_if_t<!etl::is_same<etl::remove_cvref_t<T>, variant>::value, int> = 0>
     ETL_CONSTEXPR14 variant(T&& value)
       : operation(operation_type<etl::remove_cvref_t<T>, etl::is_copy_constructible<etl::remove_cvref_t<T>>::value, etl::is_move_constructible<etl::remove_cvref_t<T>>::value>::do_operation)
@@ -548,12 +548,12 @@ namespace etl
 
       construct_in_place<etl::remove_cvref_t<T>>(data, etl::forward<T>(value));
     }
-#include "etl/private/diagnostic_pop.h"
+#include "diagnostic_pop.h"
 
     //***************************************************************************
     /// Construct from arguments.
     //***************************************************************************
-#include "etl/private/diagnostic_uninitialized_push.h"
+#include "diagnostic_uninitialized_push.h"
     template <typename T, typename... TArgs>
     ETL_CONSTEXPR14 explicit variant(etl::in_place_type_t<T>, TArgs&&... args)
       : operation(operation_type<etl::remove_cvref_t<T>, etl::is_copy_constructible<etl::remove_cvref_t<T>>::value, etl::is_move_constructible<etl::remove_cvref_t<T>>::value>::do_operation)
@@ -563,12 +563,12 @@ namespace etl
 
       construct_in_place_args<etl::remove_cvref_t<T>>(data, etl::forward<TArgs>(args)...);
     }
-#include "etl/private/diagnostic_pop.h"
+#include "diagnostic_pop.h"
 
     //***************************************************************************
     /// Construct from arguments.
     //***************************************************************************
-#include "etl/private/diagnostic_uninitialized_push.h"
+#include "diagnostic_uninitialized_push.h"
     template <size_t Index, typename... TArgs>
     ETL_CONSTEXPR14 explicit variant(etl::in_place_index_t<Index>, TArgs&&... args)
       : type_id(Index)
@@ -580,13 +580,13 @@ namespace etl
 
       operation = operation_type<type, etl::is_copy_constructible<type>::value, etl::is_move_constructible<type>::value>::do_operation;
     }
-#include "etl/private/diagnostic_pop.h"
+#include "diagnostic_pop.h"
 
 #if ETL_HAS_INITIALIZER_LIST
     //***************************************************************************
     /// Construct from type, initializer_list and arguments.
     //***************************************************************************
-#include "etl/private/diagnostic_uninitialized_push.h"
+#include "diagnostic_uninitialized_push.h"
     template <typename T, typename U, typename... TArgs >
     ETL_CONSTEXPR14 explicit variant(etl::in_place_type_t<T>, std::initializer_list<U> init, TArgs&&... args)
       : operation(operation_type<etl::remove_cvref_t<T>, etl::is_copy_constructible<etl::remove_cvref_t<T>>::value, etl::is_move_constructible<etl::remove_cvref_t<T>>::value>::do_operation)
@@ -596,12 +596,12 @@ namespace etl
 
       construct_in_place_args<etl::remove_cvref_t<T>>(data, init, etl::forward<TArgs>(args)...);
     }
-#include "etl/private/diagnostic_pop.h"
+#include "diagnostic_pop.h"
 
     //***************************************************************************
     /// Construct from index, initializer_list and arguments.
     //***************************************************************************
-#include "etl/private/diagnostic_uninitialized_push.h"
+#include "diagnostic_uninitialized_push.h"
     template <size_t Index, typename U, typename... TArgs >
     ETL_CONSTEXPR14 explicit variant(etl::in_place_index_t<Index>, std::initializer_list<U> init, TArgs&&... args)
       : type_id(Index)
@@ -613,14 +613,14 @@ namespace etl
 
       operation = operation_type<type, etl::is_copy_constructible<type>::value, etl::is_move_constructible<type>::value>::do_operation;
     }
-#include "etl/private/diagnostic_pop.h"
+#include "diagnostic_pop.h"
 #endif
 
     //***************************************************************************
     /// Copy constructor.
     ///\param other The other variant object to copy.
     //***************************************************************************
-#include "etl/private/diagnostic_uninitialized_push.h"
+#include "diagnostic_uninitialized_push.h"
     ETL_CONSTEXPR14 variant(const variant& other)
       : operation(other.operation)
       , type_id(other.type_id)
@@ -637,13 +637,13 @@ namespace etl
         }
       }
     }
-#include "etl/private/diagnostic_pop.h"
+#include "diagnostic_pop.h"
 
     //***************************************************************************
     /// Move constructor.
     ///\param other The other variant object to copy.
     //***************************************************************************
-#include "etl/private/diagnostic_uninitialized_push.h"
+#include "diagnostic_uninitialized_push.h"
     ETL_CONSTEXPR14 variant(variant&& other)
       : operation(other.operation)
       , type_id(other.type_id)
@@ -664,7 +664,7 @@ namespace etl
         type_id = variant_npos;
       }
     }
-#include "etl/private/diagnostic_pop.h"
+#include "diagnostic_pop.h"
 
     //***************************************************************************
     /// Destructor.
@@ -706,7 +706,7 @@ namespace etl
     //***************************************************************************
     template <size_t Index, typename... TArgs>
     typename etl::variant_alternative<Index, variant<TArgs...>>::type& emplace(TArgs&&... args)
-    {    
+    {
       static_assert(Index < etl::private_variant::parameter_pack<TTypes...>::size, "Index out of range");
 
       using type = typename etl::private_variant::parameter_pack<TTypes...>::template type_from_index<Index>::type;
@@ -826,7 +826,7 @@ namespace etl
     /// Accept an etl::visitor.
     //***************************************************************************
     template <typename TVisitor>
-    etl::enable_if_t<etl::is_visitor<TVisitor>::value, void> 
+    etl::enable_if_t<etl::is_visitor<TVisitor>::value, void>
       accept(TVisitor& v)
     {
 #if ETL_USING_CPP17 && !defined(ETL_VARIANT_FORCE_CPP11)
@@ -840,7 +840,7 @@ namespace etl
     /// Accept an etl::visitor.
     //***************************************************************************
     template <typename TVisitor>
-    etl::enable_if_t<etl::is_visitor<TVisitor>::value, void> 
+    etl::enable_if_t<etl::is_visitor<TVisitor>::value, void>
       accept(TVisitor& v) const
     {
 #if ETL_USING_CPP17 && !defined(ETL_VARIANT_FORCE_CPP11)
@@ -1125,7 +1125,7 @@ namespace etl
       {
         // Workaround for MSVC (2023/05/13)
         // It doesn't compile 'visitor.visit(etl::get<Index>(*this))' correctly for C++17 & C++20.
-        // Changed all of the instances for consistancy.   
+        // Changed all of the instances for consistancy.
         auto& v = etl::get<Index>(*this);
         visitor.visit(v);
         return true;
@@ -1146,7 +1146,7 @@ namespace etl
       {
         // Workaround for MSVC (2023/05/13)
         // It doesn't compile 'visitor.visit(etl::get<Index>(*this))' correctly for C++17 & C++20.
-        // Changed all of the instances for consistancy.      
+        // Changed all of the instances for consistancy.
         auto& v = etl::get<Index>(*this);
         visitor.visit(v);
         return true;
@@ -1700,7 +1700,7 @@ namespace etl
     struct do_visit_helper
     {
       using function_pointer = add_pointer_t<TRet(TCallable&&, TCurVariant&&, TVarRest&&...)>;
-      
+
       template <size_t tIndex>
       static constexpr function_pointer fptr() noexcept
       {
@@ -1715,10 +1715,10 @@ namespace etl
     static ETL_CONSTEXPR14 TRet do_visit(TCallable&& f, TVariant&& v, index_sequence<tIndices...>, TVarRest&&... variants)
     {
       ETL_ASSERT(!v.valueless_by_exception(), ETL_ERROR(bad_variant_access));
-      
+
       using helper_t = do_visit_helper<TRet, TCallable, TVariant, TVarRest...>;
       using func_ptr = typename helper_t::function_pointer;
-      
+
       constexpr func_ptr jmp_table[]
       {
         helper_t::template fptr<tIndices>()...


### PR DESCRIPTION
We have a use-case, where we include etl-header relative (some wrapping stuff). This leads to problems when absolute paths are used. This PR changes those to relative paths; same as other "private" includes.

