### PR TITLE
In subspan function, add static checks on extents

### DIFF
--- a/include/etl/span.h
+++ b/include/etl/span.h
@@ -296,8 +296,8 @@ namespace etl
     template <size_t COUNT>
     ETL_NODISCARD ETL_CONSTEXPR etl::span<element_type, COUNT> first() const ETL_NOEXCEPT
     {
-      //if extent is static, check that original span contains at least COUNT elements
-      ETL_STATIC_ASSERT((extent != etl::dynamic_extent) ? COUNT <= extent : true, "Original span does not contain COUNT elements");
+      //if Extent is static, check that original span contains at least COUNT elements
+      ETL_STATIC_ASSERT((Extent != etl::dynamic_extent) ? COUNT <= Extent : true, "Original span does not contain COUNT elements");
 
       return etl::span<element_type, COUNT>(pbegin, pbegin + COUNT);
     }
@@ -316,8 +316,8 @@ namespace etl
     template <size_t COUNT>
     ETL_NODISCARD ETL_CONSTEXPR etl::span<element_type, COUNT> last() const ETL_NOEXCEPT
     {
-      //if extent is static, check that original span contains at least COUNT elements
-      ETL_STATIC_ASSERT((extent != etl::dynamic_extent) ? COUNT <= extent : true, "Original span does not contain COUNT elements");
+      //if Extent is static, check that original span contains at least COUNT elements
+      ETL_STATIC_ASSERT((Extent != etl::dynamic_extent) ? COUNT <= Extent : true, "Original span does not contain COUNT elements");
 
       return etl::span<element_type, COUNT>(pbegin + Extent - COUNT, (pbegin + Extent));
     }
@@ -338,11 +338,11 @@ namespace etl
     ETL_NODISCARD ETL_CONSTEXPR
     etl::span<element_type, COUNT != etl::dynamic_extent ? COUNT : Extent - OFFSET> subspan() const ETL_NOEXCEPT
     {
-      //if extent is static, check that OFFSET is within the original span
-      ETL_STATIC_ASSERT((extent != etl::dynamic_extent) ? OFFSET <= extent : true, "OFFSET is not within the original span");
+      //if Extent is static, check that OFFSET is within the original span
+      ETL_STATIC_ASSERT((Extent != etl::dynamic_extent) ? OFFSET <= Extent : true, "OFFSET is not within the original span");
 
       //if count is also static, check that OFFSET + COUNT is within the original span
-      ETL_STATIC_ASSERT((extent != etl::dynamic_extent) && (COUNT != etl::dynamic_extent) ? COUNT <= (extent - OFFSET) : true, "OFFSET + COUNT is not within the original span");
+      ETL_STATIC_ASSERT((Extent != etl::dynamic_extent) && (COUNT != etl::dynamic_extent) ? COUNT <= (Extent - OFFSET) : true, "OFFSET + COUNT is not within the original span");
       
       return (COUNT == etl::dynamic_extent) ? etl::span<element_type, COUNT != etl::dynamic_extent ? COUNT : Extent - OFFSET>(pbegin + OFFSET, (pbegin + Extent))
                                             : etl::span<element_type, COUNT != etl::dynamic_extent ? COUNT : Extent - OFFSET>(pbegin + OFFSET, pbegin + OFFSET + COUNT);
@@ -354,11 +354,11 @@ namespace etl
     template <size_t OFFSET, size_t COUNT>
     etl::span<element_type, COUNT != etl::dynamic_extent ? COUNT : Extent - OFFSET> subspan() const
     {
-      //if extent is static, check that OFFSET is within the original span
-      ETL_STATIC_ASSERT((extent != etl::dynamic_extent) ? OFFSET <= extent : true, "OFFSET is not within the original span");
+      //if Extent is static, check that OFFSET is within the original span
+      ETL_STATIC_ASSERT((Extent != etl::dynamic_extent) ? OFFSET <= Extent : true, "OFFSET is not within the original span");
 
       //if count is also static, check that OFFSET + COUNT is within the original span
-      ETL_STATIC_ASSERT((extent != etl::dynamic_extent) && (COUNT != etl::dynamic_extent) ? COUNT <= (extent - OFFSET) : true, "OFFSET + COUNT is not within the original span");
+      ETL_STATIC_ASSERT((Extent != etl::dynamic_extent) && (COUNT != etl::dynamic_extent) ? COUNT <= (Extent - OFFSET) : true, "OFFSET + COUNT is not within the original span");
       
       if (COUNT == etl::dynamic_extent)
       {

--- a/include/etl/span.h
+++ b/include/etl/span.h
@@ -354,6 +354,12 @@ namespace etl
     template <size_t OFFSET, size_t COUNT>
     etl::span<element_type, COUNT != etl::dynamic_extent ? COUNT : Extent - OFFSET> subspan() const
     {
+      //if extent is static, check that OFFSET is within the original span
+      ETL_STATIC_ASSERT((extent != etl::dynamic_extent) ? OFFSET <= extent : true, "OFFSET is not within the original span");
+
+      //if count is also static, check that OFFSET + COUNT is within the original span
+      ETL_STATIC_ASSERT((extent != etl::dynamic_extent) && (COUNT != etl::dynamic_extent) ? COUNT <= (extent - OFFSET) : true, "OFFSET + COUNT is not within the original span");
+      
       if (COUNT == etl::dynamic_extent)
       {
         return etl::span<element_type, (COUNT != etl::dynamic_extent ? COUNT : Extent - OFFSET)>(pbegin + OFFSET, (pbegin + Extent));

--- a/include/etl/span.h
+++ b/include/etl/span.h
@@ -331,6 +331,12 @@ namespace etl
     ETL_NODISCARD ETL_CONSTEXPR
     etl::span<element_type, COUNT != etl::dynamic_extent ? COUNT : Extent - OFFSET> subspan() const ETL_NOEXCEPT
     {
+      //if extent is static, check that OFFSET is within the original span
+      static_assert((extent != etl::dynamic_extent) ? OFFSET <= extent : true);
+
+      //if count is also static, check that OFFSET + COUNT is within the original span
+      static_assert((extent != etl::dynamic_extent) && (COUNT != etl::dynamic_extent) ? COUNT <= (extent - OFFSET) : true);
+      
       return (COUNT == etl::dynamic_extent) ? etl::span<element_type, COUNT != etl::dynamic_extent ? COUNT : Extent - OFFSET>(pbegin + OFFSET, (pbegin + Extent))
                                             : etl::span<element_type, COUNT != etl::dynamic_extent ? COUNT : Extent - OFFSET>(pbegin + OFFSET, pbegin + OFFSET + COUNT);
     }

--- a/include/etl/span.h
+++ b/include/etl/span.h
@@ -42,6 +42,7 @@ SOFTWARE.
 #include "memory.h"
 #include "array.h"
 #include "byte.h"
+#include "static_assert.h"
 
 #include "private/dynamic_extent.h"
 
@@ -295,6 +296,9 @@ namespace etl
     template <size_t COUNT>
     ETL_NODISCARD ETL_CONSTEXPR etl::span<element_type, COUNT> first() const ETL_NOEXCEPT
     {
+      //if extent is static, check that original span contains at least COUNT elements
+      ETL_STATIC_ASSERT((extent != etl::dynamic_extent) ? COUNT <= extent : true, "Original span does not contain COUNT elements");
+
       return etl::span<element_type, COUNT>(pbegin, pbegin + COUNT);
     }
 
@@ -312,6 +316,9 @@ namespace etl
     template <size_t COUNT>
     ETL_NODISCARD ETL_CONSTEXPR etl::span<element_type, COUNT> last() const ETL_NOEXCEPT
     {
+      //if extent is static, check that original span contains at least COUNT elements
+      ETL_STATIC_ASSERT((extent != etl::dynamic_extent) ? COUNT <= extent : true, "Original span does not contain COUNT elements");
+
       return etl::span<element_type, COUNT>(pbegin + Extent - COUNT, (pbegin + Extent));
     }
 
@@ -332,10 +339,10 @@ namespace etl
     etl::span<element_type, COUNT != etl::dynamic_extent ? COUNT : Extent - OFFSET> subspan() const ETL_NOEXCEPT
     {
       //if extent is static, check that OFFSET is within the original span
-      static_assert((extent != etl::dynamic_extent) ? OFFSET <= extent : true);
+      ETL_STATIC_ASSERT((extent != etl::dynamic_extent) ? OFFSET <= extent : true, "OFFSET is not within the original span");
 
       //if count is also static, check that OFFSET + COUNT is within the original span
-      static_assert((extent != etl::dynamic_extent) && (COUNT != etl::dynamic_extent) ? COUNT <= (extent - OFFSET) : true);
+      ETL_STATIC_ASSERT((extent != etl::dynamic_extent) && (COUNT != etl::dynamic_extent) ? COUNT <= (extent - OFFSET) : true, "OFFSET + COUNT is not within the original span");
       
       return (COUNT == etl::dynamic_extent) ? etl::span<element_type, COUNT != etl::dynamic_extent ? COUNT : Extent - OFFSET>(pbegin + OFFSET, (pbegin + Extent))
                                             : etl::span<element_type, COUNT != etl::dynamic_extent ? COUNT : Extent - OFFSET>(pbegin + OFFSET, pbegin + OFFSET + COUNT);


### PR DESCRIPTION
Potential fix for issue #842 

etl::span subspan function does not currently statically check extents. std::span does check this.

Code demonstration:
```
std::array<int, 10> array {0};

//std::span std_span1 = std::span(array).subspan<15, 1>(); //compile time error
//std::span std_span2 = std::span(array).subspan<5, 8>(); //compile time error

etl::span etl_span1 = etl::span(array).subspan<15, 1>(); //currently no compile time error
etl::span etl_span2 = etl::span(array).subspan<5, 8>(); //currently no compile time error
```

This PR should enable c++11 and newer to have compile error when the extent check fails.