### PR TITLE
Adding constexpr to intrusive containers

### DIFF
--- a/include/etl/intrusive_forward_list.h
+++ b/include/etl/intrusive_forward_list.h
@@ -55,6 +55,7 @@ namespace etl
   {
   public:
 
+    ETL_CONSTEXPR
     intrusive_forward_list_exception(string_type reason_, string_type file_name_, numeric_type line_number_)
       : exception(reason_, file_name_, line_number_)
     {
@@ -69,6 +70,7 @@ namespace etl
   {
   public:
 
+    ETL_CONSTEXPR
     intrusive_forward_list_empty(string_type file_name_, numeric_type line_number_)
       : intrusive_forward_list_exception(ETL_ERROR_TEXT("intrusive_forward_list:empty", ETL_INTRUSIVE_FORWARD_LIST_FILE_ID"A"), file_name_, line_number_)
     {
@@ -83,6 +85,7 @@ namespace etl
   {
   public:
 
+    ETL_CONSTEXPR
     intrusive_forward_list_iterator_exception(string_type file_name_, numeric_type line_number_)
       : intrusive_forward_list_exception(ETL_ERROR_TEXT("intrusive_forward_list:iterator", ETL_INTRUSIVE_FORWARD_LIST_FILE_ID"B"), file_name_, line_number_)
     {
@@ -97,6 +100,7 @@ namespace etl
   {
   public:
 
+    ETL_CONSTEXPR
     intrusive_forward_list_index_exception(string_type file_name_, numeric_type line_number_)
       : intrusive_forward_list_exception(ETL_ERROR_TEXT("intrusive_forward_list:bounds", ETL_INTRUSIVE_FORWARD_LIST_FILE_ID"C"), file_name_, line_number_)
     {
@@ -111,6 +115,7 @@ namespace etl
   {
   public:
 
+    ETL_CONSTEXPR
     intrusive_forward_list_unsorted(string_type file_name_, numeric_type line_number_)
       : intrusive_forward_list_exception(ETL_ERROR_TEXT("intrusive_forward_list:unsorted", ETL_INTRUSIVE_FORWARD_LIST_FILE_ID"D"), file_name_, line_number_)
     {
@@ -125,6 +130,7 @@ namespace etl
   {
   public:
 
+    ETL_CONSTEXPR
     intrusive_forward_list_value_is_already_linked(string_type file_name_, numeric_type line_number_)
       : intrusive_forward_list_exception(ETL_ERROR_TEXT("intrusive_forward_list:value is already linked", ETL_INTRUSIVE_FORWARD_LIST_FILE_ID"E"), file_name_, line_number_)
     {
@@ -146,7 +152,7 @@ namespace etl
     //*************************************************************************
     /// Clears the intrusive_forward_list.
     //*************************************************************************
-    void clear()
+    ETL_CONSTEXPR14 void clear()
     {
       // Unlink all of the items.
       link_type* p_unlink = start.etl_next;
@@ -166,7 +172,7 @@ namespace etl
     /// If ETL_THROW_EXCEPTIONS & ETL_DEBUG are defined throws forward_list_iterator if the iterators are reversed.
     //*************************************************************************
     template <typename TIterator>
-    void assign(TIterator first, TIterator last)
+    ETL_CONSTEXPR14 void assign(TIterator first, TIterator last)
     {
 #if ETL_IS_DEBUG_BUILD
       intmax_t d = etl::distance(first, last);
@@ -194,7 +200,7 @@ namespace etl
     //*************************************************************************
     /// Pushes a value to the front of the intrusive_forward_list.
     //*************************************************************************
-    void push_front(link_type& value)
+    ETL_CONSTEXPR14 void push_front(link_type& value)
     {
       ETL_ASSERT_OR_RETURN(!value.is_linked(), ETL_ERROR(intrusive_forward_list_value_is_already_linked));
 
@@ -204,7 +210,7 @@ namespace etl
     //*************************************************************************
     /// Removes a value from the front of the intrusive_forward_list.
     //*************************************************************************
-    void pop_front()
+    ETL_CONSTEXPR14 void pop_front()
     {
 #if defined(ETL_CHECK_PUSH_POP)
       ETL_ASSERT_OR_RETURN(!empty(), ETL_ERROR(intrusive_forward_list_empty));
@@ -215,7 +221,7 @@ namespace etl
     //*************************************************************************
     /// Reverses the intrusive_forward_list.
     //*************************************************************************
-    void reverse()
+    ETL_CONSTEXPR14 void reverse()
     {
       if (is_trivial_list())
       {
@@ -240,7 +246,7 @@ namespace etl
     //*************************************************************************
     /// Returns true if the list has no elements.
     //*************************************************************************
-    bool empty() const
+    ETL_CONSTEXPR bool empty() const
     {
       return (current_size == 0);
     }
@@ -248,7 +254,7 @@ namespace etl
     //*************************************************************************
     /// Returns the number of elements.
     //*************************************************************************
-    size_t size() const
+    ETL_CONSTEXPR size_t size() const
     {
       return current_size;
     }
@@ -263,7 +269,7 @@ namespace etl
     //*************************************************************************
     /// Constructor
     //*************************************************************************
-    intrusive_forward_list_base()
+    ETL_CONSTEXPR14 intrusive_forward_list_base()
     {
       initialise();
     }
@@ -279,7 +285,7 @@ namespace etl
     //*************************************************************************
     /// Is the intrusive_forward_list a trivial length?
     //*************************************************************************
-    bool is_trivial_list() const
+    ETL_CONSTEXPR bool is_trivial_list() const
     {
       return (size() <= 1U);
     }
@@ -287,7 +293,7 @@ namespace etl
     //*************************************************************************
     /// Insert a link.
     //*************************************************************************
-    void insert_link_after(link_type& position, link_type& link)
+    ETL_CONSTEXPR14 void insert_link_after(link_type& position, link_type& link)
     {
       // Connect to the intrusive_forward_list.
       etl::link_splice<link_type>(position, link);
@@ -297,7 +303,7 @@ namespace etl
     //*************************************************************************
     /// Remove a link.
     //*************************************************************************
-    void remove_link_after(link_type& link)
+    ETL_CONSTEXPR14 void remove_link_after(link_type& link)
     {
       link_type* p_next = link.etl_next;
 
@@ -312,7 +318,7 @@ namespace etl
     //*************************************************************************
     /// Get the head link.
     //*************************************************************************
-    link_type* get_head()
+    ETL_CONSTEXPR14 link_type* get_head()
     {
       return start.etl_next;
     }
@@ -320,7 +326,7 @@ namespace etl
     //*************************************************************************
     /// Get the head link.
     //*************************************************************************
-    const link_type* get_head() const
+    ETL_CONSTEXPR14 const link_type* get_head() const
     {
       return start.etl_next;
     }
@@ -328,7 +334,7 @@ namespace etl
     //*************************************************************************
     /// Initialise the intrusive_forward_list.
     //*************************************************************************
-    void initialise()
+    ETL_CONSTEXPR14 void initialise()
     {
       start.etl_next = &terminator;
       current_size = 0;
@@ -371,24 +377,24 @@ namespace etl
       friend class intrusive_forward_list;
       friend class const_iterator;
 
-      iterator()
+      ETL_CONSTEXPR iterator()
         : p_value(ETL_NULLPTR)
       {
       }
 
-      iterator(const iterator& other)
+      ETL_CONSTEXPR iterator(const iterator& other)
         : p_value(other.p_value)
       {
       }
 
-      iterator& operator ++()
+      ETL_CONSTEXPR14 iterator& operator ++()
       {
         // Read the appropriate 'etl_next'.
         p_value = p_value->etl_next;
         return *this;
       }
 
-      iterator operator ++(int)
+      ETL_CONSTEXPR14 iterator operator ++(int)
       {
         iterator temp(*this);
         // Read the appropriate 'etl_next'.
@@ -396,40 +402,40 @@ namespace etl
         return temp;
       }
 
-      iterator& operator =(const iterator& other)
+      ETL_CONSTEXPR14 iterator& operator =(const iterator& other)
       {
         p_value = other.p_value;
         return *this;
       }
 
-      reference operator *() const
+      ETL_CONSTEXPR reference operator *() const
       {
         return *static_cast<pointer>(p_value);
       }
 
-      pointer operator &() const
+      ETL_CONSTEXPR pointer operator &() const
       {
         return static_cast<pointer>(p_value);
       }
 
-      pointer operator ->() const
+      ETL_CONSTEXPR pointer operator ->() const
       {
         return static_cast<pointer>(p_value);
       }
 
-      friend bool operator == (const iterator& lhs, const iterator& rhs)
+      ETL_CONSTEXPR friend bool operator == (const iterator& lhs, const iterator& rhs)
       {
         return lhs.p_value == rhs.p_value;
       }
 
-      friend bool operator != (const iterator& lhs, const iterator& rhs)
+      ETL_CONSTEXPR friend bool operator != (const iterator& lhs, const iterator& rhs)
       {
         return !(lhs == rhs);
       }
 
     private:
 
-      iterator(link_type* value)
+      ETL_CONSTEXPR iterator(link_type* value)
         : p_value(value)
       {
       }
@@ -446,29 +452,29 @@ namespace etl
 
       friend class intrusive_forward_list;
 
-      const_iterator()
+      ETL_CONSTEXPR const_iterator()
         : p_value(ETL_NULLPTR)
       {
       }
 
-      const_iterator(const typename intrusive_forward_list::iterator& other)
+      ETL_CONSTEXPR const_iterator(const typename intrusive_forward_list::iterator& other)
         : p_value(other.p_value)
       {
       }
 
-      const_iterator(const const_iterator& other)
+      ETL_CONSTEXPR const_iterator(const const_iterator& other)
         : p_value(other.p_value)
       {
       }
 
-      const_iterator& operator ++()
+      ETL_CONSTEXPR14 const_iterator& operator ++()
       {
         // Read the appropriate 'etl_next'.
         p_value = p_value->etl_next;
         return *this;
       }
 
-      const_iterator operator ++(int)
+      ETL_CONSTEXPR14 const_iterator operator ++(int)
       {
         const_iterator temp(*this);
         // Read the appropriate 'etl_next'.
@@ -476,40 +482,40 @@ namespace etl
         return temp;
       }
 
-      const_iterator& operator =(const const_iterator& other)
+      ETL_CONSTEXPR14 const_iterator& operator =(const const_iterator& other)
       {
         p_value = other.p_value;
         return *this;
       }
 
-      const_reference operator *() const
+      ETL_CONSTEXPR const_reference operator *() const
       {
         return *static_cast<const value_type*>(p_value);
       }
 
-      const_pointer operator &() const
+      ETL_CONSTEXPR const_pointer operator &() const
       {
         return static_cast<const value_type*>(p_value);
       }
 
-      const_pointer operator ->() const
+      ETL_CONSTEXPR const_pointer operator ->() const
       {
         return static_cast<const value_type*>(p_value);
       }
 
-      friend bool operator == (const const_iterator& lhs, const const_iterator& rhs)
+      ETL_CONSTEXPR friend bool operator == (const const_iterator& lhs, const const_iterator& rhs)
       {
         return lhs.p_value == rhs.p_value;
       }
 
-      friend bool operator != (const const_iterator& lhs, const const_iterator& rhs)
+      ETL_CONSTEXPR friend bool operator != (const const_iterator& lhs, const const_iterator& rhs)
       {
         return !(lhs == rhs);
       }
 
     private:
 
-      const_iterator(const link_type* value)
+      ETL_CONSTEXPR const_iterator(const link_type* value)
         : p_value(value)
       {
       }
@@ -522,7 +528,7 @@ namespace etl
     //*************************************************************************
     /// Constructor.
     //*************************************************************************
-    intrusive_forward_list()
+    ETL_CONSTEXPR intrusive_forward_list()
     {
     }
 
@@ -537,7 +543,7 @@ namespace etl
     /// Constructor from range
     //*************************************************************************
     template <typename TIterator>
-    intrusive_forward_list(TIterator first, TIterator last, typename etl::enable_if<!etl::is_integral<TIterator>::value, int>::type = 0)
+    ETL_CONSTEXPR14 intrusive_forward_list(TIterator first, TIterator last, typename etl::enable_if<!etl::is_integral<TIterator>::value, int>::type = 0)
     {
       this->assign(first, last);
     }
@@ -545,7 +551,7 @@ namespace etl
     //*************************************************************************
     /// Gets the beginning of the intrusive_forward_list.
     //*************************************************************************
-    iterator begin()
+    ETL_CONSTEXPR14 iterator begin()
     {
       return iterator(this->get_head());
     }
@@ -553,7 +559,7 @@ namespace etl
     //*************************************************************************
     /// Gets the beginning of the intrusive_forward_list.
     //*************************************************************************
-    const_iterator begin() const
+    ETL_CONSTEXPR14 const_iterator begin() const
     {
       return const_iterator(this->get_head());
     }
@@ -561,7 +567,7 @@ namespace etl
     //*************************************************************************
     /// Gets before the beginning of the intrusive_forward_list.
     //*************************************************************************
-    iterator before_begin()
+    ETL_CONSTEXPR14 iterator before_begin()
     {
       return iterator(&this->start);
     }
@@ -569,7 +575,7 @@ namespace etl
     //*************************************************************************
     /// Gets before the beginning of the intrusive_forward_list.
     //*************************************************************************
-    const_iterator before_begin() const
+    ETL_CONSTEXPR14 const_iterator before_begin() const
     {
       return const_iterator(&this->start);
     }
@@ -577,7 +583,7 @@ namespace etl
     //*************************************************************************
     /// Gets the beginning of the intrusive_forward_list.
     //*************************************************************************
-    const_iterator cbegin() const
+    ETL_CONSTEXPR14 const_iterator cbegin() const
     {
       return const_iterator(this->get_head());
     }
@@ -585,7 +591,7 @@ namespace etl
     //*************************************************************************
     /// Gets the end of the intrusive_forward_list.
     //*************************************************************************
-    iterator end()
+    ETL_CONSTEXPR14 iterator end()
     {
       return iterator(&this->terminator);
     }
@@ -593,7 +599,7 @@ namespace etl
     //*************************************************************************
     /// Gets the end of the intrusive_forward_list.
     //*************************************************************************
-    const_iterator end() const
+    ETL_CONSTEXPR14 const_iterator end() const
     {
       return const_iterator(&this->terminator);
     }
@@ -601,7 +607,7 @@ namespace etl
     //*************************************************************************
     /// Gets the end of the intrusive_forward_list.
     //*************************************************************************
-    const_iterator cend() const
+    ETL_CONSTEXPR14 const_iterator cend() const
     {
       return const_iterator(&this->terminator);
     }
@@ -609,7 +615,7 @@ namespace etl
     //*************************************************************************
     /// Gets a reference to the first element.
     //*************************************************************************
-    reference front()
+    ETL_CONSTEXPR14 reference front()
     {
       return *static_cast<pointer>(this->get_head());
     }
@@ -617,7 +623,7 @@ namespace etl
     //*************************************************************************
     /// Gets a const reference to the first element.
     //*************************************************************************
-    const_reference front() const
+    ETL_CONSTEXPR14 const_reference front() const
     {
       return *static_cast<const value_type*>(this->get_head());
     }
@@ -625,7 +631,7 @@ namespace etl
     //*************************************************************************
     /// Inserts a value to the intrusive_forward_list after the specified position.
     //*************************************************************************
-    iterator insert_after(iterator position, value_type& value)
+    ETL_CONSTEXPR14 iterator insert_after(iterator position, value_type& value)
     {
       ETL_ASSERT_OR_RETURN_VALUE(!value.link_type::is_linked(), ETL_ERROR(intrusive_forward_list_value_is_already_linked), iterator(&value));
 
@@ -637,7 +643,7 @@ namespace etl
     /// Inserts a range of values to the intrusive_forward_list after the specified position.
     //*************************************************************************
     template <typename TIterator>
-    void insert_after(iterator position, TIterator first, TIterator last)
+    ETL_CONSTEXPR14 void insert_after(iterator position, TIterator first, TIterator last)
     {
       while (first != last)
       {
@@ -653,7 +659,7 @@ namespace etl
     //*************************************************************************
     /// Erases the value at the specified position.
     //*************************************************************************
-    iterator erase_after(iterator position)
+    ETL_CONSTEXPR14 iterator erase_after(iterator position)
     {
       iterator next(position);
       if (next != end())
@@ -672,7 +678,7 @@ namespace etl
     //*************************************************************************
     /// Erases a range of elements.
     //*************************************************************************
-    iterator erase_after(iterator first, iterator last)
+    ETL_CONSTEXPR14 iterator erase_after(iterator first, iterator last)
     {
       if (first != end() && (first != last))
       {
@@ -715,7 +721,7 @@ namespace etl
     /// elements in the container.
     //*************************************************************************
     template <typename TIsEqual>
-    void unique(TIsEqual isEqual)
+    ETL_CONSTEXPR14 void unique(TIsEqual isEqual)
     {
       if (this->empty())
       {
@@ -745,7 +751,7 @@ namespace etl
     //*************************************************************************
     /// Sort using in-place merge sort algorithm.
     //*************************************************************************
-    void sort()
+    ETL_CONSTEXPR14 void sort()
     {
       sort(etl::less<value_type>());
     }
@@ -776,7 +782,7 @@ namespace etl
     /// SOFTWARE.
     //*************************************************************************
     template <typename TCompare>
-    void sort(TCompare compare)
+    ETL_CONSTEXPR14 void sort(TCompare compare)
     {
       iterator i_left;
       iterator i_right;
@@ -890,7 +896,7 @@ namespace etl
     //*************************************************************************
     // Removes the values specified.
     //*************************************************************************
-    void remove(const_reference value)
+    ETL_CONSTEXPR14 void remove(const_reference value)
     {
       iterator i_item = begin();
       iterator i_last_item = before_begin();
@@ -913,7 +919,7 @@ namespace etl
     /// Removes according to a predicate.
     //*************************************************************************
     template <typename TPredicate>
-    void remove_if(TPredicate predicate)
+    ETL_CONSTEXPR14 void remove_if(TPredicate predicate)
     {
       iterator i_item = begin();
       iterator i_last_item = before_begin();
@@ -935,7 +941,7 @@ namespace etl
     //*************************************************************************
     /// Splice another list into this one.
     //*************************************************************************
-    void splice_after(iterator position, etl::intrusive_forward_list<TValue, TLink>& other)
+    ETL_CONSTEXPR14 void splice_after(iterator position, etl::intrusive_forward_list<TValue, TLink>& other)
     {
       // No point splicing to ourself!
       if (&other != this)
@@ -970,7 +976,7 @@ namespace etl
     //*************************************************************************
     /// Splice an element from another list into this one.
     //*************************************************************************
-    void splice_after(iterator position, etl::intrusive_forward_list<TValue, TLink>& other, iterator isource)
+    ETL_CONSTEXPR14 void splice_after(iterator position, etl::intrusive_forward_list<TValue, TLink>& other, iterator isource)
     {
       link_type& before = *position.p_value;
 
@@ -987,7 +993,7 @@ namespace etl
     //*************************************************************************
     /// Splice a range of elements from another list into this one.
     //*************************************************************************
-    void splice_after(iterator position, etl::intrusive_forward_list<TValue, TLink>& other, iterator begin_, iterator end_)
+    ETL_CONSTEXPR14 void splice_after(iterator position, etl::intrusive_forward_list<TValue, TLink>& other, iterator begin_, iterator end_)
     {
       if (!other.empty())
       {
@@ -1020,7 +1026,7 @@ namespace etl
     //*************************************************************************
     /// Merge another list into this one. Both lists should be sorted.
     //*************************************************************************
-    void merge(list_type& other)
+    ETL_CONSTEXPR14 void merge(list_type& other)
     {
       merge(other, etl::less<value_type>());
     }
@@ -1029,7 +1035,7 @@ namespace etl
     /// Merge another list into this one. Both lists should be sorted.
     //*************************************************************************
     template <typename TCompare>
-    void merge(list_type& other, TCompare compare)
+    ETL_CONSTEXPR14 void merge(list_type& other, TCompare compare)
     {
       if ((this != &other) && !other.empty())
       {
@@ -1090,7 +1096,7 @@ namespace etl
     //*************************************************************************
     /// Get the next value.
     //*************************************************************************
-    link_type* get_next(link_type* link) const
+    ETL_CONSTEXPR link_type* get_next(link_type* link) const
     {
       return link->etl_next;
     }

--- a/include/etl/intrusive_links.h
+++ b/include/etl/intrusive_links.h
@@ -61,6 +61,7 @@ namespace etl
   {
   public:
 
+    ETL_CONSTEXPR14
     link_exception(string_type reason_, string_type file_name_, numeric_type line_number_)
       : exception(reason_, file_name_, line_number_)
     {
@@ -74,6 +75,7 @@ namespace etl
   {
   public:
 
+    ETL_CONSTEXPR14
     not_unlinked_exception(string_type file_name_, numeric_type line_number_)
       : link_exception(ETL_ERROR_TEXT("link:still linked", ETL_INTRUSIVE_LINKS_FILE_ID"A"), file_name_, line_number_)
     {
@@ -92,24 +94,28 @@ namespace etl
     };
 
     //***********************************
+    ETL_CONSTEXPR
     forward_link()
       : etl_next(ETL_NULLPTR)
     {
     }
 
     //***********************************
+    ETL_CONSTEXPR
     forward_link(forward_link* p_next)
       : etl_next(p_next)
     {
     }
 
     //***********************************
+    ETL_CONSTEXPR
     forward_link(const forward_link& other)
       : etl_next(other.etl_next)
     {
     }
 
     //***********************************
+    ETL_CONSTEXPR14
     forward_link& operator =(const forward_link& other)
     {
       etl_next = other.etl_next;
@@ -118,39 +124,42 @@ namespace etl
     }
 
     //***********************************
+    ETL_CONSTEXPR14
     void clear()
     {
       etl_next = ETL_NULLPTR;
     }
 
     //***********************************
-    ETL_NODISCARD
+    ETL_NODISCARD ETL_CONSTEXPR14
     bool is_linked() const
     {
       return etl_next != ETL_NULLPTR;
     }
 
     //***********************************
-    ETL_NODISCARD
+    ETL_NODISCARD ETL_CONSTEXPR14
     bool has_next() const
     {
       return etl_next != ETL_NULLPTR;
     }
 
     //***********************************
+    ETL_CONSTEXPR14
     void set_next(forward_link* n)
     {
       etl_next = n;
     }
 
     //***********************************
+    ETL_CONSTEXPR14
     void set_next(forward_link& n)
     {
       etl_next = &n;
     }
 
     //***********************************
-    ETL_NODISCARD
+    ETL_NODISCARD ETL_CONSTEXPR14
     forward_link* get_next() const
     {
       return etl_next;
@@ -177,6 +186,7 @@ namespace etl
   //***************************************************************************
   // Reference, Reference
   template <typename TLink>
+  ETL_CONSTEXPR14
   typename etl::enable_if<etl::is_forward_link<TLink>::value, void>::type
     link(TLink& lhs, TLink& rhs)
   {
@@ -186,6 +196,7 @@ namespace etl
   //***********************************
   // Pointer, Pointer
   template <typename TLink>
+  ETL_CONSTEXPR14
   typename etl::enable_if<etl::is_forward_link<TLink>::value, void>::type
     link(TLink* lhs, TLink* rhs)
   {
@@ -198,6 +209,7 @@ namespace etl
   //***********************************
   // Reference, Pointer
   template <typename TLink>
+  ETL_CONSTEXPR14
   typename etl::enable_if<etl::is_forward_link<TLink>::value, void>::type
     link(TLink& lhs, TLink* rhs)
   {
@@ -207,6 +219,7 @@ namespace etl
   //***********************************
   // Pointer, Reference
   template <typename TLink>
+  ETL_CONSTEXPR14
   typename etl::enable_if<etl::is_forward_link<TLink>::value, void>::type
     link(TLink* lhs, TLink& rhs)
   {
@@ -221,6 +234,7 @@ namespace etl
   //***************************************************************************
   // Reference, Reference
   template <typename TLink>
+  ETL_CONSTEXPR14
   typename etl::enable_if<etl::is_forward_link<TLink>::value, void>::type
     link_splice(TLink& lhs, TLink& rhs)
   {
@@ -231,6 +245,7 @@ namespace etl
   //***********************************
   // Pointer, Pointer
   template <typename TLink>
+  ETL_CONSTEXPR14
   typename etl::enable_if<etl::is_forward_link<TLink>::value, void>::type
     link_splice(TLink* lhs, TLink* rhs)
   {
@@ -248,6 +263,7 @@ namespace etl
   //***********************************
   // Reference, Pointer
   template <typename TLink>
+  ETL_CONSTEXPR14
   typename etl::enable_if<etl::is_forward_link<TLink>::value, void>::type
     link_splice(TLink& lhs, TLink* rhs)
   {
@@ -262,6 +278,7 @@ namespace etl
   //***********************************
   // Pointer, Reference
   template <typename TLink>
+  ETL_CONSTEXPR14
   typename etl::enable_if<etl::is_forward_link<TLink>::value, void>::type
     link_splice(TLink* lhs, TLink& rhs)
   {
@@ -275,6 +292,7 @@ namespace etl
   //***********************************
   // Reference, Reference, Reference
   template <typename TLink>
+  ETL_CONSTEXPR14
   typename etl::enable_if<etl::is_forward_link<TLink>::value, void>::type
     link_splice(TLink& lhs, TLink& first, TLink& last)
   {
@@ -285,6 +303,7 @@ namespace etl
   //***********************************
   // Pointer, Reference, Reference
   template <typename TLink>
+  ETL_CONSTEXPR14
   typename etl::enable_if<etl::is_forward_link<TLink>::value, void>::type
     link_splice(TLink* lhs, TLink& first, TLink& last)
   {
@@ -304,6 +323,7 @@ namespace etl
   //***************************************************************************
   // Reference
   template <typename TLink>
+  ETL_CONSTEXPR14
   typename etl::enable_if<etl::is_forward_link<TLink>::value, TLink*>::type
     unlink_after(TLink& node)
   {
@@ -321,6 +341,7 @@ namespace etl
   //***********************************
   // Reference, Reference
   template <typename TLink>
+  ETL_CONSTEXPR14
   typename etl::enable_if<etl::is_forward_link<TLink>::value, TLink*>::type
     unlink_after(TLink& before, TLink& last)
   {
@@ -337,6 +358,7 @@ namespace etl
 
   // Reference
   template <typename TLink>
+  ETL_CONSTEXPR14
   typename etl::enable_if<etl::is_forward_link<TLink>::value, bool>::type
     is_linked(TLink& node)
   {
@@ -345,6 +367,7 @@ namespace etl
 
   // Pointer
   template <typename TLink>
+  ETL_CONSTEXPR14
   typename etl::enable_if<etl::is_forward_link<TLink>::value, bool>::type
     is_linked(TLink* node)
   {
@@ -356,6 +379,7 @@ namespace etl
   //***************************************************************************
   // Reference
   template <typename TLink>
+  ETL_CONSTEXPR14
   typename etl::enable_if<etl::is_forward_link<TLink>::value, void>::type
     link_clear(TLink& start)
   {
@@ -365,6 +389,7 @@ namespace etl
   //***********************************
   // Pointer
   template <typename TLink>
+  ETL_CONSTEXPR14
   typename etl::enable_if<etl::is_forward_link<TLink>::value, void>::type
     link_clear(TLink* start)
   {
@@ -379,6 +404,7 @@ namespace etl
   //***************************************************************************
   // Reference
   template <typename TLink>
+  ETL_CONSTEXPR14
   typename etl::enable_if<etl::is_forward_link<TLink>::value, void>::type
     link_clear_range(TLink& start)
   {
@@ -395,6 +421,7 @@ namespace etl
   //***********************************
   // Pointer
   template <typename TLink>
+  ETL_CONSTEXPR14
   typename etl::enable_if<etl::is_forward_link<TLink>::value, void>::type
     link_clear_range(TLink* start)
   {
@@ -416,28 +443,28 @@ namespace etl
     };
 
     //***********************************
-    bidirectional_link()
+    ETL_CONSTEXPR14 bidirectional_link()
       : etl_previous(ETL_NULLPTR)
       , etl_next(ETL_NULLPTR)
     {
     }
 
     //***********************************
-    bidirectional_link(bidirectional_link* p_previous, bidirectional_link* p_next)
+    ETL_CONSTEXPR14 bidirectional_link(bidirectional_link* p_previous, bidirectional_link* p_next)
       : etl_previous(p_previous)
       , etl_next(p_next)
     {
     }
 
     //***********************************
-    bidirectional_link(const bidirectional_link& other)
+    ETL_CONSTEXPR14 bidirectional_link(const bidirectional_link& other)
       : etl_previous(other.etl_previous)
       , etl_next(other.etl_next)
     {
     }
 
     //***********************************
-    bidirectional_link& operator =(const bidirectional_link& other)
+    ETL_CONSTEXPR14 bidirectional_link& operator =(const bidirectional_link& other)
     {
       etl_previous = other.etl_previous;
       etl_next     = other.etl_next;
@@ -446,72 +473,77 @@ namespace etl
     }
 
     //***********************************
-    void clear()
+    ETL_CONSTEXPR14 void clear()
     {
       etl_previous = ETL_NULLPTR;
       etl_next     = ETL_NULLPTR;
     }
 
     //***********************************
-    ETL_NODISCARD
+    ETL_NODISCARD ETL_CONSTEXPR14
     bool is_linked() const
     {
       return (etl_previous != ETL_NULLPTR) || (etl_next != ETL_NULLPTR);
     }
 
     //***********************************
-    ETL_NODISCARD
+    ETL_NODISCARD ETL_CONSTEXPR14
     bool has_next() const
     {
       return etl_next != ETL_NULLPTR;
     }
 
     //***********************************
-    ETL_NODISCARD
+    ETL_NODISCARD ETL_CONSTEXPR14
     bool has_previous() const
     {
       return etl_previous != ETL_NULLPTR;
     }
 
     //***********************************
+    ETL_CONSTEXPR14
     void set_next(bidirectional_link* n)
     {
       etl_next = n;
     }
 
     //***********************************
+    ETL_CONSTEXPR14
     void set_next(bidirectional_link& n)
     {
       etl_next = &n;
     }
 
     //***********************************
-    ETL_NODISCARD
+    ETL_NODISCARD ETL_CONSTEXPR14
     bidirectional_link* get_next() const
     {
       return etl_next;
     }
 
     //***********************************
+    ETL_CONSTEXPR14
     void set_previous(bidirectional_link* n)
     {
       etl_previous = n;
     }
 
     //***********************************
+    ETL_CONSTEXPR14
     void set_previous(bidirectional_link& n)
     {
       etl_previous = &n;
     }
 
     //***********************************
-    ETL_NODISCARD
+    ETL_NODISCARD ETL_CONSTEXPR14
     bidirectional_link* get_previous() const
     {
       return etl_previous;
     }
 
     //***********************************
+    ETL_CONSTEXPR14
     void reverse()
     {
       using ETL_OR_STD::swap; // Allow ADL
@@ -519,6 +551,7 @@ namespace etl
     }
 
     //***********************************
+    ETL_CONSTEXPR14
     void unlink()
     {
       // Connect the previous link with the next.
@@ -558,6 +591,7 @@ namespace etl
   //***************************************************************************
   // Reference, Reference
   template <typename TLink>
+  ETL_CONSTEXPR14
   typename etl::enable_if<etl::is_same<TLink, etl::bidirectional_link<TLink::ID> >::value, void>::type
     link(TLink& lhs, TLink& rhs)
   {
@@ -568,6 +602,7 @@ namespace etl
   //***********************************
   // Pointer, Pointer
   template <typename TLink>
+  ETL_CONSTEXPR14
   typename etl::enable_if<etl::is_same<TLink, etl::bidirectional_link<TLink::ID> >::value, void>::type
     link(TLink* lhs, TLink* rhs)
   {
@@ -585,6 +620,7 @@ namespace etl
   //***********************************
   // Reference, Pointer
   template <typename TLink>
+  ETL_CONSTEXPR14
   typename etl::enable_if<etl::is_same<TLink, etl::bidirectional_link<TLink::ID> >::value, void>::type
     link(TLink& lhs, TLink* rhs)
   {
@@ -599,6 +635,7 @@ namespace etl
   //***********************************
   // Pointer, Reference
   template <typename TLink>
+  ETL_CONSTEXPR14
   typename etl::enable_if<etl::is_same<TLink, etl::bidirectional_link<TLink::ID> >::value, void>::type
     link(TLink* lhs, TLink& rhs)
   {
@@ -613,6 +650,7 @@ namespace etl
   //***********************************
   // Reference, Reference
   template <typename TLink>
+  ETL_CONSTEXPR14
   typename etl::enable_if<etl::is_same<TLink, etl::bidirectional_link<TLink::ID> >::value, void>::type
     link_splice(TLink& lhs, TLink& rhs)
   {
@@ -632,6 +670,7 @@ namespace etl
   //***************************************************************************
   // Pointer, Pointer
   template <typename TLink>
+  ETL_CONSTEXPR14
   typename etl::enable_if<etl::is_same<TLink, etl::bidirectional_link<TLink::ID> >::value, void>::type
     link_splice(TLink* lhs, TLink* rhs)
   {
@@ -659,6 +698,7 @@ namespace etl
   //***********************************
   // Reference, Pointer
   template <typename TLink>
+  ETL_CONSTEXPR14
   typename etl::enable_if<etl::is_same<TLink, etl::bidirectional_link<TLink::ID> >::value, void>::type
     link_splice(TLink& lhs, TLink* rhs)
   {
@@ -679,6 +719,7 @@ namespace etl
   //***********************************
   // Pointer, Reference
   template <typename TLink>
+  ETL_CONSTEXPR14
   typename etl::enable_if<etl::is_same<TLink, etl::bidirectional_link<TLink::ID> >::value, void>::type
     link_splice(TLink* lhs, TLink& rhs)
   {
@@ -703,6 +744,7 @@ namespace etl
   //***********************************
   // Reference, Reference, Reference
   template <typename TLink>
+  ETL_CONSTEXPR14
   typename etl::enable_if<etl::is_same<TLink, etl::bidirectional_link<TLink::ID> >::value, void>::type
     link_splice(TLink& lhs, TLink& first, TLink& last)
   {
@@ -720,6 +762,7 @@ namespace etl
   //***********************************
   // Pointer, Reference, Reference
   template <typename TLink>
+  ETL_CONSTEXPR14
   typename etl::enable_if<etl::is_same<TLink, etl::bidirectional_link<TLink::ID> >::value, void>::type
     link_splice(TLink* lhs, TLink& first, TLink& last)
   {
@@ -750,6 +793,7 @@ namespace etl
   //***************************************************************************
   // Reference
   template <typename TLink>
+  ETL_CONSTEXPR14
   typename etl::enable_if<etl::is_same<TLink, etl::bidirectional_link<TLink::ID> >::value, void>::type
     unlink(TLink& node)
   {
@@ -759,6 +803,7 @@ namespace etl
   //***********************************
   // Reference Reference
   template <typename TLink>
+  ETL_CONSTEXPR14
   typename etl::enable_if<etl::is_same<TLink, etl::bidirectional_link<TLink::ID> >::value, TLink&>::type
     unlink(TLink& first, TLink& last)
   {
@@ -788,6 +833,7 @@ namespace etl
 
   // Reference
   template <typename TLink>
+  ETL_CONSTEXPR14
   typename etl::enable_if<etl::is_same<TLink, etl::bidirectional_link<TLink::ID> >::value, bool>::type
     is_linked(TLink& node)
   {
@@ -796,6 +842,7 @@ namespace etl
 
   // Pointer
   template <typename TLink>
+  ETL_CONSTEXPR14
   typename etl::enable_if<etl::is_same<TLink, etl::bidirectional_link<TLink::ID> >::value, bool>::type
     is_linked(TLink* node)
   {
@@ -807,6 +854,7 @@ namespace etl
   //***************************************************************************
   // Reference
   template <typename TLink>
+  ETL_CONSTEXPR14
   typename etl::enable_if<etl::is_same<TLink, etl::bidirectional_link<TLink::ID> >::value, void>::type
     link_clear_range(TLink& start)
   {
@@ -823,6 +871,7 @@ namespace etl
   //***********************************
   // Pointer
   template <typename TLink>
+  ETL_CONSTEXPR14
   typename etl::enable_if<etl::is_same<TLink, etl::bidirectional_link<TLink::ID> >::value, void>::type
     link_clear_range(TLink* start)
   {
@@ -841,7 +890,7 @@ namespace etl
       };
 
       //***********************************
-      tree_link()
+      ETL_CONSTEXPR14 tree_link()
         : etl_parent(ETL_NULLPTR)
         , etl_left(ETL_NULLPTR)
         , etl_right(ETL_NULLPTR)
@@ -849,7 +898,7 @@ namespace etl
       }
 
       //***********************************
-      tree_link(tree_link* p_parent, tree_link* p_left, tree_link* p_right)
+      ETL_CONSTEXPR14 tree_link(tree_link* p_parent, tree_link* p_left, tree_link* p_right)
         : etl_parent(p_parent)
         , etl_left(p_left)
         , etl_right(p_right)
@@ -857,7 +906,7 @@ namespace etl
       }
 
       //***********************************
-      tree_link(const tree_link& other)
+      ETL_CONSTEXPR14 tree_link(const tree_link& other)
         : etl_parent(other.etl_parent)
         , etl_left(other.etl_left)
         , etl_right(other.etl_right)
@@ -865,7 +914,7 @@ namespace etl
       }
 
       //***********************************
-      tree_link& operator =(const tree_link& other)
+      ETL_CONSTEXPR14 tree_link& operator =(const tree_link& other)
       {
         etl_parent = other.etl_parent;
         etl_left   = other.etl_left;
@@ -875,7 +924,7 @@ namespace etl
       }
 
       //***********************************
-      void clear()
+      ETL_CONSTEXPR14 void clear()
       {
         etl_parent = ETL_NULLPTR;
         etl_left   = ETL_NULLPTR;
@@ -883,63 +932,69 @@ namespace etl
       }
 
       //***********************************
-      bool is_linked() const
+      ETL_CONSTEXPR14 bool is_linked() const
       {
         return (etl_parent != ETL_NULLPTR) || (etl_left != ETL_NULLPTR) || (etl_right != ETL_NULLPTR);
       }
 
       //***********************************
-      ETL_NODISCARD
+      ETL_NODISCARD ETL_CONSTEXPR14
       bool has_parent() const
       {
         return etl_parent != ETL_NULLPTR;
       }
 
       //***********************************
-      ETL_NODISCARD
+      ETL_NODISCARD ETL_CONSTEXPR14
       bool has_left() const
       {
         return etl_left != ETL_NULLPTR;
       }
 
       //***********************************
-      ETL_NODISCARD
+      ETL_NODISCARD ETL_CONSTEXPR14
       bool has_right() const
       {
         return etl_right != ETL_NULLPTR;
       }
 
       //***********************************
+      ETL_CONSTEXPR14
       void set_parent(tree_link* p)
       {
         etl_parent = p;
       }
 
       //***********************************
+      ETL_CONSTEXPR14
       void set_left(tree_link* l)
       {
         etl_left = l;
       }
 
       //***********************************
+      ETL_CONSTEXPR14
       void set_right(tree_link* r)
       {
         etl_right = r;
       }
 
       //***********************************
+      ETL_CONSTEXPR14
       void set_parent(tree_link& p)
       {
         etl_parent = &p;
       }
 
       //***********************************
+      ETL_CONSTEXPR14
       void set_left(tree_link& l)
       {
         etl_left = &l;
       }
 
       //***********************************
+      ETL_CONSTEXPR14
       void set_right(tree_link& r)
       {
         etl_right = &r;
@@ -953,20 +1008,21 @@ namespace etl
       }
 
       //***********************************
-      ETL_NODISCARD
+      ETL_NODISCARD ETL_CONSTEXPR14
       tree_link* get_left() const
       {
         return etl_left;
       }
 
       //***********************************
-      ETL_NODISCARD
+      ETL_NODISCARD ETL_CONSTEXPR14
       tree_link* get_right() const
       {
         return etl_right;
       }
 
       //***********************************
+      ETL_CONSTEXPR14
       void mirror()
       {
         using ETL_OR_STD::swap;
@@ -997,6 +1053,7 @@ namespace etl
   //***************************************************************************
   // Reference, Reference
   template <typename TLink>
+  ETL_CONSTEXPR14
   typename etl::enable_if<etl::is_same<TLink, etl::tree_link<TLink::ID> >::value, void>::type
     link_left(TLink& parent, TLink& leaf)
   {
@@ -1007,6 +1064,7 @@ namespace etl
   //***********************************
   // Pointer, Pointer
   template <typename TLink>
+  ETL_CONSTEXPR14
   typename etl::enable_if<etl::is_same<TLink, etl::tree_link<TLink::ID> >::value, void>::type
     link_left(TLink* parent, TLink* leaf)
   {
@@ -1024,6 +1082,7 @@ namespace etl
   //***********************************
   // Reference, Pointer
   template <typename TLink>
+  ETL_CONSTEXPR14
   typename etl::enable_if<etl::is_same<TLink, etl::tree_link<TLink::ID> >::value, void>::type
     link_left(TLink& parent, TLink* leaf)
   {
@@ -1038,6 +1097,7 @@ namespace etl
   //***********************************
   // Pointer, Reference
   template <typename TLink>
+  ETL_CONSTEXPR14
   typename etl::enable_if<etl::is_same<TLink, etl::tree_link<TLink::ID> >::value, void>::type
     link_left(TLink* parent, TLink& leaf)
   {
@@ -1054,6 +1114,7 @@ namespace etl
   // Sets the right link.
   //***************************************************************************
   template <typename TLink>
+  ETL_CONSTEXPR14
   typename etl::enable_if<etl::is_same<TLink, etl::tree_link<TLink::ID> >::value, void>::type
     link_right(TLink& parent, TLink& leaf)
   {
@@ -1063,6 +1124,7 @@ namespace etl
 
   //***********************************
   template <typename TLink>
+  ETL_CONSTEXPR14
   typename etl::enable_if<etl::is_same<TLink, etl::tree_link<TLink::ID> >::value, void>::type
     link_right(TLink* parent, TLink* leaf)
   {
@@ -1079,6 +1141,7 @@ namespace etl
 
   //***********************************
   template <typename TLink>
+  ETL_CONSTEXPR14
   typename etl::enable_if<etl::is_same<TLink, etl::tree_link<TLink::ID> >::value, void>::type
     link_right(TLink& parent, TLink* leaf)
   {
@@ -1092,6 +1155,7 @@ namespace etl
 
   //***********************************
   template <typename TLink>
+  ETL_CONSTEXPR14
   typename etl::enable_if<etl::is_same<TLink, etl::tree_link<TLink::ID> >::value, void>::type
     link_right(TLink* parent, TLink& leaf)
   {
@@ -1108,6 +1172,7 @@ namespace etl
   //***************************************************************************
   // Reference, Reference
   template <typename TLink>
+  ETL_CONSTEXPR14
   typename etl::enable_if<etl::is_same<TLink, etl::tree_link<TLink::ID> >::value, void>::type
     link_rotate_left(TLink& parent, TLink& leaf)
   {
@@ -1126,6 +1191,7 @@ namespace etl
   //***********************************
   // Pointer, Pointer
   template <typename TLink>
+  ETL_CONSTEXPR14
   typename etl::enable_if<etl::is_same<TLink, etl::tree_link<TLink::ID> >::value, void>::type
     link_rotate_left(TLink* parent, TLink* leaf)
   {
@@ -1138,6 +1204,7 @@ namespace etl
   //***********************************
   // Reference, Pointer
   template <typename TLink>
+  ETL_CONSTEXPR14
   typename etl::enable_if<etl::is_same<TLink, etl::tree_link<TLink::ID> >::value, void>::type
     link_rotate_left(TLink& parent, TLink* leaf)
   {
@@ -1150,6 +1217,7 @@ namespace etl
   //***********************************
   // Pointer, Reference
   template <typename TLink>
+  ETL_CONSTEXPR14
   typename etl::enable_if<etl::is_same<TLink, etl::tree_link<TLink::ID> >::value, void>::type
     link_rotate_left(TLink* parent, TLink& leaf)
   {
@@ -1163,6 +1231,7 @@ namespace etl
   // link_rotate_right
   //***************************************************************************
   template <typename TLink>
+  ETL_CONSTEXPR14
   typename etl::enable_if<etl::is_same<TLink, etl::tree_link<TLink::ID> >::value, void>::type
     link_rotate_right(TLink& parent, TLink& leaf)
   {
@@ -1180,6 +1249,7 @@ namespace etl
 
  
   template <typename TLink>
+  ETL_CONSTEXPR14
   typename etl::enable_if<etl::is_same<TLink, etl::tree_link<TLink::ID> >::value, void>::type
     link_rotate_right(TLink* parent, TLink* leaf)
   {
@@ -1190,6 +1260,7 @@ namespace etl
   }
 
   template <typename TLink>
+  ETL_CONSTEXPR14
   typename etl::enable_if<etl::is_same<TLink, etl::tree_link<TLink::ID> >::value, void>::type
     link_rotate_right(TLink& parent, TLink* leaf)
   {
@@ -1201,6 +1272,7 @@ namespace etl
 
   //***********************************
   template <typename TLink>
+  ETL_CONSTEXPR14
   typename etl::enable_if<etl::is_same<TLink, etl::tree_link<TLink::ID> >::value, void>::type
     link_rotate_right(TLink* parent, TLink& leaf)
   {
@@ -1216,6 +1288,7 @@ namespace etl
   // Reference, Reference
   /// Automatically detects whether a left or right rotate is expected.
   template <typename TLink>
+  ETL_CONSTEXPR14
   typename etl::enable_if<etl::is_same<TLink, etl::tree_link<TLink::ID> >::value, void>::type
     link_rotate(TLink& parent, TLink& leaf)
   {
@@ -1233,6 +1306,7 @@ namespace etl
   // Pointer, Pointer
   /// Automatically detects whether a left or right rotate is expected.
   template <typename TLink>
+  ETL_CONSTEXPR14
   typename etl::enable_if<etl::is_same<TLink, etl::tree_link<TLink::ID> >::value, void>::type
     link_rotate(TLink* parent, TLink* leaf)
   {
@@ -1253,6 +1327,7 @@ namespace etl
   // Reference, Pointer
   /// Automatically detects whether a left or right rotate is expected.
   template <typename TLink>
+  ETL_CONSTEXPR14
   typename etl::enable_if<etl::is_same<TLink, etl::tree_link<TLink::ID> >::value, void>::type
     link_rotate(TLink& parent, TLink* leaf)
   {
@@ -1273,6 +1348,7 @@ namespace etl
   // Pointer, Reference
   /// Automatically detects whether a left or right rotate is expected.
   template <typename TLink>
+  ETL_CONSTEXPR14
   typename etl::enable_if<etl::is_same<TLink, etl::tree_link<TLink::ID> >::value, void>::type
     link_rotate(TLink* parent, TLink& leaf)
   {
@@ -1291,6 +1367,7 @@ namespace etl
 
   // Reference
   template <typename TLink>
+  ETL_CONSTEXPR14
   typename etl::enable_if<etl::is_same<TLink, etl::tree_link<TLink::ID> >::value, void>::type
     link_clear(TLink& node)
   {
@@ -1299,6 +1376,7 @@ namespace etl
 
   // Pointer
   template <typename TLink>
+  ETL_CONSTEXPR14
   typename etl::enable_if<etl::is_same<TLink, etl::tree_link<TLink::ID> >::value, void>::type
     link_clear(TLink* node)
   {
@@ -1307,6 +1385,7 @@ namespace etl
 
   // Reference
   template <typename TLink>
+  ETL_CONSTEXPR14
   typename etl::enable_if<etl::is_same<TLink, etl::tree_link<TLink::ID> >::value, bool>::type
     is_linked(TLink& node)
   {
@@ -1315,6 +1394,7 @@ namespace etl
 
   // Pointer
   template <typename TLink>
+  ETL_CONSTEXPR14
   typename etl::enable_if<etl::is_same<TLink, etl::tree_link<TLink::ID> >::value, bool>::type
     is_linked(TLink* node)
   {

--- a/include/etl/intrusive_list.h
+++ b/include/etl/intrusive_list.h
@@ -56,6 +56,7 @@ namespace etl
   {
   public:
 
+    ETL_CONSTEXPR
     intrusive_list_exception(string_type reason_, string_type file_name_, numeric_type line_number_)
       : exception(reason_, file_name_, line_number_)
     {
@@ -70,6 +71,7 @@ namespace etl
   {
   public:
 
+    ETL_CONSTEXPR
     intrusive_list_empty(string_type file_name_, numeric_type line_number_)
       : intrusive_list_exception(ETL_ERROR_TEXT("intrusive_list:empty", ETL_INTRUSIVE_LIST_FILE_ID"A"), file_name_, line_number_)
     {
@@ -84,6 +86,7 @@ namespace etl
   {
   public:
 
+    ETL_CONSTEXPR
     intrusive_list_iterator_exception(string_type file_name_, numeric_type line_number_)
       : intrusive_list_exception(ETL_ERROR_TEXT("intrusive_list:iterator", ETL_INTRUSIVE_LIST_FILE_ID"B"), file_name_, line_number_)
     {
@@ -98,6 +101,7 @@ namespace etl
   {
   public:
 
+    ETL_CONSTEXPR
     intrusive_list_unsorted(string_type file_name_, numeric_type line_number_)
       : intrusive_list_exception(ETL_ERROR_TEXT("intrusive_list:unsorted", ETL_INTRUSIVE_LIST_FILE_ID"C"), file_name_, line_number_)
     {
@@ -112,6 +116,7 @@ namespace etl
   {
   public:
 
+    ETL_CONSTEXPR
     intrusive_list_value_is_already_linked(string_type file_name_, numeric_type line_number_)
       : intrusive_list_exception(ETL_ERROR_TEXT("intrusive_list:value is already linked", ETL_INTRUSIVE_LIST_FILE_ID"E"), file_name_, line_number_)
     {
@@ -136,7 +141,7 @@ namespace etl
     /// intrusive_list_iterator_exception if the iterators are reversed.
     //*************************************************************************
     template <typename TIterator>
-    void assign(TIterator first, TIterator last)
+    ETL_CONSTEXPR14 void assign(TIterator first, TIterator last)
     {
 #if ETL_IS_DEBUG_BUILD
       intmax_t d = etl::distance(first, last);
@@ -160,7 +165,7 @@ namespace etl
     //*************************************************************************
     /// Pushes a value to the front of the intrusive_list.
     //*************************************************************************
-    void push_front(link_type& value)
+    ETL_CONSTEXPR14 void push_front(link_type& value)
     {
       ETL_ASSERT_OR_RETURN(!value.is_linked(), ETL_ERROR(intrusive_list_value_is_already_linked));
 
@@ -170,7 +175,7 @@ namespace etl
     //*************************************************************************
     /// Removes a value from the front of the intrusive_list.
     //*************************************************************************
-    void pop_front()
+    ETL_CONSTEXPR14 void pop_front()
     {
 #if defined(ETL_CHECK_PUSH_POP)
       ETL_ASSERT(!empty(), ETL_ERROR(intrusive_list_empty));
@@ -181,7 +186,7 @@ namespace etl
     //*************************************************************************
     /// Pushes a value to the back of the intrusive_list.
     //*************************************************************************
-    void push_back(link_type& value)
+    ETL_CONSTEXPR14 void push_back(link_type& value)
     {
       ETL_ASSERT_OR_RETURN(!value.is_linked(), ETL_ERROR(intrusive_list_value_is_already_linked));
 
@@ -191,7 +196,7 @@ namespace etl
     //*************************************************************************
     /// Removes a value from the back of the intrusive_list.
     //*************************************************************************
-    void pop_back()
+    ETL_CONSTEXPR14 void pop_back()
     {
 #if defined(ETL_CHECK_PUSH_POP)
       ETL_ASSERT(!empty(), ETL_ERROR(intrusive_list_empty));
@@ -202,7 +207,7 @@ namespace etl
     //*************************************************************************
     /// Clears the intrusive_list.
     //*************************************************************************
-    void clear()
+    ETL_CONSTEXPR14 void clear()
     {
       // Unlink all of the items.
       link_type* p_unlink = terminal_link.etl_next;
@@ -220,7 +225,7 @@ namespace etl
     //*************************************************************************
     /// Reverses the list.
     //*************************************************************************
-    void reverse()
+    ETL_CONSTEXPR void reverse()
     {
       if (is_trivial_list())
       {
@@ -242,7 +247,7 @@ namespace etl
     //*************************************************************************
     /// Returns true if the list has no elements.
     //*************************************************************************
-    bool empty() const
+    ETL_CONSTEXPR bool empty() const
     {
       return (terminal_link.link_type::etl_next == &terminal_link);
     }
@@ -250,7 +255,7 @@ namespace etl
     //*************************************************************************
     /// Returns the number of elements.
     //*************************************************************************
-    size_t size() const
+    ETL_CONSTEXPR size_t size() const
     {
       return current_size;
     }
@@ -272,7 +277,7 @@ namespace etl
     //*************************************************************************
     /// Is the intrusive_list a trivial length?
     //*************************************************************************
-    bool is_trivial_list() const
+    ETL_CONSTEXPR bool is_trivial_list() const
     {
       return (terminal_link.link_type::etl_next == &terminal_link) || (terminal_link.link_type::etl_next->etl_next == &terminal_link);
     }
@@ -280,7 +285,7 @@ namespace etl
     //*************************************************************************
     /// Insert a link.
     //*************************************************************************
-    void insert_link(link_type& previous, link_type& new_link)
+    ETL_CONSTEXPR14 void insert_link(link_type& previous, link_type& new_link)
     {
       // Connect to the intrusive_list.
       etl::link_splice<link_type>(previous, new_link);
@@ -290,7 +295,7 @@ namespace etl
     //*************************************************************************
     /// Insert a link.
     //*************************************************************************
-    void insert_link(link_type* previous, link_type& new_link)
+    ETL_CONSTEXPR14 void insert_link(link_type* previous, link_type& new_link)
     {
       // Connect to the intrusive_list.
       etl::link_splice<link_type>(previous, new_link);
@@ -300,7 +305,7 @@ namespace etl
     //*************************************************************************
     /// Insert a link.
     //*************************************************************************
-    void insert_link(link_type& previous, link_type* new_link)
+    ETL_CONSTEXPR14 void insert_link(link_type& previous, link_type* new_link)
     {
       // Connect to the intrusive_list.
       etl::link_splice<link_type>(previous, new_link);
@@ -310,7 +315,7 @@ namespace etl
     //*************************************************************************
     /// Insert a link.
     //*************************************************************************
-    void insert_link(link_type* previous, link_type* new_link)
+    ETL_CONSTEXPR14 void insert_link(link_type* previous, link_type* new_link)
     {
       // Connect to the intrusive_list.
       etl::link_splice<link_type>(previous, new_link);
@@ -320,7 +325,7 @@ namespace etl
     //*************************************************************************
     /// Remove a link.
     //*************************************************************************
-    void remove_link(link_type& link)
+    ETL_CONSTEXPR14 void remove_link(link_type& link)
     {
       etl::unlink<link_type>(link);
       --current_size;
@@ -329,7 +334,7 @@ namespace etl
     //*************************************************************************
     /// Remove a link.
     //*************************************************************************
-    void remove_link(link_type* link)
+    ETL_CONSTEXPR14 void remove_link(link_type* link)
     {
       etl::unlink<link_type>(*link);
       --current_size;
@@ -338,7 +343,7 @@ namespace etl
     //*************************************************************************
     /// Get the head link.
     //*************************************************************************
-    link_type* get_head()
+    ETL_CONSTEXPR14 link_type* get_head()
     {
       return terminal_link.etl_next;
     }
@@ -346,7 +351,7 @@ namespace etl
     //*************************************************************************
     /// Get the head link.
     //*************************************************************************
-    const link_type* get_head() const
+    ETL_CONSTEXPR14 const link_type* get_head() const
     {
       return terminal_link.etl_next;
     }
@@ -354,7 +359,7 @@ namespace etl
     //*************************************************************************
     /// Get the tail link.
     //*************************************************************************
-    link_type* get_tail()
+    ETL_CONSTEXPR14 link_type* get_tail()
     {
       return terminal_link.etl_previous;
     }
@@ -362,7 +367,7 @@ namespace etl
     //*************************************************************************
     /// Get the tail link.
     //*************************************************************************
-    const link_type* get_tail() const
+    ETL_CONSTEXPR14 const link_type* get_tail() const
     {
       return terminal_link.etl_previous;
     }
@@ -370,7 +375,7 @@ namespace etl
     //*************************************************************************
     /// Initialise the intrusive_list.
     //*************************************************************************
-    void initialise()
+    ETL_CONSTEXPR14 void initialise()
     {
       etl::link(terminal_link, terminal_link);
       current_size = 0;
@@ -410,24 +415,24 @@ namespace etl
       friend class intrusive_list;
       friend class const_iterator;
 
-      iterator()
+      ETL_CONSTEXPR iterator()
         : p_value(ETL_NULLPTR)
       {
       }
 
-      iterator(const iterator& other)
+      ETL_CONSTEXPR iterator(const iterator& other)
         : p_value(other.p_value)
       {
       }
 
-      iterator& operator ++()
+      ETL_CONSTEXPR14 iterator& operator ++()
       {
         // Read the appropriate 'etl_next'.
         p_value = p_value->etl_next;
         return *this;
       }
 
-      iterator operator ++(int)
+      ETL_CONSTEXPR14 iterator operator ++(int)
       {
         iterator temp(*this);
         // Read the appropriate 'etl_next'.
@@ -435,14 +440,14 @@ namespace etl
         return temp;
       }
 
-      iterator& operator --()
+      ETL_CONSTEXPR14 iterator& operator --()
       {
         // Read the appropriate 'etl_previous'.
         p_value = p_value->etl_previous;
         return *this;
       }
 
-      iterator operator --(int)
+      ETL_CONSTEXPR14 iterator operator --(int)
       {
         iterator temp(*this);
         // Read the appropriate 'etl_previous'.
@@ -450,40 +455,40 @@ namespace etl
         return temp;
       }
 
-      iterator& operator =(const iterator& other)
+      ETL_CONSTEXPR14 iterator& operator =(const iterator& other)
       {
         p_value = other.p_value;
         return *this;
       }
 
-      reference operator *() const
+      ETL_CONSTEXPR reference operator *() const
       {
         return *static_cast<pointer>(p_value);
       }
 
-      pointer operator &() const
+      ETL_CONSTEXPR pointer operator &() const
       {
         return static_cast<pointer>(p_value);
       }
 
-      pointer operator ->() const
+      ETL_CONSTEXPR pointer operator ->() const
       {
         return static_cast<pointer>(p_value);
       }
 
-      friend bool operator == (const iterator& lhs, const iterator& rhs)
+      ETL_CONSTEXPR friend bool operator == (const iterator& lhs, const iterator& rhs)
       {
         return lhs.p_value == rhs.p_value;
       }
 
-      friend bool operator != (const iterator& lhs, const iterator& rhs)
+      ETL_CONSTEXPR friend bool operator != (const iterator& lhs, const iterator& rhs)
       {
         return !(lhs == rhs);
       }
 
     private:
 
-      iterator(link_type* value)
+      ETL_CONSTEXPR iterator(link_type* value)
         : p_value(value)
       {
       }
@@ -500,29 +505,29 @@ namespace etl
 
       friend class intrusive_list;
 
-      const_iterator()
+      ETL_CONSTEXPR const_iterator()
         : p_value(ETL_NULLPTR)
       {
       }
 
-      const_iterator(const typename intrusive_list::iterator& other)
+      ETL_CONSTEXPR const_iterator(const typename intrusive_list::iterator& other)
         : p_value(other.p_value)
       {
       }
 
-      const_iterator(const const_iterator& other)
+      ETL_CONSTEXPR const_iterator(const const_iterator& other)
         : p_value(other.p_value)
       {
       }
 
-      const_iterator& operator ++()
+      ETL_CONSTEXPR14 const_iterator& operator ++()
       {
         // Read the appropriate 'etl_next'.
         p_value = p_value->etl_next;
         return *this;
       }
 
-      const_iterator operator ++(int)
+      ETL_CONSTEXPR14 const_iterator operator ++(int)
       {
         const_iterator temp(*this);
         // Read the appropriate 'etl_next'.
@@ -530,14 +535,14 @@ namespace etl
         return temp;
       }
 
-      const_iterator& operator --()
+      ETL_CONSTEXPR14 const_iterator& operator --()
       {
         // Read the appropriate 'etl_previous'.
         p_value = p_value->etl_previous;
         return *this;
       }
 
-      const_iterator operator --(int)
+      ETL_CONSTEXPR14 const_iterator operator --(int)
       {
         const_iterator temp(*this);
         // Read the appropriate 'etl_previous'.
@@ -545,40 +550,40 @@ namespace etl
         return temp;
       }
 
-      const_iterator& operator =(const const_iterator& other)
+      ETL_CONSTEXPR14 const_iterator& operator =(const const_iterator& other)
       {
         p_value = other.p_value;
         return *this;
       }
 
-      const_reference operator *() const
+      ETL_CONSTEXPR const_reference operator *() const
       {
         return *static_cast<const_pointer>(p_value);
       }
 
-      const_pointer operator &() const
+      ETL_CONSTEXPR const_pointer operator &() const
       {
         return static_cast<const_pointer>(p_value);
       }
 
-      const_pointer operator ->() const
+      ETL_CONSTEXPR const_pointer operator ->() const
       {
         return static_cast<const_pointer>(p_value);
       }
 
-      friend bool operator == (const const_iterator& lhs, const const_iterator& rhs)
+      ETL_CONSTEXPR friend bool operator == (const const_iterator& lhs, const const_iterator& rhs)
       {
         return lhs.p_value == rhs.p_value;
       }
 
-      friend bool operator != (const const_iterator& lhs, const const_iterator& rhs)
+      ETL_CONSTEXPR friend bool operator != (const const_iterator& lhs, const const_iterator& rhs)
       {
         return !(lhs == rhs);
       }
 
     private:
 
-      const_iterator(const link_type* value)
+      ETL_CONSTEXPR const_iterator(const link_type* value)
         : p_value(value)
       {
       }
@@ -591,7 +596,7 @@ namespace etl
     //*************************************************************************
     /// Constructor.
     //*************************************************************************
-    intrusive_list()
+    ETL_CONSTEXPR14 intrusive_list()
     {
       this->initialise();
     }
@@ -608,7 +613,7 @@ namespace etl
     /// Constructor from range
     //*************************************************************************
     template <typename TIterator>
-    intrusive_list(TIterator first, TIterator last, typename etl::enable_if<!etl::is_integral<TIterator>::value, int>::type = 0)
+    ETL_CONSTEXPR14 intrusive_list(TIterator first, TIterator last, typename etl::enable_if<!etl::is_integral<TIterator>::value, int>::type = 0)
     {
       this->assign(first, last);
     }
@@ -616,7 +621,7 @@ namespace etl
     //*************************************************************************
     /// Gets the beginning of the intrusive_list.
     //*************************************************************************
-    iterator begin()
+    ETL_CONSTEXPR14 iterator begin()
     {
       return iterator(this->get_head());
     }
@@ -624,7 +629,7 @@ namespace etl
     //*************************************************************************
     /// Gets the beginning of the intrusive_list.
     //*************************************************************************
-    const_iterator begin() const
+    ETL_CONSTEXPR14 const_iterator begin() const
     {
       return const_iterator(this->get_head());
     }
@@ -632,7 +637,7 @@ namespace etl
     //*************************************************************************
     /// Gets the beginning of the intrusive_list.
     //*************************************************************************
-    const_iterator cbegin() const
+    ETL_CONSTEXPR14 const_iterator cbegin() const
     {
       return const_iterator(this->get_head());
     }
@@ -640,7 +645,7 @@ namespace etl
     //*************************************************************************
     /// Gets the end of the intrusive_list.
     //*************************************************************************
-    iterator end()
+    ETL_CONSTEXPR14 iterator end()
     {
       return iterator(&this->terminal_link);
     }
@@ -648,7 +653,7 @@ namespace etl
     //*************************************************************************
     /// Gets the end of the intrusive_list.
     //*************************************************************************
-    const_iterator end() const
+    ETL_CONSTEXPR14 const_iterator end() const
     {
       return const_iterator(&this->terminal_link);
     }
@@ -656,7 +661,7 @@ namespace etl
     //*************************************************************************
     /// Gets the end of the intrusive_list.
     //*************************************************************************
-    const_iterator cend() const
+    ETL_CONSTEXPR const_iterator cend() const
     {
       return const_iterator(&this->terminal_link);
     }
@@ -664,7 +669,7 @@ namespace etl
     //*************************************************************************
     /// Gets a reference to the first element.
     //*************************************************************************
-    reference front()
+    ETL_CONSTEXPR14 reference front()
     {
       return *static_cast<pointer>(this->get_head());
     }
@@ -672,7 +677,7 @@ namespace etl
     //*************************************************************************
     /// Gets a const reference to the first element.
     //*************************************************************************
-    const_reference front() const
+    ETL_CONSTEXPR14 const_reference front() const
     {
       return *static_cast<const_pointer>(this->get_head());
     }
@@ -680,7 +685,7 @@ namespace etl
     //*************************************************************************
     /// Gets a reference to the last element.
     //*************************************************************************
-    reference back()
+    ETL_CONSTEXPR14 reference back()
     {
       return *static_cast<pointer>(this->get_tail());
     }
@@ -688,7 +693,7 @@ namespace etl
     //*************************************************************************
     /// Gets a const reference to the last element.
     //*************************************************************************
-    const_reference back() const
+    ETL_CONSTEXPR14 const_reference back() const
     {
       return *static_cast<const_pointer>(this->get_tail());
     }
@@ -696,7 +701,7 @@ namespace etl
     //*************************************************************************
     /// Inserts a value to the intrusive_list before the specified position.
     //*************************************************************************
-    iterator insert(const_iterator position, value_type& value)
+    ETL_CONSTEXPR14 iterator insert(const_iterator position, value_type& value)
     {
       this->insert_link(position.p_value->link_type::etl_previous, value);
       return iterator(&value);
@@ -706,7 +711,7 @@ namespace etl
     /// Inserts a range of values to the intrusive_list after the specified position.
     //*************************************************************************
     template <typename TIterator>
-    void insert(const_iterator position, TIterator first, TIterator last)
+    ETL_CONSTEXPR14 void insert(const_iterator position, TIterator first, TIterator last)
     {
       while (first != last)
       {
@@ -719,7 +724,7 @@ namespace etl
     //*************************************************************************
     /// Erases the value at the specified position.
     //*************************************************************************
-    iterator erase(iterator position)
+    ETL_CONSTEXPR14 iterator erase(iterator position)
     {
       iterator next(position);
       ++next;
@@ -732,7 +737,7 @@ namespace etl
     //*************************************************************************
     /// Erases the value at the specified position.
     //*************************************************************************
-    iterator erase(const_iterator position)
+    ETL_CONSTEXPR14 iterator erase(const_iterator position)
     {
       iterator next(position);
       ++next;
@@ -746,7 +751,7 @@ namespace etl
     /// Erases a range of elements.
     /// Clears the links after erasing if AUTO or CHECKED.
     //*************************************************************************
-    iterator erase(const_iterator first, const_iterator last)
+    ETL_CONSTEXPR14 iterator erase(const_iterator first, const_iterator last)
     {
       const link_type* cp_first = first.p_value;
       const link_type* cp_last  = last.p_value;
@@ -781,7 +786,7 @@ namespace etl
     /// elements in the container.
     //*************************************************************************
     template <typename TIsEqual>
-    void unique(TIsEqual isEqual)
+    ETL_CONSTEXPR14 void unique(TIsEqual isEqual)
     {
       if (this->empty())
       {
@@ -809,7 +814,7 @@ namespace etl
     //*************************************************************************
     /// Sort using in-place merge sort algorithm.
     //*************************************************************************
-    void sort()
+    ETL_CONSTEXPR14 void sort()
     {
       sort(etl::less<value_type>());
     }
@@ -840,7 +845,7 @@ namespace etl
     /// SOFTWARE.
     //*************************************************************************
     template <typename TCompare>
-    void sort(TCompare compare)
+    ETL_CONSTEXPR14 void sort(TCompare compare)
     {
       iterator i_left;
       iterator i_right;
@@ -950,7 +955,7 @@ namespace etl
     //*************************************************************************
     // Removes the values specified.
     //*************************************************************************
-    void remove(const_reference value)
+    ETL_CONSTEXPR14 void remove(const_reference value)
     {
       iterator i_item = begin();
 
@@ -971,7 +976,7 @@ namespace etl
     /// Removes according to a predicate.
     //*************************************************************************
     template <typename TPredicate>
-    void remove_if(TPredicate predicate)
+    ETL_CONSTEXPR14 void remove_if(TPredicate predicate)
     {
       iterator i_item = begin();
 
@@ -991,7 +996,7 @@ namespace etl
     //*************************************************************************
     /// Splice another list into this one.
     //*************************************************************************
-    void splice(iterator position, list_type& other)
+    ETL_CONSTEXPR14 void splice(iterator position, list_type& other)
     {
       // No point splicing to ourself!
       if (&other != this)
@@ -1020,7 +1025,7 @@ namespace etl
     //*************************************************************************
     /// Splice an element from another list into this one.
     //*************************************************************************
-    void splice(iterator position, list_type& other, iterator isource)
+    ETL_CONSTEXPR14 void splice(iterator position, list_type& other, iterator isource)
     {
       link_type& before = *position.p_value->link_type::etl_previous;
 
@@ -1037,7 +1042,7 @@ namespace etl
     //*************************************************************************
     /// Splice a range of elements from another list into this one.
     //*************************************************************************
-    void splice(iterator position, list_type& other, iterator begin_, iterator end_)
+    ETL_CONSTEXPR14 void splice(iterator position, list_type& other, iterator begin_, iterator end_)
     {
       if (!other.empty())
       {
@@ -1064,7 +1069,7 @@ namespace etl
     //*************************************************************************
     /// Merge another list into this one. Both lists should be sorted.
     //*************************************************************************
-    void merge(list_type& other)
+    ETL_CONSTEXPR14 void merge(list_type& other)
     {
       merge(other, etl::less<value_type>());
     }
@@ -1073,7 +1078,7 @@ namespace etl
     /// Merge another list into this one. Both lists should be sorted.
     //*************************************************************************
     template <typename TCompare>
-    void merge(list_type& other, TCompare compare)
+    ETL_CONSTEXPR14 void merge(list_type& other, TCompare compare)
     {
       if ((this != &other) && !other.empty())
       {

--- a/include/etl/intrusive_queue.h
+++ b/include/etl/intrusive_queue.h
@@ -48,7 +48,7 @@ namespace etl
   {
   public:
 
-    intrusive_queue_exception(string_type reason_, string_type file_name_, numeric_type line_number_)
+    ETL_CONSTEXPR intrusive_queue_exception(string_type reason_, string_type file_name_, numeric_type line_number_)
       : exception(reason_, file_name_, line_number_)
     {
     }
@@ -62,7 +62,7 @@ namespace etl
   {
   public:
 
-    intrusive_queue_empty(string_type file_name_, numeric_type line_number_)
+    ETL_CONSTEXPR intrusive_queue_empty(string_type file_name_, numeric_type line_number_)
       : intrusive_queue_exception(ETL_ERROR_TEXT("intrusive_queue:empty", ETL_INTRUSIVE_QUEUE_FILE_ID"A"), file_name_, line_number_)
     {
     }
@@ -76,7 +76,7 @@ namespace etl
   {
   public:
 
-    intrusive_queue_value_is_already_linked(string_type file_name_, numeric_type line_number_)
+    ETL_CONSTEXPR intrusive_queue_value_is_already_linked(string_type file_name_, numeric_type line_number_)
       : intrusive_queue_exception(ETL_ERROR_TEXT("intrusive_queue:value is already linked", ETL_INTRUSIVE_QUEUE_FILE_ID"B"), file_name_, line_number_)
     {
     }
@@ -99,7 +99,7 @@ namespace etl
     /// Adds a value to the queue.
     ///\param value The value to push to the queue.
     //*************************************************************************
-    void push(link_type& value)
+    ETL_CONSTEXPR14 void push(link_type& value)
     {
       ETL_ASSERT_OR_RETURN(!value.is_linked(), ETL_ERROR(intrusive_queue_value_is_already_linked));
 
@@ -122,7 +122,7 @@ namespace etl
     /// Removes the oldest item from the queue.
     /// Undefined behaviour if the queue is already empty.
     //*************************************************************************
-    void pop()
+    ETL_CONSTEXPR14 void pop()
     {
 #if defined(ETL_CHECK_PUSH_POP)
       ETL_ASSERT_OR_RETURN(!empty(), ETL_ERROR(intrusive_queue_empty));
@@ -149,7 +149,7 @@ namespace etl
     /// NOTE: The destination must be an intrusive container that supports a push(TLink) member function.
     //*************************************************************************
     template <typename TContainer>
-    void pop_into(TContainer& destination)
+    ETL_CONSTEXPR14 void pop_into(TContainer& destination)
     {
       link_type* p_link = terminator.etl_next;
       pop();
@@ -159,7 +159,7 @@ namespace etl
     //*************************************************************************
     /// Clears the queue to the empty state.
     //*************************************************************************
-    void clear()
+    ETL_CONSTEXPR14 void clear()
     {
       while (!empty())
       {
@@ -172,7 +172,7 @@ namespace etl
     //*************************************************************************
     /// Checks if the queue is in the empty state.
     //*************************************************************************
-    bool empty() const
+    ETL_CONSTEXPR bool empty() const
     {
       return current_size == 0;
     }
@@ -180,7 +180,7 @@ namespace etl
     //*************************************************************************
     /// Returns the number of elements.
     //*************************************************************************
-    size_t size() const
+    ETL_CONSTEXPR size_t size() const
     {
       return current_size;
     }
@@ -190,7 +190,7 @@ namespace etl
     //*************************************************************************
     /// Constructor
     //*************************************************************************
-    intrusive_queue_base()
+    ETL_CONSTEXPR14 intrusive_queue_base()
       : p_back (&terminator)
       , current_size(0)
     {
@@ -236,7 +236,7 @@ namespace etl
     //*************************************************************************
     /// Constructor
     //*************************************************************************
-    intrusive_queue()
+    ETL_CONSTEXPR intrusive_queue()
       : intrusive_queue_base<TLink>()
     {
     }
@@ -246,7 +246,7 @@ namespace etl
     /// Undefined behaviour if the queue is empty.
     /// \return A reference to the value at the front of the queue.
     //*************************************************************************
-    reference front()
+    ETL_CONSTEXPR14 reference front()
     {
       return *static_cast<TValue*>(this->terminator.etl_next);
     }
@@ -256,7 +256,7 @@ namespace etl
     /// Undefined behaviour if the queue is empty.
     /// \return A reference to the value at the back of the queue.
     //*************************************************************************
-    reference back()
+    ETL_CONSTEXPR14 reference back()
     {
       return *static_cast<TValue*>(this->p_back);
     }
@@ -266,7 +266,7 @@ namespace etl
     /// Undefined behaviour if the queue is empty.
     /// \return A const reference to the value at the front of the queue.
     //*************************************************************************
-    const_reference front() const
+    ETL_CONSTEXPR14 const_reference front() const
     {
       return *static_cast<const TValue*>(this->terminator.etl_next);
     }
@@ -276,7 +276,7 @@ namespace etl
     /// Undefined behaviour if the queue is empty.
     /// \return A reference to the value at the back of the queue.
     //*************************************************************************
-    const_reference back() const
+    ETL_CONSTEXPR14 const_reference back() const
     {
       return *static_cast<const TValue*>(this->p_back);
     }

--- a/include/etl/intrusive_stack.h
+++ b/include/etl/intrusive_stack.h
@@ -48,6 +48,7 @@ namespace etl
   {
   public:
 
+    ETL_CONSTEXPR
     intrusive_stack_exception(string_type reason_, string_type file_name_, numeric_type line_number_)
       : exception(reason_, file_name_, line_number_)
     {
@@ -62,6 +63,7 @@ namespace etl
   {
   public:
 
+    ETL_CONSTEXPR
     intrusive_stack_empty(string_type file_name_, numeric_type line_number_)
       : intrusive_stack_exception(ETL_ERROR_TEXT("intrusive_stack:empty", ETL_INTRUSIVE_STACK_FILE_ID"A"), file_name_, line_number_)
     {
@@ -76,6 +78,7 @@ namespace etl
   {
   public:
 
+    ETL_CONSTEXPR
     intrusive_stack_value_is_already_linked(string_type file_name_, numeric_type line_number_)
       : intrusive_stack_exception(ETL_ERROR_TEXT("intrusive_stack:value is already linked", ETL_INTRUSIVE_STACK_FILE_ID"B"), file_name_, line_number_)
     {
@@ -99,7 +102,7 @@ namespace etl
     /// Adds a value to the stack.
     ///\param value The value to push to the stack.
     //*************************************************************************
-    void push(link_type& value)
+    ETL_CONSTEXPR14 void push(link_type& value)
     {
       ETL_ASSERT_OR_RETURN(!value.is_linked(), ETL_ERROR(intrusive_stack_value_is_already_linked));
 
@@ -113,7 +116,7 @@ namespace etl
     /// Removes the oldest item from the top of the stack.
     /// Undefined behaviour if the stack is already empty.
     //*************************************************************************
-    void pop()
+    ETL_CONSTEXPR14 void pop()
     {
 #if defined(ETL_CHECK_PUSH_POP)
       ETL_ASSERT_OR_RETURN(!empty(), ETL_ERROR(intrusive_stack_empty));
@@ -130,7 +133,7 @@ namespace etl
     /// NOTE: The destination must be an intrusive container that supports a push(TLink) member function.
     //*************************************************************************
     template <typename TContainer>
-    void pop_into(TContainer& destination)
+    ETL_CONSTEXPR14 void pop_into(TContainer& destination)
     {
       link_type* p_link = p_top;
       pop();
@@ -140,7 +143,7 @@ namespace etl
     //*************************************************************************
     /// Reverses the stack order.
     //*************************************************************************
-    void reverse()
+    ETL_CONSTEXPR14 void reverse()
     {
       link_type* previous = &terminator;
       link_type* current = p_top;
@@ -160,7 +163,7 @@ namespace etl
     //*************************************************************************
     /// Clears the stack to the empty state.
     //*************************************************************************
-    void clear()
+    ETL_CONSTEXPR14 void clear()
     {
       while (!empty())
       {
@@ -173,7 +176,7 @@ namespace etl
     //*************************************************************************
     /// Checks if the stack is in the empty state.
     //*************************************************************************
-    bool empty() const
+    ETL_CONSTEXPR bool empty() const
     {
       return current_size == 0;
     }
@@ -181,7 +184,7 @@ namespace etl
     //*************************************************************************
     /// Returns the number of elements.
     //*************************************************************************
-    size_t size() const
+    ETL_CONSTEXPR size_t size() const
     {
       return current_size;
     }
@@ -191,7 +194,7 @@ namespace etl
     //*************************************************************************
     /// Constructor
     //*************************************************************************
-    intrusive_stack_base()
+    ETL_CONSTEXPR14 intrusive_stack_base()
       : p_top(&terminator)
       , current_size(0)
     {      
@@ -236,7 +239,7 @@ namespace etl
     //*************************************************************************
     /// Constructor
     //*************************************************************************
-    intrusive_stack()
+    ETL_CONSTEXPR14 intrusive_stack()
     : intrusive_stack_base<TLink>()
     {
     }
@@ -246,7 +249,7 @@ namespace etl
     /// Undefined behaviour if the stack is empty.
     /// \return A reference to the value at the top of the stack.
     //*************************************************************************
-    reference top()
+    ETL_CONSTEXPR14 reference top()
     {
       return *static_cast<TValue*>(this->p_top);
     }
@@ -255,7 +258,7 @@ namespace etl
     /// Gets a const reference to the value at the top of the stack.<br>
     /// \return A const reference to the value at the top of the stack.
     //*************************************************************************
-    const_reference top() const
+    ETL_CONSTEXPR14 const_reference top() const
     {
       return *static_cast<const TValue*>(this->p_top);
     }


### PR DESCRIPTION
Adding `constexpr` to the intrusive containers. I was able to build and run tests for c++11, 14, and 17. c++20 had some issues with `char8_t` so I was unable to run those. c++03 was very broken for me but `ETL_CONSTEXPR` should be pre-compiled away  so I don't think this could have broken anything.