### PR TITLE
Fixes compiler detection with Wundef

### DIFF
--- a/include/etl/pool.h
+++ b/include/etl/pool.h
@@ -71,7 +71,6 @@ namespace etl
 
     //*************************************************************************
     /// Allocate an object from the pool.
-    /// Uses the default constructor.
     /// If asserts or exceptions are enabled and there are no more free items an
     /// etl::pool_no_allocation if thrown, otherwise a null pointer is returned.
     /// Static asserts if the specified type is too large for the pool.

--- a/include/etl/profiles/determine_compiler.h
+++ b/include/etl/profiles/determine_compiler.h
@@ -79,7 +79,7 @@ SOFTWARE.
     #if defined(__clang__) || defined(__llvm__)
       #define ETL_COMPILER_CLANG
       #define ETL_COMPILER_TYPE_DETECTED
-      #if __AVR__ == 1
+      #if defined(__AVR__) && (__AVR__ == 1)
         #define ETL_CROSS_COMPILING_TO_AVR
       #endif
     #endif


### PR DESCRIPTION
When Wundef is passed to GCC, the preprocessor will complain that `__AVR__` is not defined and thus it has to default it to zero. A simple fix is to check if it's defined and use short-circuiting logic to then check the value 