### PR TITLE
Fixed names according to arduino's guidlines

### DIFF
--- a/arduino/library-arduino.json
+++ b/arduino/library-arduino.json
@@ -1,5 +1,5 @@
 {
-  "name": "Embedded Template Library - Arduino",
+  "name": "Embedded Template Library ETL",
   "version": "20.38.10",
   "authors": {
     "name": "John Wellbelove",

--- a/arduino/library-arduino.properties
+++ b/arduino/library-arduino.properties
@@ -1,4 +1,4 @@
-name=Embedded Template Library - Arduino
+name=Embedded Template Library ETL
 version=20.38.10
 author= John Wellbelove <john.wellbelove@etlcpp.com>
 maintainer=John Wellbelove <john.wellbelove@etlcpp.com>


### PR DESCRIPTION
this is to fix the issue in the arduino repo
https://github.com/ETLCPP/etl-arduino/issues/4

for this to take effect, a git version tag must be pointing to a commit with the fixed name

after the tag is set, the status of its registration by arduino's tools can be checked in the following link:
https://downloads.arduino.cc/libraries/logs/github.com/ETLCPP/etl-arduino/

according to the documentation, the status page is [updated every hour](https://github.com/arduino/library-registry/blob/main/FAQ.md#what-are-the-requirements-for-a-library-to-be-added-to-library-manager)