### PR TITLE
Add an etl::nullptr_t type to <etl/nullptr.h>

### DIFF
--- a/include/etl/memory.h
+++ b/include/etl/memory.h
@@ -1393,7 +1393,7 @@ namespace etl
     }
 
     //*********************************
-    void reset(pointer p_ = pointer()) ETL_NOEXCEPT
+    void reset(pointer p_) ETL_NOEXCEPT
     {
       assert(p_ != p);
 
@@ -1404,6 +1404,12 @@ namespace etl
       {
         deleter(value);
       }
+    }
+
+    void reset(etl::nullptr_t p_ = ETL_NULLPTR) ETL_NOEXCEPT
+    {
+      (void)p_; // unused argument
+      reset(pointer());
     }
 
     //*********************************
@@ -1420,29 +1426,16 @@ namespace etl
       return (p != ETL_NULLPTR);
     }
 
-#if ETL_USING_STL && ETL_USING_CPP11
     //*********************************
-    unique_ptr&	operator =(std::nullptr_t) ETL_NOEXCEPT
+    unique_ptr&	operator =(etl::nullptr_t) ETL_NOEXCEPT
     {
       if (p)
       {
-        reset(nullptr);
+        reset(ETL_NULLPTR);
       }
 
       return *this;
     }
-#else
-    //*********************************
-    unique_ptr&	operator =(void*) ETL_NOEXCEPT
-    {
-      if (p)
-      {
-        reset(NULL);
-      }
-
-      return *this;
-    }
-#endif
 
 #if ETL_USING_CPP11
     //*********************************

--- a/include/etl/memory.h
+++ b/include/etl/memory.h
@@ -1393,10 +1393,10 @@ namespace etl
     }
 
     //*********************************
-    void reset(pointer p_) ETL_NOEXCEPT
+    void reset(pointer p_ = pointer()) ETL_NOEXCEPT
     {
-      assert(p_ != p);
-
+      assert(p_ == ETL_NULLPTR || p_ != p);
+      
       pointer value = p;
       p = p_;
 
@@ -1404,12 +1404,6 @@ namespace etl
       {
         deleter(value);
       }
-    }
-
-    void reset(etl::nullptr_t p_ = ETL_NULLPTR) ETL_NOEXCEPT
-    {
-      (void)p_; // unused argument
-      reset(pointer());
     }
 
     //*********************************
@@ -1615,6 +1609,11 @@ namespace etl
       }
     }
 
+    void reset(etl::nullptr_t = ETL_NULLPTR) ETL_NOEXCEPT
+    {
+      reset(pointer());
+    }
+
     //*********************************
     void swap(unique_ptr& v) ETL_NOEXCEPT
     {
@@ -1629,23 +1628,13 @@ namespace etl
       return (p != ETL_NULLPTR);
     }
 
-#if ETL_USING_STL && ETL_USING_CPP11
     //*********************************
-    unique_ptr& operator =(std::nullptr_t) ETL_NOEXCEPT
+    unique_ptr& operator =(etl::nullptr_t) ETL_NOEXCEPT
     {
-      reset(nullptr);
+      reset(ETL_NULLPTR);
 
       return *this;
     }
-#else
-    //*********************************
-    unique_ptr& operator =(void*) ETL_NOEXCEPT
-    {
-      reset(NULL);
-
-      return *this;
-    }
-#endif
 
 #if ETL_USING_CPP11
     //*********************************

--- a/include/etl/nullptr.h
+++ b/include/etl/nullptr.h
@@ -38,8 +38,18 @@ SOFTWARE.
 namespace etl
 {
 #if ETL_CPP11_NOT_SUPPORTED
-  // Use the old style C++ NULL definition.
-  typedef enum { _nullptr = 0 } nullptr_t;
+  class nullptr_t
+  {
+  public:
+    template <class T>
+    inline operator T*() const { return 0; }
+    
+    inline bool operator==(nullptr_t) const { return true; }
+    inline bool operator!=(nullptr_t) const { return false; }
+  };
+  
+  static const nullptr_t _nullptr = nullptr_t();
+
   #define ETL_NULLPTR (etl::_nullptr)
 #else
   // Use the new style nullptr.

--- a/include/etl/nullptr.h
+++ b/include/etl/nullptr.h
@@ -43,9 +43,14 @@ namespace etl
   public:
     template <class T>
     inline operator T*() const { return 0; }
+
+    template <class C, class T>
+    inline operator T C::* () const { return 0; }
     
     inline bool operator==(nullptr_t) const { return true; }
     inline bool operator!=(nullptr_t) const { return false; }
+  private:
+    void operator&() const ETL_DELETE; // cannot take the address of ETL_NULLPTR
   };
   
   static const nullptr_t _nullptr = nullptr_t();

--- a/include/etl/nullptr.h
+++ b/include/etl/nullptr.h
@@ -35,13 +35,18 @@ SOFTWARE.
 
 #include <stddef.h>
 
+namespace etl
+{
 #if ETL_CPP11_NOT_SUPPORTED
   // Use the old style C++ NULL definition.
-  #define ETL_NULLPTR 0
+  typedef enum { _nullptr = 0 } nullptr_t;
+  #define ETL_NULLPTR (etl::_nullptr)
 #else
   // Use the new style nullptr.
+  typedef decltype(nullptr) nullptr_t;
   #define ETL_NULLPTR nullptr
 #endif
+}
 
 #endif
 

--- a/include/etl/private/addressof.h
+++ b/include/etl/private/addressof.h
@@ -49,7 +49,7 @@ namespace etl
   ///\ingroup memory
   //*****************************************************************************
   template <typename T>
-  ETL_CONSTEXPR17 typename etl::enable_if<!etl::is_same<T, etl::nullptr_t>::value>::type* addressof(T& t)
+  ETL_CONSTEXPR17 typename etl::enable_if<!etl::is_same<T, etl::nullptr_t>::value, T>::type* addressof(T& t)
   {
 #if ETL_USING_STL && ETL_USING_CPP11
     return std::addressof(t);

--- a/include/etl/private/addressof.h
+++ b/include/etl/private/addressof.h
@@ -48,8 +48,8 @@ namespace etl
   /// https://en.cppreference.com/w/cpp/memory/addressof
   ///\ingroup memory
   //*****************************************************************************
-  template <typename T, typename = typename etl::enable_if<!etl::is_same<T, etl::nullptr_t>::value>::type>
-  ETL_CONSTEXPR17 T* addressof(T& t)
+  template <typename T>
+  ETL_CONSTEXPR17 typename etl::enable_if<!etl::is_same<T, etl::nullptr_t>::value>::type* addressof(T& t)
   {
 #if ETL_USING_STL && ETL_USING_CPP11
     return std::addressof(t);

--- a/include/etl/private/addressof.h
+++ b/include/etl/private/addressof.h
@@ -32,6 +32,7 @@ SOFTWARE.
 #define ETL_ADDRESSOF_INCLUDED
 
 #include "../platform.h"
+#include "../type_traits.h"
 
 #if defined(ETL_IN_UNIT_TEST) || ETL_USING_STL
   #include <memory>
@@ -47,7 +48,7 @@ namespace etl
   /// https://en.cppreference.com/w/cpp/memory/addressof
   ///\ingroup memory
   //*****************************************************************************
-  template <typename T>
+  template <typename T, typename = typename etl::enable_if<!etl::is_same<T, etl::nullptr_t>::value>::type>
   ETL_CONSTEXPR17 T* addressof(T& t)
   {
 #if ETL_USING_STL && ETL_USING_CPP11


### PR DESCRIPTION
Well, the title is self-explanatory. This is a tiny change anyway, and the code is basically what's proposed in #922.

Edit: As of this moment, I changed the pre-C++11 code from an enum into a  custom class