### PR TITLE
Fix missing partial specialisation equal operators

### DIFF
--- a/include/etl/expected.h
+++ b/include/etl/expected.h
@@ -976,7 +976,35 @@ bool operator ==(const etl::expected<TValue, TError>& lhs, const etl::unexpected
   {
     return false;
   }
-  return lhs.error() == rhs;
+  return lhs.error() == rhs.error();
+}
+
+//*******************************************
+template <typename TError, typename TError2>
+ETL_CONSTEXPR14
+bool operator ==(const etl::expected<void, TError>& lhs, const etl::expected<void, TError2>& rhs)
+{
+  if (lhs.has_value() != rhs.has_value())
+  {
+    return false;
+  }
+  if (lhs.has_value())
+  {
+    return true;
+  }
+  return lhs.error() == rhs.error();
+}
+
+//*******************************************
+template <typename TError, typename TError2>
+ETL_CONSTEXPR14
+bool operator ==(const etl::expected<void, TError>& lhs, const etl::unexpected<TError2>& rhs)
+{
+  if (lhs.has_value())
+  {
+    return false;
+  }
+  return lhs.error() == rhs.error();
 }
 
 //*******************************************
@@ -1007,6 +1035,22 @@ bool operator !=(const etl::expected<TValue, TError>& lhs, const TValue2& rhs)
 template <typename TValue, typename TError, typename TError2>
 ETL_CONSTEXPR14
 bool operator !=(const etl::expected<TValue, TError>& lhs, const etl::unexpected<TError2>& rhs)
+{
+  return !(lhs == rhs);
+}
+
+//*******************************************
+template <typename TError, typename TError2>
+ETL_CONSTEXPR14
+bool operator !=(const etl::expected<void, TError>& lhs, const etl::expected<void, TError2>& rhs)
+{
+  return !(lhs == rhs);
+}
+
+//*******************************************
+template <typename TError, typename TError2>
+ETL_CONSTEXPR14
+bool operator !=(const etl::expected<void, TError>& lhs, const etl::unexpected<TError2>& rhs)
 {
   return !(lhs == rhs);
 }

--- a/test/test_expected.cpp
+++ b/test/test_expected.cpp
@@ -666,6 +666,24 @@ namespace
 
 
     //*************************************************************************
+    TEST(test_expected_void_equal_operator)
+    {
+      etl::expected<void, int> test_exp;
+      etl::expected<void, int> test_exp2;
+      etl::expected<void, int> test_unexp = etl::unexpected<int>(1);
+      etl::expected<void, int> test_unexp2 = etl::unexpected<int>(2);
+
+      CHECK_TRUE(test_exp == test_exp2);
+      CHECK_FALSE(test_exp != test_exp2);
+
+      CHECK_FALSE(test_exp == test_unexp);
+      CHECK_TRUE(test_exp != test_unexp);
+
+      CHECK_FALSE(test_unexp == test_unexp2);
+      CHECK_TRUE(test_unexp != test_unexp2);
+    }
+
+    //*************************************************************************
     TEST(test_unexpected_equal_operator)
     {
       etl::unexpected<int> test_unexp = etl::unexpected<int>(1);


### PR DESCRIPTION
Forgot partial specialisation of etl::expected.
Additionally, fixed a small bug in a comparison operator.