### PR TITLE
Allow Building Tests as Submodule and GCC < 11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,9 +73,10 @@ if(${CMAKE_PROJECT_NAME} STREQUAL ${PROJECT_NAME})
         "${PROJECT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"
         DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/${PROJECT_NAME}/cmake)
     install(DIRECTORY ${PROJECT_SOURCE_DIR}/include/etl DESTINATION include)
-    
-    if (BUILD_TESTS)
-        enable_testing()
-        add_subdirectory(test) 
-    endif()
+
+endif()
+
+if (BUILD_TESTS)
+    enable_testing()
+    add_subdirectory(test)
 endif()

--- a/include/etl/private/diagnostic_stringop_overread_push.h
+++ b/include/etl/private/diagnostic_stringop_overread_push.h
@@ -33,11 +33,11 @@ SOFTWARE.
  * This file is intended to evaluated multiple times by design.
  */
 
-#if defined(__GNUC__) && !defined(__clang__) && !defined(__llvm__)
-  #pragma GCC diagnostic push 
+#if defined(__GNUC__) && (__GNUC__ >= 11) && !defined(__clang__) && !defined(__llvm__)
+  #pragma GCC diagnostic push
   #pragma GCC diagnostic ignored "-Wstringop-overread"
 #endif
 
 #if defined(__clang__) || defined(__llvm__)
-  #pragma clang diagnostic push 
+  #pragma clang diagnostic push
 #endif


### PR DESCRIPTION
moved BUILD_TESTS check outside of root cmake check to allow building tests when ETL is a submodule

added check for GNUC >= 11 for -Wstringop-overread ignore pragma since it isn't introduced until gcc/g++-11