### PR TITLE
Draft: Add Small Buffer-Optimization for lambda and functor created delegates (C11)

### DIFF
--- a/include/etl/private/delegate_cpp11.h
+++ b/include/etl/private/delegate_cpp11.h
@@ -111,7 +111,7 @@ namespace etl
     //*************************************************************************
     // Construct from lambda or functor.
     //*************************************************************************
-    template <typename TLambda, typename = etl::enable_if_t<etl::is_class<TLambda>::value && !etl::is_same<etl::delegate<TReturn(TParams...)>, TLambda>::value, void>>
+    template <typename TLambda, typename etl::enable_if_t<etl::is_class<TLambda>::value && !etl::is_same<etl::delegate<TReturn(TParams...)>, TLambda>::value, bool> = true>
     ETL_CONSTEXPR14 delegate(TLambda& instance)
     {
       assign((void*)(&instance), lambda_stub<TLambda>);
@@ -120,7 +120,7 @@ namespace etl
     //*************************************************************************
     // Construct from const lambda or functor.
     //*************************************************************************
-    template <typename TLambda, typename = etl::enable_if_t<etl::is_class<TLambda>::value && !etl::is_same<etl::delegate<TReturn(TParams...)>, TLambda>::value, void>>
+    template <typename TLambda, typename etl::enable_if_t<etl::is_class<TLambda>::value && !etl::is_same<etl::delegate<TReturn(TParams...)>, TLambda>::value, bool> = true>
     ETL_CONSTEXPR14 delegate(const TLambda& instance)
     {
       assign((void*)(&instance), const_lambda_stub<TLambda>);
@@ -139,7 +139,7 @@ namespace etl
     //*************************************************************************
     /// Create from Lambda or Functor.
     //*************************************************************************
-    template <typename TLambda, typename = etl::enable_if_t<etl::is_class<TLambda>::value && !etl::is_same<etl::delegate<TReturn(TParams...)>, TLambda>::value, void>>
+    template <typename TLambda, typename etl::enable_if_t<etl::is_class<TLambda>::value && !etl::is_same<etl::delegate<TReturn(TParams...)>, TLambda>::value, bool> = true>
     ETL_NODISCARD
     static ETL_CONSTEXPR14 delegate create(TLambda& instance)
     {
@@ -149,7 +149,7 @@ namespace etl
     //*************************************************************************
     /// Create from const Lambda or Functor.
     //*************************************************************************
-    template <typename TLambda, typename = etl::enable_if_t<etl::is_class<TLambda>::value && !etl::is_same<etl::delegate<TReturn(TParams...)>, TLambda>::value, void>>
+    template <typename TLambda, typename etl::enable_if_t<etl::is_class<TLambda>::value && !etl::is_same<etl::delegate<TReturn(TParams...)>, TLambda>::value, bool> = true>
     ETL_NODISCARD
       static ETL_CONSTEXPR14 delegate create(const TLambda& instance)
     {
@@ -235,7 +235,7 @@ namespace etl
     //*************************************************************************
     /// Set from Lambda or Functor.
     //*************************************************************************
-    template <typename TLambda, typename = etl::enable_if_t<etl::is_class<TLambda>::value && !etl::is_same<etl::delegate<TReturn(TParams...)>, TLambda>::value, void>>
+    template <typename TLambda, typename etl::enable_if_t<etl::is_class<TLambda>::value && !etl::is_same<etl::delegate<TReturn(TParams...)>, TLambda>::value, bool> = true>
     ETL_CONSTEXPR14 void set(TLambda& instance)
     {
       assign((void*)(&instance), lambda_stub<TLambda>);
@@ -244,7 +244,7 @@ namespace etl
     //*************************************************************************
     /// Set from const Lambda or Functor.
     //*************************************************************************
-    template <typename TLambda, typename = etl::enable_if_t<etl::is_class<TLambda>::value && !etl::is_same<etl::delegate<TReturn(TParams...)>, TLambda>::value, void>>
+    template <typename TLambda, typename etl::enable_if_t<etl::is_class<TLambda>::value && !etl::is_same<etl::delegate<TReturn(TParams...)>, TLambda>::value, bool> = true>
     ETL_CONSTEXPR14 void set(const TLambda& instance)
     {
       assign((void*)(&instance), const_lambda_stub<TLambda>);
@@ -383,7 +383,7 @@ namespace etl
     //*************************************************************************
     /// Create from Lambda or Functor.
     //*************************************************************************
-    template <typename TLambda, typename = etl::enable_if_t<etl::is_class<TLambda>::value && !etl::is_same<etl::delegate<TReturn(TParams...)>, TLambda>::value, void>>
+    template <typename TLambda, typename etl::enable_if_t<etl::is_class<TLambda>::value && !etl::is_same<etl::delegate<TReturn(TParams...)>, TLambda>::value, bool> = true>
     ETL_CONSTEXPR14 delegate& operator =(TLambda& instance)
     {
       assign((void*)(&instance), lambda_stub<TLambda>);
@@ -393,7 +393,7 @@ namespace etl
     //*************************************************************************
     /// Create from const Lambda or Functor.
     //*************************************************************************
-    template <typename TLambda, typename = etl::enable_if_t<etl::is_class<TLambda>::value && !etl::is_same<etl::delegate<TReturn(TParams...)>, TLambda>::value, void>>
+    template <typename TLambda, typename etl::enable_if_t<etl::is_class<TLambda>::value && !etl::is_same<etl::delegate<TReturn(TParams...)>, TLambda>::value, bool> = true>
     ETL_CONSTEXPR14 delegate& operator =(const TLambda& instance)
     {
       assign((void*)(&instance), const_lambda_stub<TLambda>);

--- a/include/etl/type_traits.h
+++ b/include/etl/type_traits.h
@@ -1713,7 +1713,7 @@ typedef integral_constant<bool, true>  true_type;
   using is_trivially_destructible = std::is_trivially_destructible<T>;
 #else
   template <typename T>
-  using is_trivially_destructible = etl::bool_constant<etl::is_arithmetic<T>::value || etl::is_pointer<T>::value>;
+  using is_trivially_destructible = etl::bool_constant<etl::is_arithmetic<T>::value || etl::is_pointer<T>::value> || etl::is_pod<T>::value;
 #endif
 
   //*********************************************

--- a/include/etl/type_traits.h
+++ b/include/etl/type_traits.h
@@ -807,6 +807,35 @@ namespace etl
   inline constexpr size_t alignment_of_v = etl::alignment_of<T>::value;
 #endif
 
+#if ETL_USING_CPP11
+  //***************************************************************************
+  /// is_empty
+  ///\ingroup type_traits
+  namespace private_type_traits 
+  {
+    // Make use of Empty Base Class Optimization for this to work
+    template <typename T, bool=false>
+    struct is_empty_ {
+      static constexpr bool value = false;
+    };
+    template <typename T>
+    struct is_empty_<T, true> { 
+      struct empty : T {
+        char _;
+      };
+      static constexpr bool value = sizeof(empty) == sizeof(char);
+    };
+  }
+
+  template <typename T, typename = void> struct is_empty : etl::false_type {};
+  template <typename T> struct is_empty<T, typename etl::enable_if<private_type_traits::is_empty_<T,is_class<T>::value>::value>::type> : etl::true_type {};
+
+#if ETL_USING_CPP17
+  template <typename T>
+  inline constexpr bool is_empty_v = is_empty<T>::value;
+#endif
+#endif
+
 #else // Condition = ETL_USING_STL && ETL_USING_CPP11
 
 //*****************************************************************************
@@ -1319,6 +1348,18 @@ typedef integral_constant<bool, true>  true_type;
 #if ETL_USING_CPP17
   template <typename T>
   inline constexpr size_t alignment_of_v = std::alignment_of_v<T>;
+#endif
+
+#if ETL_USING_CPP11
+  //***************************************************************************
+  /// is_empty
+  ///\ingroup type_traits
+  template <typename T> struct is_empty : std::is_empty<T> {};
+
+#if ETL_USING_CPP17
+  template <typename T>
+  inline constexpr bool is_empty_v = is_empty<T>::value;
+#endif
 #endif
 
 #endif // Condition = ETL_USING_STL && ETL_USING_CPP11

--- a/test/test_callback_timer_interrupt.cpp
+++ b/test/test_callback_timer_interrupt.cpp
@@ -803,13 +803,13 @@ namespace
         timer_log.push_back(TimerLogEntry{ 3, timer_count });
       };
 
-      callback_type delegate_callback0(dc0);
+      callback_type delegate_callback0(etl::ref(dc0));
       
-      callback_type delegate_callback1(dc1);
+      callback_type delegate_callback1(etl::ref(dc1));
       
-      callback_type delegate_callback2(dc2);
+      callback_type delegate_callback2(etl::ref(dc2));
       
-      callback_type delegate_callback3(dc3);
+      callback_type delegate_callback3(etl::ref(dc3));
 
       timer_log.clear();
       timer_controller.enable(true);

--- a/test/test_delegate.cpp
+++ b/test/test_delegate.cpp
@@ -422,11 +422,31 @@ namespace
     }
 
     //*************************************************************************
+    TEST_FIXTURE(SetupFixture, test_lambda_capture_int)
+    {
+      struct CaptureObject {
+        int i;
+        int j;
+
+        bool eval(int i_, int j_) const { return (i_ == i) && (j_ == j); } 
+      };
+
+      CaptureObject co { VALUE1, VALUE2 };
+
+      etl::delegate<void(int, int)> d([co](int i, int j) { function_called = FunctionCalled::Lambda_Called; parameter_correct = co.eval(i,j); });
+
+      d(VALUE1, VALUE2);
+
+      CHECK(function_called == FunctionCalled::Lambda_Called);
+      CHECK(parameter_correct);
+    }
+
+    //*************************************************************************
     TEST_FIXTURE(SetupFixture, test_lambda_int_create)
     {
       auto lambda = [](int i, int j) { function_called = FunctionCalled::Lambda_Called; parameter_correct = (i == VALUE1) && (j == VALUE2); };
 
-      etl::delegate<void(int, int)> d(lambda);
+      etl::delegate<void(int, int)> d(etl::ref(lambda));
 
       d(VALUE1, VALUE2);
 
@@ -439,7 +459,7 @@ namespace
     {
       Test test;
 
-      etl::delegate<void(void)> d(test);
+      etl::delegate<void(void)> d(etl::ref(test));
 
       d();
 
@@ -477,7 +497,7 @@ namespace
     {
       const Test test;
 
-      etl::delegate<void(void)> d(test);
+      etl::delegate<void(void)> d(etl::ref(test));
 
       d();
 
@@ -537,7 +557,7 @@ namespace
 
       etl::delegate<void(void)> d;
 
-      d = test;
+      d = etl::ref(test);
 
       d();
 
@@ -958,6 +978,29 @@ namespace
     }
 
     //*************************************************************************
+    TEST_FIXTURE(SetupFixture, test_set_lambda_capture_int)
+    {
+      etl::delegate<void(int, int)> d;
+
+      struct CaptureObject {
+        int i;
+        int j;
+
+        bool eval(int i_, int j_) const { return (i_ == i) && (j_ == j); } 
+        void assign(int i_, int j_) { this->i = i_; this->j = j_; }
+      };
+
+      CaptureObject co { 0, 0 };
+
+      d.set([&co](int i, int j) { co.assign(i,j); function_called = FunctionCalled::Lambda_Called; parameter_correct = co.eval(i,j); });
+
+      d(VALUE1, VALUE2);
+
+      CHECK(function_called == FunctionCalled::Lambda_Called);
+      CHECK(parameter_correct);
+    }
+
+    //*************************************************************************
     TEST_FIXTURE(SetupFixture, test_set_member_reference)
     {
       Test test;
@@ -1194,7 +1237,7 @@ namespace
     {
       std::function<void(int, int)> std_function(free_int);
 
-      etl::delegate<void(int, int)> d(std_function);
+      etl::delegate<void(int, int)> d(etl::ref(std_function));
 
       d(VALUE1, VALUE2);
 

--- a/test/test_type_traits.cpp
+++ b/test/test_type_traits.cpp
@@ -694,6 +694,56 @@ namespace
     }
 
     //*************************************************************************
+namespace private_test_is_empty {
+      struct A {};
+      struct B { int m; };
+      struct C { static int m; };
+      struct D { virtual ~D(); };
+      union E {};
+#if ETL_USING_CPP20
+      struct F { [[no_unique_address]] E e; };
+#endif
+      struct G
+      {
+          int:0;
+          // C++ standard allow "as a special case, an unnamed bit-field with a width of zero
+          // specifies alignment of the next bit-field at an allocation unit boundary.
+          // Only when declaring an unnamed bit-field may the width be zero."
+      };
+  
+};
+    TEST(test_is_empty)
+    {
+#if ETL_USING_CPP11
+#if ETL_USING_CPP17
+      CHECK(etl::is_empty_v<private_test_is_empty::A> == std::is_empty_v<private_test_is_empty::A>);
+      CHECK(etl::is_empty_v<private_test_is_empty::B> == std::is_empty_v<private_test_is_empty::B>);
+      CHECK(etl::is_empty_v<private_test_is_empty::C> == std::is_empty_v<private_test_is_empty::C>);
+      CHECK(etl::is_empty_v<private_test_is_empty::D> == std::is_empty_v<private_test_is_empty::D>);
+#if ETL_USING_STL
+      CHECK(etl::is_empty_v<private_test_is_empty::E> == std::is_empty_v<private_test_is_empty::E>);
+#endif
+#if ETL_USING_CPP20
+      CHECK(etl::is_empty_v<private_test_is_empty::F> == std::is_empty_v<private_test_is_empty::F>);
+#endif
+      CHECK(etl::is_empty_v<private_test_is_empty::G> == std::is_empty_v<private_test_is_empty::G>);
+#else
+      CHECK(etl::is_empty<private_test_is_empty::A>::value == std::is_empty<private_test_is_empty::A>::value);
+      CHECK(etl::is_empty<private_test_is_empty::B>::value == std::is_empty<private_test_is_empty::B>::value);
+      CHECK(etl::is_empty<private_test_is_empty::C>::value == std::is_empty<private_test_is_empty::C>::value);
+      CHECK(etl::is_empty<private_test_is_empty::D>::value == std::is_empty<private_test_is_empty::D>::value);
+#if ETL_USING_STL
+      CHECK(etl::is_empty<private_test_is_empty::E>::value == std::is_empty<private_test_is_empty::E>::value);
+#endif
+#if ETL_USING_CPP20
+      CHECK(etl::is_empty<private_test_is_empty::F>::value == std::is_empty<private_test_is_empty::F>::value);
+#endif
+      CHECK(etl::is_empty<private_test_is_empty::G>::value == std::is_empty<private_test_is_empty::G>::value);
+#endif
+#endif
+    }
+
+    //*************************************************************************
     TEST(test_is_one_of)
     {
       typedef Type<0> T0;


### PR DESCRIPTION
Hi,
I've changed the creation of lambda and functor delegates, where I use the area for the pointer to create a Small Buffer-Optimized area instead of a reference to these types. This will be a breaking change, and may also in the worst case be a silent change, as the compiler will not detect some cases, i.e. no compile error.
However, IMHO I think this is a pretty good improvement that will make it a bit easier to use for lambdas, and add a behavior I've been missing for a long time.

This commit adds 'Small Buffer Optimization' to functor and lambda functions with small footprint, i.e. the same size as 'void *' or less, and will therefore mimic the `std::function` behavior for these types, instead of being a reference to them as before.

This means that the following operations are now allowed to delegate with deferred/out-of-scope calls:

```
etl::delegate<void()> Class::method() {
  etl::delegate<void()> d {[this](){ this->do_something(); }};
  return d;
}
```

A caveat is that the old behavior where everything became a reference instead of an object is changed and the user must now use a `reference_wrapper` to gain the same behavior, i.e. using `etl::ref` or `etl::cref`:

```
  auto f = [&](){ /* ... */ };
  etl::delegate<void()> d { etl::ref(d) };
  d();
```

This change of behavior also matches the C++ Core Guidelines for how to pass parameters
[https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#f15-prefer-simple-and-conventional-ways-of-passing-information]

Please review my MR, and I'm pleased to get feedback. I have not done any performance testing so it may add an extra penalty, but when I've elaborated with compiler explorer, it seems to be similar.

Also notice that I haven't changed the `create` functionality of delegates, as I don't know if it should be kept as is...?