### PR TITLE
Fix histogram indexing when accessed via operator[]

### DIFF
--- a/include/etl/histogram.h
+++ b/include/etl/histogram.h
@@ -249,7 +249,7 @@ namespace etl
     //*********************************
     value_type operator [](key_type key) const
     {
-      return this->accumulator[key];
+      return this->accumulator[key - Start_Index];
     }
   };
 
@@ -373,7 +373,7 @@ namespace etl
     //*********************************
     value_type operator [](key_type key) const
     {
-      return this->accumulator[key];
+      return this->accumulator[key - start_index];
     }
 
   private:

--- a/test/test_histogram.cpp
+++ b/test/test_histogram.cpp
@@ -247,7 +247,7 @@ namespace
 
       for (size_t i = 0UL; i < output1.size(); ++i)
       {
-        CHECK_EQUAL(int(output1[i]), int(histogram[i]));
+        CHECK_EQUAL(int(output1[i]), int(histogram[i - 4]));
       }
     }
 


### PR DESCRIPTION
This PR fixes the histogram indexing issue when the start index is not zero. The unit test was previously passing because it didn't account for non-zero start index too (seems like a copy-paste of zero offset unit test).