### PR TITLE
fix(unique_ptr): assigning nullptr to a null unique_ptr causes an assert

### DIFF
--- a/include/etl/memory.h
+++ b/include/etl/memory.h
@@ -1424,7 +1424,10 @@ namespace etl
     //*********************************
     unique_ptr&	operator =(std::nullptr_t) ETL_NOEXCEPT
     {
-      reset(nullptr);
+      if (p)
+      {
+        reset(nullptr);
+      }
 
       return *this;
     }
@@ -1432,7 +1435,10 @@ namespace etl
     //*********************************
     unique_ptr&	operator =(void*) ETL_NOEXCEPT
     {
-      reset(NULL);
+      if (p)
+      {
+        reset(NULL);
+      }
 
       return *this;
     }

--- a/test/test_memory.cpp
+++ b/test/test_memory.cpp
@@ -925,6 +925,17 @@ namespace
     }
 
     //*************************************************************************
+    TEST(test_unique_ptr_nullptr_from_nullptr_assignment)
+    {
+      etl::unique_ptr<int> up;
+
+      up = nullptr;
+
+      CHECK(up.get() == nullptr);
+      CHECK(!bool(up));
+    }
+
+    //*************************************************************************
     TEST(test_unique_ptr_move_assignment)
     {
       etl::unique_ptr<int> up1(new int(1));


### PR DESCRIPTION
The assertion in `reset()`: `p_ != p` is triggered by the unconditional `reset(nullptr)` when `unique_ptr` already is set to `nullptr`.