### PR TITLE
variant varadic default constructed state

### DIFF
--- a/include/etl/private/variant_variadic.h
+++ b/include/etl/private/variant_variadic.h
@@ -531,7 +531,7 @@ namespace etl
 
       default_construct_in_place<type>(data);
       operation = operation_type<type, etl::is_copy_constructible<type>::value, etl::is_move_constructible<type>::value>::do_operation;
-      type_id   = 0U;
+      type_id   = variant_npos;
     }
 #include "diagnostic_pop.h"
 

--- a/test/test_variant_variadic.cpp
+++ b/test/test_variant_variadic.cpp
@@ -420,15 +420,15 @@ namespace
 
       test_variant_etl_3 variant_etl;
 
-      CHECK(etl::holds_alternative<char>(variant_etl));
+      CHECK(!etl::holds_alternative<char>(variant_etl));
       CHECK(!etl::holds_alternative<int>(variant_etl));
       CHECK(!etl::holds_alternative<std::string>(variant_etl));
 
-      CHECK(etl::holds_alternative<0U>(variant_etl));
+      CHECK(!etl::holds_alternative<0U>(variant_etl));
       CHECK(!etl::holds_alternative<1U>(variant_etl));
       CHECK(!etl::holds_alternative<2U>(variant_etl));
 
-      CHECK(etl::holds_alternative(0U, variant_etl));
+      CHECK(!etl::holds_alternative(0U, variant_etl));
       CHECK(!etl::holds_alternative(1U, variant_etl));
       CHECK(!etl::holds_alternative(2U, variant_etl));
       CHECK(!etl::holds_alternative(99U, variant_etl));
@@ -1830,7 +1830,7 @@ namespace
     //*************************************************************************
     TEST(test_variant_visit_void)
     {
-      etl::variant<int8_t, uint8_t> variant1;
+      etl::variant<int8_t, uint8_t> variant1 = int8_t{};
 
       bool       variant_was_signed{};
       auto const f = [&variant_was_signed](auto v)
@@ -1857,7 +1857,7 @@ namespace
 
       std::string result = "?";
 
-      etl::variant<TypeA, TypeB, TypeC, TypeD> package;
+      etl::variant<TypeA, TypeB, TypeC, TypeD> package = TypeA{};
 
       etl::visit(etl::overload
         {


### PR DESCRIPTION
Hi,

It seems variant_varadic still contains valid type_id when default constructed, 
initializing to `variant_npos` should resolve the issue.

Regards,
Manuel