### PR TITLE
Validate allocated DataNode is not null to prevent gcc -Wnull-dereference (issue #830)

### DIFF
--- a/include/etl/map.h
+++ b/include/etl/map.h
@@ -935,7 +935,9 @@ namespace etl
         ETL_ASSERT(!full(), ETL_ERROR(map_full));
 
         // Get next available free node
-        Data_Node& node = allocate_data_node_with_key(etl::move(key));
+        Data_Node* node = allocate_data_node_with_key(etl::move(key));
+
+        ETL_ASSERT(node != ETL_NULLPTR, ETL_ERROR(map_full));
 
         // Obtain the inserted node (might be ETL_NULLPTR if node was a duplicate)
         inserted_node = insert_node(root_node, node);
@@ -965,10 +967,12 @@ namespace etl
         ETL_ASSERT(!full(), ETL_ERROR(map_full));
 
         // Get next available free node
-        Data_Node& node = allocate_data_node_with_key(key);
+        Data_Node* node = allocate_data_node_with_key(key);
+
+        ETL_ASSERT(node != ETL_NULLPTR, ETL_ERROR(map_full));
 
         // Obtain the inserted node (might be ETL_NULLPTR if node was a duplicate)
-        inserted_node = insert_node(root_node, node);
+        inserted_node = insert_node(root_node, *node);
 
         // Insert node into tree and return iterator to new node location in tree
         i_element = iterator(*this, inserted_node);
@@ -1213,10 +1217,12 @@ namespace etl
       ETL_ASSERT(!full(), ETL_ERROR(map_full));
 
       // Get next available free node
-      Data_Node& node = allocate_data_node(value);
+      Data_Node* node = allocate_data_node(value);
+
+      ETL_ASSERT(node != ETL_NULLPTR, ETL_ERROR(map_full));
 
       // Obtain the inserted node (might be ETL_NULLPTR if node was a duplicate)
-      inserted_node = insert_node(root_node, node);
+      inserted_node = insert_node(root_node, *node);
       inserted = inserted_node == &node;
 
       // Insert node into tree and return iterator to new node location in tree
@@ -1238,10 +1244,12 @@ namespace etl
       ETL_ASSERT(!full(), ETL_ERROR(map_full));
 
       // Get next available free node
-      Data_Node& node = allocate_data_node(etl::move(value));
+      Data_Node* node = allocate_data_node(etl::move(value));
+
+      ETL_ASSERT(node != ETL_NULLPTR, ETL_ERROR(map_full));
 
       // Obtain the inserted node (might be ETL_NULLPTR if node was a duplicate)
-      inserted_node = insert_node(root_node, node);
+      inserted_node = insert_node(root_node, *node);
       inserted = inserted_node == &node;
 
       // Insert node into tree and return iterator to new node location in tree
@@ -1263,10 +1271,12 @@ namespace etl
       ETL_ASSERT(!full(), ETL_ERROR(map_full));
 
       // Get next available free node
-      Data_Node& node = allocate_data_node(value);
+      Data_Node* node = allocate_data_node(value);
+
+      ETL_ASSERT(node != ETL_NULLPTR, ETL_ERROR(map_full));
 
       // Obtain the inserted node (might be ETL_NULLPTR if node was a duplicate)
-      inserted_node = insert_node(root_node, node);
+      inserted_node = insert_node(root_node, *node);
 
       // Insert node into tree and return iterator to new node location in tree
       return iterator(*this, inserted_node);
@@ -1287,10 +1297,12 @@ namespace etl
       ETL_ASSERT(!full(), ETL_ERROR(map_full));
 
       // Get next available free node
-      Data_Node& node = allocate_data_node(etl::move(value));
+      Data_Node* node = allocate_data_node(etl::move(value));
+
+      ETL_ASSERT(node != ETL_NULLPTR, ETL_ERROR(map_full));
 
       // Obtain the inserted node (might be ETL_NULLPTR if node was a duplicate)
-      inserted_node = insert_node(root_node, node);
+      inserted_node = insert_node(root_node, *node);
 
       // Insert node into tree and return iterator to new node location in tree
       return iterator(*this, inserted_node);
@@ -1494,10 +1506,14 @@ namespace etl
     //*************************************************************************
     /// Allocate a Data_Node.
     //*************************************************************************
-    Data_Node& allocate_data_node(const_reference value)
+    Data_Node* allocate_data_node(const_reference value)
     {
-      Data_Node& node = allocate_data_node();
-      ::new (&node.value) value_type(value);
+      Data_Node* node = allocate_data_node();
+      if (node == ETL_NULLPTR)
+      {
+        return ETL_NULLPTR;
+      }
+      ::new (&node->value) value_type(value);
       ETL_INCREMENT_DEBUG_COUNT;
       return node;
     }
@@ -1505,12 +1521,15 @@ namespace etl
     //*************************************************************************
     /// Allocate a Data_Node with the supplied key.
     //*************************************************************************
-    Data_Node& allocate_data_node_with_key(const_key_reference key)
+    Data_Node* allocate_data_node_with_key(const_key_reference key)
     {
-      Data_Node& node = allocate_data_node();
-
-      ::new ((void*)etl::addressof(node.value.first))  key_type(key);
-      ::new ((void*)etl::addressof(node.value.second)) mapped_type();
+      Data_Node* node = allocate_data_node();
+      if (node == ETL_NULLPTR)
+      {
+        return ETL_NULLPTR;
+      }
+      ::new ((void*)etl::addressof(node->value.first))  key_type(key);
+      ::new ((void*)etl::addressof(node->value.second)) mapped_type();
       ETL_INCREMENT_DEBUG_COUNT;
       return node;
     }
@@ -1519,10 +1538,14 @@ namespace etl
     //*************************************************************************
     /// Allocate a Data_Node.
     //*************************************************************************
-    Data_Node& allocate_data_node(rvalue_reference value)
+    Data_Node* allocate_data_node(rvalue_reference value)
     {
-      Data_Node& node = allocate_data_node();
-      ::new (&node.value) value_type(etl::move(value));
+      Data_Node* node = allocate_data_node();
+      if (node == ETL_NULLPTR)
+      {
+        return ETL_NULLPTR;
+      }
+      ::new (&node->value) value_type(etl::move(value));
       ETL_INCREMENT_DEBUG_COUNT;
       return node;
     }
@@ -1530,12 +1553,15 @@ namespace etl
     //*************************************************************************
     /// Allocate a Data_Node with the supplied key.
     //*************************************************************************
-    Data_Node& allocate_data_node_with_key(rvalue_key_reference key)
+    Data_Node* allocate_data_node_with_key(rvalue_key_reference key)
     {
-      Data_Node& node = allocate_data_node();
-
-      ::new ((void*)etl::addressof(node.value.first))  key_type(etl::move(key));
-      ::new ((void*)etl::addressof(node.value.second)) mapped_type();
+      Data_Node* node = allocate_data_node();
+      if (node == ETL_NULLPTR)
+      {
+        return ETL_NULLPTR;
+      }
+      ::new ((void*)etl::addressof(node->value.first))  key_type(etl::move(key));
+      ::new ((void*)etl::addressof(node->value.second)) mapped_type();
       ETL_INCREMENT_DEBUG_COUNT;
       return node;
     }
@@ -1545,10 +1571,10 @@ namespace etl
     //*************************************************************************
     /// Create a Data_Node.
     //*************************************************************************
-    Data_Node& allocate_data_node()
+    Data_Node* allocate_data_node()
     {
       Data_Node* (etl::ipool::*func)() = &etl::ipool::allocate<Data_Node>;
-      return *(p_node_pool->*func)();
+      return (p_node_pool->*func)();
     }
 
     //*************************************************************************


### PR DESCRIPTION
gcc appears to warn about not checking for null when allocating these pointers. It is probably a false positive because clang does not issue the same warning, and optimizations can change how gcc issues this warning. Nonetheless, this is one approach to resolving the issue.

Addresses https://github.com/ETLCPP/etl/issues/830