### PR TITLE
Fix doc comment for pool::allocate()

### DIFF
--- a/include/etl/pool.h
+++ b/include/etl/pool.h
@@ -71,7 +71,6 @@ namespace etl
 
     //*************************************************************************
     /// Allocate an object from the pool.
-    /// Uses the default constructor.
     /// If asserts or exceptions are enabled and there are no more free items an
     /// etl::pool_no_allocation if thrown, otherwise a null pointer is returned.
     /// Static asserts if the specified type is too large for the pool.


### PR DESCRIPTION
The documentation comment for `pool::allocate()` in `include/etl/pool.h` states that the default constructor is to be called, while [according to the documentation](https://www.etlcpp.com/pool.html) and to the code (including the documentation comment for `generic_pool::allocate()`) it is not true.