### PR TITLE
Fix algorithm.h

### DIFF
--- a/include/etl/algorithm.h
+++ b/include/etl/algorithm.h
@@ -1293,7 +1293,7 @@ namespace etl
 
       TIterator next = middle;
       TIterator result = first;
-      std::advance(result, std::distance(middle, last));
+      ETL_OR_STD::advance(result, ETL_OR_STD::distance(middle, last));
 
       while (first != next)
       {


### PR DESCRIPTION
Fix compilation errors introduced by f9867c2281218340b0962ddce257f3c8a1eb5456

Errors fixed:

> Embedded Template Library/include/etl/algorithm.h:1296:12: error: 'advance' is not a member of 'std'
> Embedded Template Library/include/etl/algorithm.h:1296:33: error: 'distance' is not a member of 'std'