### PR TITLE
Fix #832: Only copy/move storage value when optional is valid

### DIFF
--- a/include/etl/optional.h
+++ b/include/etl/optional.h
@@ -768,7 +768,10 @@ namespace etl
     {
       if (this != &other)
       {
-        storage.value = other.storage.value;
+        if (other.valid)
+        {
+          storage.value = other.storage.value;
+        }
         valid = other.valid;
       }
 
@@ -783,7 +786,10 @@ namespace etl
     {
       if (this != &other)
       {
-        storage.value = etl::move(other.storage.value);
+        if (other.valid)
+        {
+          storage.value = etl::move(other.storage.value);
+        }
         valid = other.valid;
       }
 


### PR DESCRIPTION
Copy and move assignment only copy storage if assigned optional is valid.