### PR TITLE
Rename successor to avoid shadowing

### DIFF
--- a/include/etl/message_router.h
+++ b/include/etl/message_router.h
@@ -200,8 +200,8 @@ namespace etl
     }
 
     //********************************************
-    null_message_router(etl::imessage_router& successor)
-      : imessage_router(imessage_router::NULL_MESSAGE_ROUTER, successor)
+    null_message_router(etl::imessage_router& successor_)
+      : imessage_router(imessage_router::NULL_MESSAGE_ROUTER, successor_)
     {
     }
     
@@ -278,8 +278,8 @@ namespace etl
     }
 
     //********************************************
-    message_producer(etl::imessage_router& successor)
-      : imessage_router(imessage_router::NULL_MESSAGE_ROUTER, successor)
+    message_producer(etl::imessage_router& successor_)
+      : imessage_router(imessage_router::NULL_MESSAGE_ROUTER, successor_)
     {
     }
 
@@ -291,8 +291,8 @@ namespace etl
     }
 
     //********************************************
-    message_producer(etl::message_router_id_t id_, etl::imessage_router& successor)
-      : imessage_router(id_, successor)
+    message_producer(etl::message_router_id_t id_, etl::imessage_router& successor_)
+      : imessage_router(id_, successor_)
     {
       ETL_ASSERT(id_ <= etl::imessage_router::MAX_MESSAGE_ROUTER, ETL_ERROR(etl::message_router_illegal_id));
     }


### PR DESCRIPTION
Some of the constructors in [message_router.h](https://github.com/ETLCPP/etl/blob/master/include/etl/message_router.h) are using arguments named `successor`, resulting in following warning/error message:

```
etl/message_router.h:296:5: error: declaration of ‘successor’ shadows a member of ‘etl::message_producer’
```

This PR renames arguments to `successor_` to prevent shadowing.