### PR TITLE
Fix library error for Github Actions for Clang C++20

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -361,6 +361,7 @@ endif ()
 
 if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     message(STATUS "Using Clang compiler")
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
 endif ()
 
 if ((CMAKE_CXX_COMPILER_ID MATCHES "GNU") OR (CMAKE_CXX_COMPILER_ID MATCHES "Clang"))


### PR DESCRIPTION
I observed that the GitHub Actions fail. Through analysis since which commit the build fails, I to applied a fix to make the workflow running successfully again.

I am not sure why this fixes the workflow. 🤷 I merely re-applied f208eb4073c98b3c190b17a73db3b61aa35fae25. I think that change accidentally got lost in the merge 95c7f44cc61d51406a70ccb9048724f9fbdd78f9.

