### PR TITLE
Fix doc comment for exception::line_number()

### DIFF
--- a/include/etl/exception.h
+++ b/include/etl/exception.h
@@ -100,7 +100,7 @@ namespace etl
 
     //***************************************************************************
     /// Gets the line for the exception.
-    /// \return const char* to the line.
+    /// \return int as line number.
     //***************************************************************************
     ETL_CONSTEXPR
     numeric_type line_number() const


### PR DESCRIPTION
The documentation comment for `exception::line_number()` in `include/etl/exception.h` states falsely that the return type for the function is a `const char*`. It should state that the return type is `numeric_type`, which is an `int`. So change the documentation comment to reflect that the return type is an `int`.

I know that this is a small issue but when I'm setting up error handling for _ETL_ it just irks me to have my IDE report false data.