### PR TITLE
Reduce compiler warning when using `ETL_DECLARE_DEBUG_COUNT`.

### DIFF
--- a/include/etl/circular_buffer.h
+++ b/include/etl/circular_buffer.h
@@ -170,7 +170,7 @@ namespace etl
     size_type buffer_size;
     size_type in;            ///< Index to the next write.
     size_type out;           ///< Index to the next read.
-    ETL_DECLARE_DEBUG_COUNT;  ///< Internal debugging.
+    ETL_DECLARE_DEBUG_COUNT  ///< Internal debugging.
   };
 
   //***************************************************************************

--- a/include/etl/debug_count.h
+++ b/include/etl/debug_count.h
@@ -42,7 +42,7 @@ SOFTWARE.
 
 #if defined(ETL_DEBUG_COUNT)
 
-  #define ETL_DECLARE_DEBUG_COUNT              etl::debug_count etl_debug_count
+  #define ETL_DECLARE_DEBUG_COUNT              etl::debug_count etl_debug_count;
   #define ETL_SET_DEBUG_COUNT(n)               etl_debug_count.set(n)
   #define ETL_GET_DEBUG_COUNT                  etl_debug_count.get()
   #define ETL_INCREMENT_DEBUG_COUNT            ++etl_debug_count;

--- a/include/etl/deque.h
+++ b/include/etl/deque.h
@@ -214,7 +214,7 @@ namespace etl
     size_type       current_size; ///< The current number of elements in the deque.
     const size_type CAPACITY;     ///< The maximum number of elements in the deque.
     const size_type BUFFER_SIZE;  ///< The number of elements in the buffer.
-    ETL_DECLARE_DEBUG_COUNT;       ///< Internal debugging.
+    ETL_DECLARE_DEBUG_COUNT       ///< Internal debugging.
   };
 
   //***************************************************************************

--- a/include/etl/flat_map.h
+++ b/include/etl/flat_map.h
@@ -1019,7 +1019,7 @@ namespace etl
     TKeyCompare compare;
 
     /// Internal debugging.
-    ETL_DECLARE_DEBUG_COUNT;
+    ETL_DECLARE_DEBUG_COUNT
 
 #if ETL_USING_CPP11
     //*************************************************************************

--- a/include/etl/flat_multimap.h
+++ b/include/etl/flat_multimap.h
@@ -881,7 +881,7 @@ namespace etl
     storage_t& storage;
 
     /// Internal debugging.
-    ETL_DECLARE_DEBUG_COUNT;
+    ETL_DECLARE_DEBUG_COUNT
 
     //*************************************************************************
     /// Destructor.

--- a/include/etl/flat_multiset.h
+++ b/include/etl/flat_multiset.h
@@ -852,7 +852,7 @@ namespace etl
     TKeyCompare compare;
 
     /// Internal debugging.
-    ETL_DECLARE_DEBUG_COUNT;
+    ETL_DECLARE_DEBUG_COUNT
 
       //*************************************************************************
       /// Destructor.

--- a/include/etl/flat_set.h
+++ b/include/etl/flat_set.h
@@ -954,7 +954,7 @@ namespace etl
     TKeyCompare compare;
 
     /// Internal debugging.
-    ETL_DECLARE_DEBUG_COUNT;
+    ETL_DECLARE_DEBUG_COUNT
 
     //*************************************************************************
     /// Destructor.

--- a/include/etl/forward_list.h
+++ b/include/etl/forward_list.h
@@ -352,7 +352,7 @@ namespace etl
     etl::ipool* p_node_pool;    ///< The pool of data nodes used in the list.
     size_type   MAX_SIZE;       ///< The maximum size of the forward_list.
     bool        pool_is_shared; ///< If <b>true</b> then the pool is shared between lists.
-    ETL_DECLARE_DEBUG_COUNT;     ///< Internal debugging.
+    ETL_DECLARE_DEBUG_COUNT     ///< Internal debugging.
   };
 
   //***************************************************************************

--- a/include/etl/list.h
+++ b/include/etl/list.h
@@ -397,7 +397,7 @@ namespace etl
     node_t      terminal_node;   ///< The node that acts as the list start and end.
     size_type   MAX_SIZE;        ///< The maximum size of the list.
     bool        pool_is_shared;  ///< If <b>true</b> then the pool is shared between lists.
-    ETL_DECLARE_DEBUG_COUNT;      ///< Internal debugging.
+    ETL_DECLARE_DEBUG_COUNT      ///< Internal debugging.
   };
 
   //***************************************************************************

--- a/include/etl/map.h
+++ b/include/etl/map.h
@@ -450,7 +450,7 @@ namespace etl
     size_type current_size;   ///< The number of the used nodes.
     const size_type CAPACITY; ///< The maximum size of the map.
     Node* root_node;          ///< The node that acts as the map root.
-    ETL_DECLARE_DEBUG_COUNT;
+    ETL_DECLARE_DEBUG_COUNT
   };
 
   //***************************************************************************

--- a/include/etl/multimap.h
+++ b/include/etl/multimap.h
@@ -613,7 +613,7 @@ namespace etl
     size_type current_size;   ///< The number of the used nodes.
     const size_type CAPACITY; ///< The maximum size of the map.
     Node* root_node;          ///< The node that acts as the multimap root.
-    ETL_DECLARE_DEBUG_COUNT;
+    ETL_DECLARE_DEBUG_COUNT
   };
 
   //***************************************************************************

--- a/include/etl/multiset.h
+++ b/include/etl/multiset.h
@@ -612,7 +612,7 @@ namespace etl
     size_type current_size;   ///< The number of the used nodes.
     const size_type CAPACITY; ///< The maximum size of the set.
     Node* root_node;          ///< The node that acts as the multiset root.
-    ETL_DECLARE_DEBUG_COUNT;
+    ETL_DECLARE_DEBUG_COUNT
   };
 
   //***************************************************************************

--- a/include/etl/private/vector_base.h
+++ b/include/etl/private/vector_base.h
@@ -168,7 +168,7 @@ namespace etl
 #endif
 
     const size_type CAPACITY; ///<The maximum number of elements in the vector.
-    ETL_DECLARE_DEBUG_COUNT;   ///< Internal debugging.
+    ETL_DECLARE_DEBUG_COUNT   ///< Internal debugging.
   };
 }
 

--- a/include/etl/queue.h
+++ b/include/etl/queue.h
@@ -224,7 +224,7 @@ namespace etl
     size_type out;           ///< Where to get the oldest data.
     size_type current_size;   ///< The number of items in the queue.
     const size_type CAPACITY; ///< The maximum number of items in the queue.
-    ETL_DECLARE_DEBUG_COUNT;  ///< For internal debugging purposes.
+    ETL_DECLARE_DEBUG_COUNT  ///< For internal debugging purposes.
 
   };
 

--- a/include/etl/set.h
+++ b/include/etl/set.h
@@ -446,7 +446,7 @@ namespace etl
     size_type current_size;   ///< The number of the used nodes.
     const size_type CAPACITY; ///< The maximum size of the set.
     Node* root_node;          ///< The node that acts as the set root.
-    ETL_DECLARE_DEBUG_COUNT;
+    ETL_DECLARE_DEBUG_COUNT
 
   };
 

--- a/include/etl/stack.h
+++ b/include/etl/stack.h
@@ -202,7 +202,7 @@ namespace etl
     size_type top_index;      ///< The index of the top of the stack.
     size_type current_size;   ///< The number of items in the stack.
     const size_type CAPACITY; ///< The maximum number of items in the stack.
-    ETL_DECLARE_DEBUG_COUNT;  ///< For internal debugging purposes.
+    ETL_DECLARE_DEBUG_COUNT   ///< For internal debugging purposes.
   };
 
   //***************************************************************************

--- a/include/etl/unordered_map.h
+++ b/include/etl/unordered_map.h
@@ -1544,7 +1544,7 @@ namespace etl
     key_equal key_equal_function;
 
     /// For library debugging purposes only.
-    ETL_DECLARE_DEBUG_COUNT;
+    ETL_DECLARE_DEBUG_COUNT
 
     //*************************************************************************
     /// Destructor.

--- a/include/etl/unordered_multimap.h
+++ b/include/etl/unordered_multimap.h
@@ -1398,7 +1398,7 @@ namespace etl
     key_equal key_equal_function;
 
     /// For library debugging purposes only.
-    ETL_DECLARE_DEBUG_COUNT;
+    ETL_DECLARE_DEBUG_COUNT
 
     //*************************************************************************
     /// Destructor.

--- a/include/etl/unordered_multiset.h
+++ b/include/etl/unordered_multiset.h
@@ -1376,7 +1376,7 @@ namespace etl
     key_equal key_equal_function;
 
     /// For library debugging purposes only.
-    ETL_DECLARE_DEBUG_COUNT;
+    ETL_DECLARE_DEBUG_COUNT
 
     //*************************************************************************
     /// Destructor.

--- a/include/etl/unordered_set.h
+++ b/include/etl/unordered_set.h
@@ -1376,7 +1376,7 @@ namespace etl
     key_equal key_equal_function;
 
     /// For library debugging purposes only.
-    ETL_DECLARE_DEBUG_COUNT;
+    ETL_DECLARE_DEBUG_COUNT
 
       //*************************************************************************
       /// Destructor.


### PR DESCRIPTION
Replaced:

    (ETL_DECLARE_DEBUG_COUNT\s*?);+

with

    \1

In order to avoid warning as such

    Warning[Pe381]: extra ";" ignored etl\include\etl\private\vector_base.h 171

When

    !defined(ETL_DEBUG_COUNT)

⚠ Partially reverts c92ab94220b29b4f196c7de44a391fd3a0a1916c.

For `ETL_DECLARE_DEBUG_COUNT` it can be assumed, that it will not be part of an expression.
For the other `ETL_\w*_DEBUG_COUNT` this can not be assumend.