### PR TITLE
[WIP] implementation of templated timer tick

### DIFF
--- a/examples/ArmTimerCallbacks - C++/main.cpp
+++ b/examples/ArmTimerCallbacks - C++/main.cpp
@@ -36,10 +36,10 @@ const int N_TIMERS = 4;
 
 etl::callback_timer<N_TIMERS> callback_timer;
 
-etl::timer::id::type short_toggle;
-etl::timer::id::type long_toggle;
-etl::timer::id::type start_timers;
-etl::timer::id::type swap_timers;
+etl::timer<>::id::type short_toggle;
+etl::timer<>::id::type long_toggle;
+etl::timer<>::id::type start_timers;
+etl::timer<>::id::type swap_timers;
 
 /*----------------------------------------------------------------------------
  * SystemCoreClockConfigure: configure SystemCoreClock using HSI
@@ -131,10 +131,10 @@ int main()
 
   // The LEDs will start flashing fast after 2 seconds.
   // After another 5 seconds they will start flashing slower.
-  short_toggle = callback_timer.register_timer(LedToggle,   50,  etl::timer::mode::REPEATING);
-  long_toggle  = callback_timer.register_timer(LedToggle,   100,  etl::timer::mode::REPEATING);
-  start_timers = callback_timer.register_timer(StartTimers, 2000, etl::timer::mode::SINGLE_SHOT);
-  swap_timers  = callback_timer.register_timer(SwapTimers,  1500, etl::timer::mode::SINGLE_SHOT);
+  short_toggle = callback_timer.register_timer(LedToggle,   50,  etl::timer<>::mode::REPEATING);
+  long_toggle  = callback_timer.register_timer(LedToggle,   100,  etl::timer<>::mode::REPEATING);
+  start_timers = callback_timer.register_timer(StartTimers, 2000, etl::timer<>::mode::SINGLE_SHOT);
+  swap_timers  = callback_timer.register_timer(SwapTimers,  1500, etl::timer<>::mode::SINGLE_SHOT);
 
   SysTick_Config(SystemCoreClock / 1000);
 

--- a/include/etl/callback_timer.h
+++ b/include/etl/callback_timer.h
@@ -94,10 +94,10 @@ namespace etl
     callback_timer_data()
       : p_callback(ETL_NULLPTR),
         period(0),
-        delta(etl::timer::state::Inactive),
-        id(etl::timer::id::NO_TIMER),
-        previous(etl::timer::id::NO_TIMER),
-        next(etl::timer::id::NO_TIMER),
+        delta(etl::timer<>::state::Inactive),
+        id(etl::timer<>::id::NO_TIMER),
+        previous(etl::timer<>::id::NO_TIMER),
+        next(etl::timer<>::id::NO_TIMER),
         repeating(true),
         cbk_type(IFUNCTION)
     {
@@ -106,16 +106,16 @@ namespace etl
     //*******************************************
     /// C function callback
     //*******************************************
-    callback_timer_data(etl::timer::id::type id_,
+    callback_timer_data(etl::timer<>::id::type id_,
                         void                 (*p_callback_)(),
                         uint32_t             period_,
                         bool                 repeating_)
       : p_callback(reinterpret_cast<void*>(p_callback_)),
         period(period_),
-        delta(etl::timer::state::Inactive),
+        delta(etl::timer<>::state::Inactive),
         id(id_),
-        previous(etl::timer::id::NO_TIMER),
-        next(etl::timer::id::NO_TIMER),
+        previous(etl::timer<>::id::NO_TIMER),
+        next(etl::timer<>::id::NO_TIMER),
         repeating(repeating_),
         cbk_type(C_CALLBACK)
     {
@@ -124,16 +124,16 @@ namespace etl
     //*******************************************
     /// ETL function callback
     //*******************************************
-    callback_timer_data(etl::timer::id::type  id_,
+    callback_timer_data(etl::timer<>::id::type  id_,
                         etl::ifunction<void>& callback_,
                         uint32_t              period_,
                         bool                  repeating_)
       : p_callback(reinterpret_cast<void*>(&callback_)),
         period(period_),
-        delta(etl::timer::state::Inactive),
+        delta(etl::timer<>::state::Inactive),
         id(id_),
-        previous(etl::timer::id::NO_TIMER),
-        next(etl::timer::id::NO_TIMER),
+        previous(etl::timer<>::id::NO_TIMER),
+        next(etl::timer<>::id::NO_TIMER),
         repeating(repeating_),
         cbk_type(IFUNCTION)
     {
@@ -142,16 +142,16 @@ namespace etl
     //*******************************************
     /// ETL delegate callback
     //*******************************************
-    callback_timer_data(etl::timer::id::type id_,
+    callback_timer_data(etl::timer<>::id::type id_,
                         callback_type&       callback_,
                         uint32_t             period_,
                         bool                 repeating_)
             : p_callback(reinterpret_cast<void*>(&callback_)),
               period(period_),
-              delta(etl::timer::state::Inactive),
+              delta(etl::timer<>::state::Inactive),
               id(id_),
-              previous(etl::timer::id::NO_TIMER),
-              next(etl::timer::id::NO_TIMER),
+              previous(etl::timer<>::id::NO_TIMER),
+              next(etl::timer<>::id::NO_TIMER),
               repeating(repeating_),
               cbk_type(DELEGATE)
     {
@@ -162,7 +162,7 @@ namespace etl
     //*******************************************
     bool is_active() const
     {
-      return delta != etl::timer::state::Inactive;
+      return delta != etl::timer<>::state::Inactive;
     }
 
     //*******************************************
@@ -170,13 +170,13 @@ namespace etl
     //*******************************************
     void set_inactive()
     {
-      delta = etl::timer::state::Inactive;
+      delta = etl::timer<>::state::Inactive;
     }
 
     void*                 p_callback;
     uint32_t              period;
     uint32_t              delta;
-    etl::timer::id::type  id;
+    etl::timer<>::id::type  id;
     uint_least8_t         previous;
     uint_least8_t         next;
     bool                  repeating;
@@ -200,9 +200,9 @@ namespace etl
 
       //*******************************
       list(etl::callback_timer_data* ptimers_)
-        : head(etl::timer::id::NO_TIMER),
-          tail(etl::timer::id::NO_TIMER),
-          current(etl::timer::id::NO_TIMER),
+        : head(etl::timer<>::id::NO_TIMER),
+          tail(etl::timer<>::id::NO_TIMER),
+          current(etl::timer<>::id::NO_TIMER),
           ptimers(ptimers_)
       {
       }
@@ -210,30 +210,30 @@ namespace etl
       //*******************************
       bool empty() const
       {
-        return head == etl::timer::id::NO_TIMER;
+        return head == etl::timer<>::id::NO_TIMER;
       }
 
       //*******************************
       // Inserts the timer at the correct delta position
       //*******************************
-      void insert(etl::timer::id::type id_)
+      void insert(etl::timer<>::id::type id_)
       {
         etl::callback_timer_data& timer = ptimers[id_];
 
-        if (head == etl::timer::id::NO_TIMER)
+        if (head == etl::timer<>::id::NO_TIMER)
         {
           // No entries yet.
           head = id_;
           tail = id_;
-          timer.previous = etl::timer::id::NO_TIMER;
-          timer.next     = etl::timer::id::NO_TIMER;
+          timer.previous = etl::timer<>::id::NO_TIMER;
+          timer.next     = etl::timer<>::id::NO_TIMER;
         }
         else
         {
           // We already have entries.
-          etl::timer::id::type test_id = begin();
+          etl::timer<>::id::type test_id = begin();
 
-          while (test_id != etl::timer::id::NO_TIMER)
+          while (test_id != etl::timer<>::id::NO_TIMER)
           {
             etl::callback_timer_data& test = ptimers[test_id];
 
@@ -253,7 +253,7 @@ namespace etl
               // Adjust the next delta to compensate.
               test.delta -= timer.delta;
 
-              if (timer.previous != etl::timer::id::NO_TIMER)
+              if (timer.previous != etl::timer<>::id::NO_TIMER)
               {
                 ptimers[timer.previous].next = timer.id;
               }
@@ -268,19 +268,19 @@ namespace etl
           }
 
           // Reached the end?
-          if (test_id == etl::timer::id::NO_TIMER)
+          if (test_id == etl::timer<>::id::NO_TIMER)
           {
             // Tag on to the tail.
             ptimers[tail].next = timer.id;
             timer.previous     = tail;
-            timer.next         = etl::timer::id::NO_TIMER;
+            timer.next         = etl::timer<>::id::NO_TIMER;
             tail               = timer.id;
           }
         }
       }
 
       //*******************************
-      void remove(etl::timer::id::type id_, bool has_expired)
+      void remove(etl::timer<>::id::type id_, bool has_expired)
       {
         etl::callback_timer_data& timer = ptimers[id_];
 
@@ -305,15 +305,15 @@ namespace etl
         if (!has_expired)
         {
           // Adjust the next delta.
-          if (timer.next != etl::timer::id::NO_TIMER)
+          if (timer.next != etl::timer<>::id::NO_TIMER)
           {
             ptimers[timer.next].delta += timer.delta;
           }
         }
 
-        timer.previous = etl::timer::id::NO_TIMER;
-        timer.next     = etl::timer::id::NO_TIMER;
-        timer.delta    = etl::timer::state::Inactive;
+        timer.previous = etl::timer<>::id::NO_TIMER;
+        timer.next     = etl::timer<>::id::NO_TIMER;
+        timer.delta    = etl::timer<>::state::Inactive;
       }
 
       //*******************************
@@ -329,21 +329,21 @@ namespace etl
       }
 
       //*******************************
-      etl::timer::id::type begin()
+      etl::timer<>::id::type begin()
       {
         current = head;
         return current;
       }
 
       //*******************************
-      etl::timer::id::type previous(etl::timer::id::type last)
+      etl::timer<>::id::type previous(etl::timer<>::id::type last)
       {
         current = ptimers[last].previous;
         return current;
       }
 
       //*******************************
-      etl::timer::id::type next(etl::timer::id::type last)
+      etl::timer<>::id::type next(etl::timer<>::id::type last)
       {
         current = ptimers[last].next;
         return current;
@@ -352,25 +352,25 @@ namespace etl
       //*******************************
       void clear()
       {
-        etl::timer::id::type id = begin();
+        etl::timer<>::id::type id = begin();
 
-        while (id != etl::timer::id::NO_TIMER)
+        while (id != etl::timer<>::id::NO_TIMER)
         {
           etl::callback_timer_data& timer = ptimers[id];
           id = next(id);
-          timer.next = etl::timer::id::NO_TIMER;
+          timer.next = etl::timer<>::id::NO_TIMER;
         }
 
-        head    = etl::timer::id::NO_TIMER;
-        tail    = etl::timer::id::NO_TIMER;
-        current = etl::timer::id::NO_TIMER;
+        head    = etl::timer<>::id::NO_TIMER;
+        tail    = etl::timer<>::id::NO_TIMER;
+        current = etl::timer<>::id::NO_TIMER;
       }
 
     private:
 
-      etl::timer::id::type head;
-      etl::timer::id::type tail;
-      etl::timer::id::type current;
+      etl::timer<>::id::type head;
+      etl::timer<>::id::type tail;
+      etl::timer<>::id::type current;
 
       etl::callback_timer_data* const ptimers;
     };
@@ -388,11 +388,11 @@ namespace etl
     //*******************************************
     /// Register a timer.
     //*******************************************
-    etl::timer::id::type register_timer(void     (*p_callback_)(),
+    etl::timer<>::id::type register_timer(void     (*p_callback_)(),
                                         uint32_t period_,
                                         bool     repeating_)
     {
-      etl::timer::id::type id = etl::timer::id::NO_TIMER;
+      etl::timer<>::id::type id = etl::timer<>::id::NO_TIMER;
 
       bool is_space = (registered_timers < MAX_TIMERS);
 
@@ -403,7 +403,7 @@ namespace etl
         {
           etl::callback_timer_data& timer = timer_array[i];
 
-          if (timer.id == etl::timer::id::NO_TIMER)
+          if (timer.id == etl::timer<>::id::NO_TIMER)
           {
             // Create in-place.
             new (&timer) callback_timer_data(i, p_callback_, period_, repeating_);
@@ -420,11 +420,11 @@ namespace etl
     //*******************************************
     /// Register a timer.
     //*******************************************
-    etl::timer::id::type register_timer(etl::ifunction<void>& callback_,
+    etl::timer<>::id::type register_timer(etl::ifunction<void>& callback_,
                                         uint32_t              period_,
                                         bool                  repeating_)
     {
-      etl::timer::id::type id = etl::timer::id::NO_TIMER;
+      etl::timer<>::id::type id = etl::timer<>::id::NO_TIMER;
 
       bool is_space = (registered_timers < MAX_TIMERS);
 
@@ -435,7 +435,7 @@ namespace etl
         {
           etl::callback_timer_data& timer = timer_array[i];
 
-          if (timer.id == etl::timer::id::NO_TIMER)
+          if (timer.id == etl::timer<>::id::NO_TIMER)
           {
             // Create in-place.
             new (&timer) callback_timer_data(i, callback_, period_, repeating_);
@@ -453,11 +453,11 @@ namespace etl
       /// Register a timer.
       //*******************************************
 #if ETL_USING_CPP11
-      etl::timer::id::type register_timer(callback_type& callback_,
+      etl::timer<>::id::type register_timer(callback_type& callback_,
                                           uint32_t       period_,
                                           bool           repeating_)
       {
-          etl::timer::id::type id = etl::timer::id::NO_TIMER;
+          etl::timer<>::id::type id = etl::timer<>::id::NO_TIMER;
 
           bool is_space = (registered_timers < MAX_TIMERS);
 
@@ -468,7 +468,7 @@ namespace etl
               {
                   etl::callback_timer_data& timer = timer_array[i];
 
-                  if (timer.id == etl::timer::id::NO_TIMER)
+                  if (timer.id == etl::timer<>::id::NO_TIMER)
                   {
                       // Create in-place.
                       new (&timer) callback_timer_data(i, callback_, period_, repeating_);
@@ -486,15 +486,15 @@ namespace etl
     //*******************************************
     /// Unregister a timer.
     //*******************************************
-    bool unregister_timer(etl::timer::id::type id_)
+    bool unregister_timer(etl::timer<>::id::type id_)
     {
       bool result = false;
 
-      if (id_ != etl::timer::id::NO_TIMER)
+      if (id_ != etl::timer<>::id::NO_TIMER)
       {
         etl::callback_timer_data& timer = timer_array[id_];
 
-        if (timer.id != etl::timer::id::NO_TIMER)
+        if (timer.id != etl::timer<>::id::NO_TIMER)
         {
           if (timer.is_active())
           {
@@ -618,20 +618,20 @@ namespace etl
     //*******************************************
     /// Starts a timer.
     //*******************************************
-    bool start(etl::timer::id::type id_, bool immediate_ = false)
+    bool start(etl::timer<>::id::type id_, bool immediate_ = false)
     {
       bool result = false;
 
       // Valid timer id?
-      if (id_ != etl::timer::id::NO_TIMER)
+      if (id_ != etl::timer<>::id::NO_TIMER)
       {
         etl::callback_timer_data& timer = timer_array[id_];
 
         // Registered timer?
-        if (timer.id != etl::timer::id::NO_TIMER)
+        if (timer.id != etl::timer<>::id::NO_TIMER)
         {
           // Has a valid period.
-          if (timer.period != etl::timer::state::Inactive)
+          if (timer.period != etl::timer<>::state::Inactive)
           {
             ETL_DISABLE_TIMER_UPDATES;
             if (timer.is_active())
@@ -654,17 +654,17 @@ namespace etl
     //*******************************************
     /// Stops a timer.
     //*******************************************
-    bool stop(etl::timer::id::type id_)
+    bool stop(etl::timer<>::id::type id_)
     {
       bool result = false;
 
       // Valid timer id?
-      if (id_ != etl::timer::id::NO_TIMER)
+      if (id_ != etl::timer<>::id::NO_TIMER)
       {
         etl::callback_timer_data& timer = timer_array[id_];
 
         // Registered timer?
-        if (timer.id != etl::timer::id::NO_TIMER)
+        if (timer.id != etl::timer<>::id::NO_TIMER)
         {
           if (timer.is_active())
           {
@@ -683,7 +683,7 @@ namespace etl
     //*******************************************
     /// Sets a timer's period.
     //*******************************************
-    bool set_period(etl::timer::id::type id_, uint32_t period_)
+    bool set_period(etl::timer<>::id::type id_, uint32_t period_)
     {
       if (stop(id_))
       {
@@ -697,7 +697,7 @@ namespace etl
     //*******************************************
     /// Sets a timer's mode.
     //*******************************************
-    bool set_mode(etl::timer::id::type id_, bool repeating_)
+    bool set_mode(etl::timer<>::id::type id_, bool repeating_)
     {
       if (stop(id_))
       {
@@ -718,11 +718,11 @@ namespace etl
 
     //*******************************************
     /// Get the time to the next timer event.
-    /// Returns etl::timer::interval::No_Active_Interval if there is no active timer.
+    /// Returns etl::timer<>::interval::No_Active_Interval if there is no active timer.
     //*******************************************
     uint32_t time_to_next() const
     {
-      uint32_t delta = static_cast<uint32_t>(etl::timer::interval::No_Active_Interval);
+      uint32_t delta = static_cast<uint32_t>(etl::timer<>::interval::No_Active_Interval);
 
       if (has_active_timer())
       {
@@ -736,7 +736,7 @@ namespace etl
     /// Checks if a timer is currently active.
     /// Returns <b>true</b> if the timer is active, otherwise <b>false</b>.
     //*******************************************
-    bool is_active(etl::timer::id::type id_) const
+    bool is_active(etl::timer<>::id::type id_) const
     {
       // Valid timer id?
       if (is_valid_timer_id(id_))
@@ -746,7 +746,7 @@ namespace etl
           const etl::callback_timer_data& timer = timer_array[id_];
 
           // Registered timer?
-          if (timer.id != etl::timer::id::NO_TIMER)
+          if (timer.id != etl::timer<>::id::NO_TIMER)
           {
             return timer.is_active();
           }
@@ -778,7 +778,7 @@ namespace etl
     //*******************************************
     /// Check that the timer id is valid.
     //*******************************************
-    bool is_valid_timer_id(etl::timer::id::type id_) const
+    bool is_valid_timer_id(etl::timer<>::id::type id_) const
     {
       return (id_ < MAX_TIMERS);
     }

--- a/include/etl/callback_timer_atomic.h
+++ b/include/etl/callback_timer_atomic.h
@@ -56,11 +56,11 @@ namespace etl
     //*******************************************
     /// Register a timer.
     //*******************************************
-    etl::timer::id::type register_timer(callback_type callback_,
+    etl::timer<>::id::type register_timer(callback_type callback_,
                                         uint32_t   period_,
                                         bool       repeating_)
     {
-        etl::timer::id::type id = etl::timer::id::NO_TIMER;
+        etl::timer<>::id::type id = etl::timer<>::id::NO_TIMER;
         
         bool is_space = (number_of_registered_timers < MAX_TIMERS);
 
@@ -71,7 +71,7 @@ namespace etl
             {
               timer_data& timer = timer_array[i];
                
-              if (timer.id == etl::timer::id::NO_TIMER)
+              if (timer.id == etl::timer<>::id::NO_TIMER)
               {
                 // Create in-place.
                 new (&timer) timer_data(i, callback_, period_, repeating_);
@@ -88,15 +88,15 @@ namespace etl
     //*******************************************
     /// Unregister a timer.
     //*******************************************
-    bool unregister_timer(etl::timer::id::type id_)
+    bool unregister_timer(etl::timer<>::id::type id_)
     {
       bool result = false;
 
-      if (id_ != etl::timer::id::NO_TIMER)
+      if (id_ != etl::timer<>::id::NO_TIMER)
       {
         timer_data& timer = timer_array[id_];
 
-        if (timer.id != etl::timer::id::NO_TIMER)
+        if (timer.id != etl::timer<>::id::NO_TIMER)
         {
           if (timer.is_active())
           {
@@ -207,20 +207,20 @@ namespace etl
     //*******************************************
     /// Starts a timer.
     //*******************************************
-    bool start(etl::timer::id::type id_, bool immediate_ = false)
+    bool start(etl::timer<>::id::type id_, bool immediate_ = false)
     {
       bool result = false;
 
       // Valid timer id?
-      if (id_ != etl::timer::id::NO_TIMER)
+      if (id_ != etl::timer<>::id::NO_TIMER)
       {
         timer_data& timer = timer_array[id_];
 
         // Registered timer?
-        if (timer.id != etl::timer::id::NO_TIMER)
+        if (timer.id != etl::timer<>::id::NO_TIMER)
         {
           // Has a valid period.
-          if (timer.period != etl::timer::state::Inactive)
+          if (timer.period != etl::timer<>::state::Inactive)
           {
             ++process_semaphore;
             if (timer.is_active())
@@ -243,17 +243,17 @@ namespace etl
     //*******************************************
     /// Stops a timer.
     //*******************************************
-    bool stop(etl::timer::id::type id_)
+    bool stop(etl::timer<>::id::type id_)
     {
       bool result = false;
 
       // Valid timer id?
-      if (id_ != etl::timer::id::NO_TIMER)
+      if (id_ != etl::timer<>::id::NO_TIMER)
       {
         timer_data& timer = timer_array[id_];
 
         // Registered timer?
-        if (timer.id != etl::timer::id::NO_TIMER)
+        if (timer.id != etl::timer<>::id::NO_TIMER)
         {
           if (timer.is_active())
           {
@@ -272,7 +272,7 @@ namespace etl
     //*******************************************
     /// Sets a timer's period.
     //*******************************************
-    bool set_period(etl::timer::id::type id_, uint32_t period_)
+    bool set_period(etl::timer<>::id::type id_, uint32_t period_)
     {
       if (stop(id_))
       {
@@ -286,7 +286,7 @@ namespace etl
     //*******************************************
     /// Sets a timer's mode.
     //*******************************************
-    bool set_mode(etl::timer::id::type id_, bool repeating_)
+    bool set_mode(etl::timer<>::id::type id_, bool repeating_)
     {
       if (stop(id_))
       {
@@ -311,11 +311,11 @@ namespace etl
 
     //*******************************************
     /// Get the time to the next timer event.
-    /// Returns etl::timer::interval::No_Active_Interval if there is no active timer.
+    /// Returns etl::timer<>::interval::No_Active_Interval if there is no active timer.
     //*******************************************
     uint32_t time_to_next() const
     {
-      uint32_t delta = static_cast<uint32_t>(etl::timer::interval::No_Active_Interval);
+      uint32_t delta = static_cast<uint32_t>(etl::timer<>::interval::No_Active_Interval);
 
       ++process_semaphore;
       if (!active_list.empty())
@@ -331,7 +331,7 @@ namespace etl
     /// Checks if a timer is currently active.
     /// Returns <b>true</b> if the timer is active, otherwise <b>false</b>.
     //*******************************************
-    bool is_active(etl::timer::id::type id_) const
+    bool is_active(etl::timer<>::id::type id_) const
     {
       bool result = false;
 
@@ -344,7 +344,7 @@ namespace etl
           const timer_data& timer = timer_array[id_];
 
           // Registered timer?
-          if (timer.id != etl::timer::id::NO_TIMER)
+          if (timer.id != etl::timer<>::id::NO_TIMER)
           {
             result = timer.is_active();
           }
@@ -365,10 +365,10 @@ namespace etl
       timer_data()
         : callback()
         , period(0U)
-        , delta(etl::timer::state::Inactive)
-        , id(etl::timer::id::NO_TIMER)
-        , previous(etl::timer::id::NO_TIMER)
-        , next(etl::timer::id::NO_TIMER)
+        , delta(etl::timer<>::state::Inactive)
+        , id(etl::timer<>::id::NO_TIMER)
+        , previous(etl::timer<>::id::NO_TIMER)
+        , next(etl::timer<>::id::NO_TIMER)
         , repeating(true)
       {
       }
@@ -376,16 +376,16 @@ namespace etl
       //*******************************************
       /// ETL delegate callback
       //*******************************************
-      timer_data(etl::timer::id::type id_,
+      timer_data(etl::timer<>::id::type id_,
                  callback_type        callback_,
                  uint32_t             period_,
                  bool                 repeating_)
         : callback(callback_)
         , period(period_)
-        , delta(etl::timer::state::Inactive)
+        , delta(etl::timer<>::state::Inactive)
         , id(id_)
-        , previous(etl::timer::id::NO_TIMER)
-        , next(etl::timer::id::NO_TIMER)
+        , previous(etl::timer<>::id::NO_TIMER)
+        , next(etl::timer<>::id::NO_TIMER)
         , repeating(repeating_)
       {
       }
@@ -395,7 +395,7 @@ namespace etl
       //*******************************************
       bool is_active() const
       {
-        return delta != etl::timer::state::Inactive;
+        return delta != etl::timer<>::state::Inactive;
       }
 
       //*******************************************
@@ -403,13 +403,13 @@ namespace etl
       //*******************************************
       void set_inactive()
       {
-        delta = etl::timer::state::Inactive;
+        delta = etl::timer<>::state::Inactive;
       }
 
       callback_type        callback;
       uint32_t             period;
       uint32_t             delta;
-      etl::timer::id::type id;
+      etl::timer<>::id::type id;
       uint_least8_t        previous;
       uint_least8_t        next;
       bool                 repeating;
@@ -439,7 +439,7 @@ namespace etl
     //*******************************************
     /// Check that the timer id is valid.
     //*******************************************
-    bool is_valid_timer_id(etl::timer::id::type id_) const
+    bool is_valid_timer_id(etl::timer<>::id::type id_) const
     {
       return (id_ < MAX_TIMERS);
     }
@@ -453,9 +453,9 @@ namespace etl
 
       //*******************************
       timer_list(timer_data* ptimers_)
-        : head(etl::timer::id::NO_TIMER)
-        , tail(etl::timer::id::NO_TIMER)
-        , current(etl::timer::id::NO_TIMER)
+        : head(etl::timer<>::id::NO_TIMER)
+        , tail(etl::timer<>::id::NO_TIMER)
+        , current(etl::timer<>::id::NO_TIMER)
         , ptimers(ptimers_)
       {
       }
@@ -463,30 +463,30 @@ namespace etl
       //*******************************
       bool empty() const
       {
-        return head == etl::timer::id::NO_TIMER;
+        return head == etl::timer<>::id::NO_TIMER;
       }
 
       //*******************************
       // Inserts the timer at the correct delta position
       //*******************************
-      void insert(etl::timer::id::type id_)
+      void insert(etl::timer<>::id::type id_)
       {
         timer_data& timer = ptimers[id_];
 
-        if (head == etl::timer::id::NO_TIMER)
+        if (head == etl::timer<>::id::NO_TIMER)
         {
           // No entries yet.
           head = id_;
           tail = id_;
-          timer.previous = etl::timer::id::NO_TIMER;
-          timer.next = etl::timer::id::NO_TIMER;
+          timer.previous = etl::timer<>::id::NO_TIMER;
+          timer.next = etl::timer<>::id::NO_TIMER;
         }
         else
         {
           // We already have entries.
-          etl::timer::id::type test_id = begin();
+          etl::timer<>::id::type test_id = begin();
 
-          while (test_id != etl::timer::id::NO_TIMER)
+          while (test_id != etl::timer<>::id::NO_TIMER)
           {
             timer_data& test = ptimers[test_id];
 
@@ -506,7 +506,7 @@ namespace etl
               // Adjust the next delta to compensate.
               test.delta -= timer.delta;
 
-              if (timer.previous != etl::timer::id::NO_TIMER)
+              if (timer.previous != etl::timer<>::id::NO_TIMER)
               {
                 ptimers[timer.previous].next = timer.id;
               }
@@ -521,19 +521,19 @@ namespace etl
           }
 
           // Reached the end?
-          if (test_id == etl::timer::id::NO_TIMER)
+          if (test_id == etl::timer<>::id::NO_TIMER)
           {
             // Tag on to the tail.
             ptimers[tail].next = timer.id;
             timer.previous = tail;
-            timer.next = etl::timer::id::NO_TIMER;
+            timer.next = etl::timer<>::id::NO_TIMER;
             tail = timer.id;
           }
         }
       }
 
       //*******************************
-      void remove(etl::timer::id::type id_, bool has_expired)
+      void remove(etl::timer<>::id::type id_, bool has_expired)
       {
         timer_data& timer = ptimers[id_];
 
@@ -558,15 +558,15 @@ namespace etl
         if (!has_expired)
         {
           // Adjust the next delta.
-          if (timer.next != etl::timer::id::NO_TIMER)
+          if (timer.next != etl::timer<>::id::NO_TIMER)
           {
             ptimers[timer.next].delta += timer.delta;
           }
         }
 
-        timer.previous = etl::timer::id::NO_TIMER;
-        timer.next = etl::timer::id::NO_TIMER;
-        timer.delta = etl::timer::state::Inactive;
+        timer.previous = etl::timer<>::id::NO_TIMER;
+        timer.next = etl::timer<>::id::NO_TIMER;
+        timer.delta = etl::timer<>::state::Inactive;
       }
 
       //*******************************
@@ -582,21 +582,21 @@ namespace etl
       }
 
       //*******************************
-      etl::timer::id::type begin()
+      etl::timer<>::id::type begin()
       {
         current = head;
         return current;
       }
 
       //*******************************
-      etl::timer::id::type previous(etl::timer::id::type last)
+      etl::timer<>::id::type previous(etl::timer<>::id::type last)
       {
         current = ptimers[last].previous;
         return current;
       }
 
       //*******************************
-      etl::timer::id::type next(etl::timer::id::type last)
+      etl::timer<>::id::type next(etl::timer<>::id::type last)
       {
         current = ptimers[last].next;
         return current;
@@ -605,25 +605,25 @@ namespace etl
       //*******************************
       void clear()
       {
-        etl::timer::id::type id = begin();
+        etl::timer<>::id::type id = begin();
 
-        while (id != etl::timer::id::NO_TIMER)
+        while (id != etl::timer<>::id::NO_TIMER)
         {
           timer_data& timer = ptimers[id];
           id = next(id);
-          timer.next = etl::timer::id::NO_TIMER;
+          timer.next = etl::timer<>::id::NO_TIMER;
         }
 
-        head = etl::timer::id::NO_TIMER;
-        tail = etl::timer::id::NO_TIMER;
-        current = etl::timer::id::NO_TIMER;
+        head = etl::timer<>::id::NO_TIMER;
+        tail = etl::timer<>::id::NO_TIMER;
+        current = etl::timer<>::id::NO_TIMER;
       }
 
     private:
 
-      etl::timer::id::type head;
-      etl::timer::id::type tail;
-      etl::timer::id::type current;
+      etl::timer<>::id::type head;
+      etl::timer<>::id::type tail;
+      etl::timer<>::id::type current;
 
       timer_data* const ptimers;
     };

--- a/include/etl/callback_timer_interrupt.h
+++ b/include/etl/callback_timer_interrupt.h
@@ -55,11 +55,11 @@ namespace etl
     //*******************************************
     /// Register a timer.
     //*******************************************
-    etl::timer::id::type register_timer(const callback_type& callback_,
+    etl::timer<>::id::type register_timer(const callback_type& callback_,
                                         uint32_t             period_,
                                         bool                 repeating_)
     {
-      etl::timer::id::type id = etl::timer::id::NO_TIMER;
+      etl::timer<>::id::type id = etl::timer<>::id::NO_TIMER;
 
       bool is_space = (number_of_registered_timers < MAX_TIMERS);
 
@@ -70,7 +70,7 @@ namespace etl
         {
           timer_data& timer = timer_array[i];
 
-          if (timer.id == etl::timer::id::NO_TIMER)
+          if (timer.id == etl::timer<>::id::NO_TIMER)
           {
             TInterruptGuard guard;
             (void)guard; // Silence 'unused variable warnings.
@@ -90,15 +90,15 @@ namespace etl
     //*******************************************
     /// Unregister a timer.
     //*******************************************
-    bool unregister_timer(etl::timer::id::type id_)
+    bool unregister_timer(etl::timer<>::id::type id_)
     {
       bool result = false;
 
-      if (id_ != etl::timer::id::NO_TIMER)
+      if (id_ != etl::timer<>::id::NO_TIMER)
       {
         timer_data& timer = timer_array[id_];
 
-        if (timer.id != etl::timer::id::NO_TIMER)
+        if (timer.id != etl::timer<>::id::NO_TIMER)
         {
           if (timer.is_active())
           {
@@ -208,20 +208,20 @@ namespace etl
     //*******************************************
     /// Starts a timer.
     //*******************************************
-    bool start(etl::timer::id::type id_, bool immediate_ = false)
+    bool start(etl::timer<>::id::type id_, bool immediate_ = false)
     {
       bool result = false;
 
       // Valid timer id?
-      if (id_ != etl::timer::id::NO_TIMER)
+      if (id_ != etl::timer<>::id::NO_TIMER)
       {
         timer_data& timer = timer_array[id_];
 
         // Registered timer?
-        if (timer.id != etl::timer::id::NO_TIMER)
+        if (timer.id != etl::timer<>::id::NO_TIMER)
         {
           // Has a valid period.
-          if (timer.period != etl::timer::state::Inactive)
+          if (timer.period != etl::timer<>::state::Inactive)
           {
             TInterruptGuard guard;
             (void)guard; // Silence 'unused variable warnings.
@@ -245,17 +245,17 @@ namespace etl
     //*******************************************
     /// Stops a timer.
     //*******************************************
-    bool stop(etl::timer::id::type id_)
+    bool stop(etl::timer<>::id::type id_)
     {
       bool result = false;
 
       // Valid timer id?
-      if (id_ != etl::timer::id::NO_TIMER)
+      if (id_ != etl::timer<>::id::NO_TIMER)
       {
         timer_data& timer = timer_array[id_];
 
         // Registered timer?
-        if (timer.id != etl::timer::id::NO_TIMER)
+        if (timer.id != etl::timer<>::id::NO_TIMER)
         {
           if (timer.is_active())
           {
@@ -275,7 +275,7 @@ namespace etl
     //*******************************************
     /// Sets a timer's period.
     //*******************************************
-    bool set_period(etl::timer::id::type id_, uint32_t period_)
+    bool set_period(etl::timer<>::id::type id_, uint32_t period_)
     {
       if (stop(id_))
       {
@@ -289,7 +289,7 @@ namespace etl
     //*******************************************
     /// Sets a timer's mode.
     //*******************************************
-    bool set_mode(etl::timer::id::type id_, bool repeating_)
+    bool set_mode(etl::timer<>::id::type id_, bool repeating_)
     {
       if (stop(id_))
       {
@@ -312,11 +312,11 @@ namespace etl
 
     //*******************************************
     /// Get the time to the next timer event.
-    /// Returns etl::timer::interval::No_Active_Interval if there is no active timer.
+    /// Returns etl::timer<>::interval::No_Active_Interval if there is no active timer.
     //*******************************************
     uint32_t time_to_next() const
     {
-      uint32_t delta = static_cast<uint32_t>(etl::timer::interval::No_Active_Interval);
+      uint32_t delta = static_cast<uint32_t>(etl::timer<>::interval::No_Active_Interval);
 
       TInterruptGuard guard;
       (void)guard; // Silence 'unused variable warnings.
@@ -333,7 +333,7 @@ namespace etl
     /// Checks if a timer is currently active.
     /// Returns <b>true</b> if the timer is active, otherwise <b>false</b>.
     //*******************************************
-    bool is_active(etl::timer::id::type id_) const
+    bool is_active(etl::timer<>::id::type id_) const
     {
       // Valid timer id?
       if (is_valid_timer_id(id_))
@@ -346,7 +346,7 @@ namespace etl
           const timer_data& timer = timer_array[id_];
 
           // Registered timer?
-          if (timer.id != etl::timer::id::NO_TIMER)
+          if (timer.id != etl::timer<>::id::NO_TIMER)
           {
             return timer.is_active();
           }
@@ -366,10 +366,10 @@ namespace etl
       timer_data()
         : callback()
         , period(0U)
-        , delta(etl::timer::state::Inactive)
-        , id(etl::timer::id::NO_TIMER)
-        , previous(etl::timer::id::NO_TIMER)
-        , next(etl::timer::id::NO_TIMER)
+        , delta(etl::timer<>::state::Inactive)
+        , id(etl::timer<>::id::NO_TIMER)
+        , previous(etl::timer<>::id::NO_TIMER)
+        , next(etl::timer<>::id::NO_TIMER)
         , repeating(true)
       {
       }
@@ -377,16 +377,16 @@ namespace etl
       //*******************************************
       /// ETL delegate callback
       //*******************************************
-      timer_data(etl::timer::id::type id_,
+      timer_data(etl::timer<>::id::type id_,
                  callback_type        callback_,
                  uint32_t             period_,
                  bool                 repeating_)
         : callback(callback_)
         , period(period_)
-        , delta(etl::timer::state::Inactive)
+        , delta(etl::timer<>::state::Inactive)
         , id(id_)
-        , previous(etl::timer::id::NO_TIMER)
-        , next(etl::timer::id::NO_TIMER)
+        , previous(etl::timer<>::id::NO_TIMER)
+        , next(etl::timer<>::id::NO_TIMER)
         , repeating(repeating_)
       {
       }
@@ -396,7 +396,7 @@ namespace etl
       //*******************************************
       bool is_active() const
       {
-        return delta != etl::timer::state::Inactive;
+        return delta != etl::timer<>::state::Inactive;
       }
 
       //*******************************************
@@ -404,13 +404,13 @@ namespace etl
       //*******************************************
       void set_inactive()
       {
-        delta = etl::timer::state::Inactive;
+        delta = etl::timer<>::state::Inactive;
       }
 
       callback_type        callback;
       uint32_t             period;
       uint32_t             delta;
-      etl::timer::id::type id;
+      etl::timer<>::id::type id;
       uint_least8_t        previous;
       uint_least8_t        next;
       bool                 repeating;
@@ -439,7 +439,7 @@ namespace etl
     //*******************************************
     /// Check that the timer id is valid.
     //*******************************************
-    bool is_valid_timer_id(etl::timer::id::type id_) const
+    bool is_valid_timer_id(etl::timer<>::id::type id_) const
     {
       return (id_ < MAX_TIMERS);
     }
@@ -453,9 +453,9 @@ namespace etl
 
       //*******************************
       timer_list(timer_data* ptimers_)
-        : head(etl::timer::id::NO_TIMER)
-        , tail(etl::timer::id::NO_TIMER)
-        , current(etl::timer::id::NO_TIMER)
+        : head(etl::timer<>::id::NO_TIMER)
+        , tail(etl::timer<>::id::NO_TIMER)
+        , current(etl::timer<>::id::NO_TIMER)
         , ptimers(ptimers_)
       {
       }
@@ -463,30 +463,30 @@ namespace etl
       //*******************************
       bool empty() const
       {
-        return head == etl::timer::id::NO_TIMER;
+        return head == etl::timer<>::id::NO_TIMER;
       }
 
       //*******************************
       // Inserts the timer at the correct delta position
       //*******************************
-      void insert(etl::timer::id::type id_)
+      void insert(etl::timer<>::id::type id_)
       {
         timer_data& timer = ptimers[id_];
 
-        if (head == etl::timer::id::NO_TIMER)
+        if (head == etl::timer<>::id::NO_TIMER)
         {
           // No entries yet.
           head = id_;
           tail = id_;
-          timer.previous = etl::timer::id::NO_TIMER;
-          timer.next = etl::timer::id::NO_TIMER;
+          timer.previous = etl::timer<>::id::NO_TIMER;
+          timer.next = etl::timer<>::id::NO_TIMER;
         }
         else
         {
           // We already have entries.
-          etl::timer::id::type test_id = begin();
+          etl::timer<>::id::type test_id = begin();
 
-          while (test_id != etl::timer::id::NO_TIMER)
+          while (test_id != etl::timer<>::id::NO_TIMER)
           {
             timer_data& test = ptimers[test_id];
 
@@ -506,7 +506,7 @@ namespace etl
               // Adjust the next delta to compensate.
               test.delta -= timer.delta;
 
-              if (timer.previous != etl::timer::id::NO_TIMER)
+              if (timer.previous != etl::timer<>::id::NO_TIMER)
               {
                 ptimers[timer.previous].next = timer.id;
               }
@@ -521,19 +521,19 @@ namespace etl
           }
 
           // Reached the end?
-          if (test_id == etl::timer::id::NO_TIMER)
+          if (test_id == etl::timer<>::id::NO_TIMER)
           {
             // Tag on to the tail.
             ptimers[tail].next = timer.id;
             timer.previous = tail;
-            timer.next = etl::timer::id::NO_TIMER;
+            timer.next = etl::timer<>::id::NO_TIMER;
             tail = timer.id;
           }
         }
       }
 
       //*******************************
-      void remove(etl::timer::id::type id_, bool has_expired)
+      void remove(etl::timer<>::id::type id_, bool has_expired)
       {
         timer_data& timer = ptimers[id_];
 
@@ -558,15 +558,15 @@ namespace etl
         if (!has_expired)
         {
           // Adjust the next delta.
-          if (timer.next != etl::timer::id::NO_TIMER)
+          if (timer.next != etl::timer<>::id::NO_TIMER)
           {
             ptimers[timer.next].delta += timer.delta;
           }
         }
 
-        timer.previous = etl::timer::id::NO_TIMER;
-        timer.next     = etl::timer::id::NO_TIMER;
-        timer.delta    = etl::timer::state::Inactive;
+        timer.previous = etl::timer<>::id::NO_TIMER;
+        timer.next     = etl::timer<>::id::NO_TIMER;
+        timer.delta    = etl::timer<>::state::Inactive;
       }
 
       //*******************************
@@ -582,21 +582,21 @@ namespace etl
       }
 
       //*******************************
-      etl::timer::id::type begin()
+      etl::timer<>::id::type begin()
       {
         current = head;
         return current;
       }
 
       //*******************************
-      etl::timer::id::type previous(etl::timer::id::type last)
+      etl::timer<>::id::type previous(etl::timer<>::id::type last)
       {
         current = ptimers[last].previous;
         return current;
       }
 
       //*******************************
-      etl::timer::id::type next(etl::timer::id::type last)
+      etl::timer<>::id::type next(etl::timer<>::id::type last)
       {
         current = ptimers[last].next;
         return current;
@@ -605,25 +605,25 @@ namespace etl
       //*******************************
       void clear()
       {
-        etl::timer::id::type id = begin();
+        etl::timer<>::id::type id = begin();
 
-        while (id != etl::timer::id::NO_TIMER)
+        while (id != etl::timer<>::id::NO_TIMER)
         {
           timer_data& timer = ptimers[id];
           id = next(id);
-          timer.next = etl::timer::id::NO_TIMER;
+          timer.next = etl::timer<>::id::NO_TIMER;
         }
 
-        head    = etl::timer::id::NO_TIMER;
-        tail    = etl::timer::id::NO_TIMER;
-        current = etl::timer::id::NO_TIMER;
+        head    = etl::timer<>::id::NO_TIMER;
+        tail    = etl::timer<>::id::NO_TIMER;
+        current = etl::timer<>::id::NO_TIMER;
       }
 
     private:
 
-      etl::timer::id::type head;
-      etl::timer::id::type tail;
-      etl::timer::id::type current;
+      etl::timer<>::id::type head;
+      etl::timer<>::id::type tail;
+      etl::timer<>::id::type current;
 
       timer_data* const ptimers;
     };

--- a/include/etl/callback_timer_locked.h
+++ b/include/etl/callback_timer_locked.h
@@ -57,11 +57,11 @@ namespace etl
     //*******************************************
     /// Register a timer.
     //*******************************************
-    etl::timer::id::type register_timer(const callback_type& callback_,
+    etl::timer<>::id::type register_timer(const callback_type& callback_,
                                         uint32_t             period_,
                                         bool                 repeating_)
     {
-      etl::timer::id::type id = etl::timer::id::NO_TIMER;
+      etl::timer<>::id::type id = etl::timer<>::id::NO_TIMER;
 
       bool is_space = (number_of_registered_timers < MAX_TIMERS);
 
@@ -72,7 +72,7 @@ namespace etl
         {
           timer_data& timer = timer_array[i];
 
-          if (timer.id == etl::timer::id::NO_TIMER)
+          if (timer.id == etl::timer<>::id::NO_TIMER)
           {
             // Create in-place.
             new (&timer) timer_data(i, callback_, period_, repeating_);
@@ -89,15 +89,15 @@ namespace etl
     //*******************************************
     /// Unregister a timer.
     //*******************************************
-    bool unregister_timer(etl::timer::id::type id_)
+    bool unregister_timer(etl::timer<>::id::type id_)
     {
       bool result = false;
 
-      if (id_ != etl::timer::id::NO_TIMER)
+      if (id_ != etl::timer<>::id::NO_TIMER)
       {
         timer_data& timer = timer_array[id_];
 
-        if (timer.id != etl::timer::id::NO_TIMER)
+        if (timer.id != etl::timer<>::id::NO_TIMER)
         {
           if (timer.is_active())
           {
@@ -209,20 +209,20 @@ namespace etl
     //*******************************************
     /// Starts a timer.
     //*******************************************
-    bool start(etl::timer::id::type id_, bool immediate_ = false)
+    bool start(etl::timer<>::id::type id_, bool immediate_ = false)
     {
       bool result = false;
 
       // Valid timer id?
-      if (id_ != etl::timer::id::NO_TIMER)
+      if (id_ != etl::timer<>::id::NO_TIMER)
       {
         timer_data& timer = timer_array[id_];
 
         // Registered timer?
-        if (timer.id != etl::timer::id::NO_TIMER)
+        if (timer.id != etl::timer<>::id::NO_TIMER)
         {
           // Has a valid period.
-          if (timer.period != etl::timer::state::Inactive)
+          if (timer.period != etl::timer<>::state::Inactive)
           {
             lock();
             if (timer.is_active())
@@ -245,17 +245,17 @@ namespace etl
     //*******************************************
     /// Stops a timer.
     //*******************************************
-    bool stop(etl::timer::id::type id_)
+    bool stop(etl::timer<>::id::type id_)
     {
       bool result = false;
 
       // Valid timer id?
-      if (id_ != etl::timer::id::NO_TIMER)
+      if (id_ != etl::timer<>::id::NO_TIMER)
       {
         timer_data& timer = timer_array[id_];
 
         // Registered timer?
-        if (timer.id != etl::timer::id::NO_TIMER)
+        if (timer.id != etl::timer<>::id::NO_TIMER)
         {
           if (timer.is_active())
           {
@@ -274,7 +274,7 @@ namespace etl
     //*******************************************
     /// Sets a timer's period.
     //*******************************************
-    bool set_period(etl::timer::id::type id_, uint32_t period_)
+    bool set_period(etl::timer<>::id::type id_, uint32_t period_)
     {
       if (stop(id_))
       {
@@ -288,7 +288,7 @@ namespace etl
     //*******************************************
     /// Sets a timer's mode.
     //*******************************************
-    bool set_mode(etl::timer::id::type id_, bool repeating_)
+    bool set_mode(etl::timer<>::id::type id_, bool repeating_)
     {
       if (stop(id_))
       {
@@ -323,11 +323,11 @@ namespace etl
 
     //*******************************************
     /// Get the time to the next timer event.
-    /// Returns etl::timer::interval::No_Active_Interval if there is no active timer.
+    /// Returns etl::timer<>::interval::No_Active_Interval if there is no active timer.
     //*******************************************
     uint32_t time_to_next() const
     {
-      uint32_t delta = static_cast<uint32_t>(etl::timer::interval::No_Active_Interval);
+      uint32_t delta = static_cast<uint32_t>(etl::timer<>::interval::No_Active_Interval);
 
       lock();
       if (!active_list.empty())
@@ -343,7 +343,7 @@ namespace etl
     /// Checks if a timer is currently active.
     /// Returns <b>true</b> if the timer is active, otherwise <b>false</b>.
     //*******************************************
-    bool is_active(etl::timer::id::type id_) const
+    bool is_active(etl::timer<>::id::type id_) const
     {
       bool result = false;
 
@@ -356,7 +356,7 @@ namespace etl
           const timer_data& timer = timer_array[id_];
 
           // Registered timer?
-          if (timer.id != etl::timer::id::NO_TIMER)
+          if (timer.id != etl::timer<>::id::NO_TIMER)
           {
             result = timer.is_active();
           }
@@ -377,10 +377,10 @@ namespace etl
       timer_data()
         : callback()
         , period(0U)
-        , delta(etl::timer::state::Inactive)
-        , id(etl::timer::id::NO_TIMER)
-        , previous(etl::timer::id::NO_TIMER)
-        , next(etl::timer::id::NO_TIMER)
+        , delta(etl::timer<>::state::Inactive)
+        , id(etl::timer<>::id::NO_TIMER)
+        , previous(etl::timer<>::id::NO_TIMER)
+        , next(etl::timer<>::id::NO_TIMER)
         , repeating(true)
       {
       }
@@ -388,16 +388,16 @@ namespace etl
       //*******************************************
       /// ETL delegate callback
       //*******************************************
-      timer_data(etl::timer::id::type id_,
+      timer_data(etl::timer<>::id::type id_,
                  callback_type        callback_,
                  uint32_t             period_,
                  bool                 repeating_)
         : callback(callback_)
         , period(period_)
-        , delta(etl::timer::state::Inactive)
+        , delta(etl::timer<>::state::Inactive)
         , id(id_)
-        , previous(etl::timer::id::NO_TIMER)
-        , next(etl::timer::id::NO_TIMER)
+        , previous(etl::timer<>::id::NO_TIMER)
+        , next(etl::timer<>::id::NO_TIMER)
         , repeating(repeating_)
       {
       }
@@ -407,7 +407,7 @@ namespace etl
       //*******************************************
       bool is_active() const
       {
-        return delta != etl::timer::state::Inactive;
+        return delta != etl::timer<>::state::Inactive;
       }
 
       //*******************************************
@@ -415,13 +415,13 @@ namespace etl
       //*******************************************
       void set_inactive()
       {
-        delta = etl::timer::state::Inactive;
+        delta = etl::timer<>::state::Inactive;
       }
 
       callback_type        callback;
       uint32_t             period;
       uint32_t             delta;
-      etl::timer::id::type id;
+      etl::timer<>::id::type id;
       uint_least8_t        previous;
       uint_least8_t        next;
       bool                 repeating;
@@ -456,9 +456,9 @@ namespace etl
 
       //*******************************
       timer_list(timer_data* ptimers_)
-        : head(etl::timer::id::NO_TIMER)
-        , tail(etl::timer::id::NO_TIMER)
-        , current(etl::timer::id::NO_TIMER)
+        : head(etl::timer<>::id::NO_TIMER)
+        , tail(etl::timer<>::id::NO_TIMER)
+        , current(etl::timer<>::id::NO_TIMER)
         , ptimers(ptimers_)
       {
       }
@@ -466,30 +466,30 @@ namespace etl
       //*******************************
       bool empty() const
       {
-        return head == etl::timer::id::NO_TIMER;
+        return head == etl::timer<>::id::NO_TIMER;
       }
 
       //*******************************
       // Inserts the timer at the correct delta position
       //*******************************
-      void insert(etl::timer::id::type id_)
+      void insert(etl::timer<>::id::type id_)
       {
         timer_data& timer = ptimers[id_];
 
-        if (head == etl::timer::id::NO_TIMER)
+        if (head == etl::timer<>::id::NO_TIMER)
         {
           // No entries yet.
           head = id_;
           tail = id_;
-          timer.previous = etl::timer::id::NO_TIMER;
-          timer.next = etl::timer::id::NO_TIMER;
+          timer.previous = etl::timer<>::id::NO_TIMER;
+          timer.next = etl::timer<>::id::NO_TIMER;
         }
         else
         {
           // We already have entries.
-          etl::timer::id::type test_id = begin();
+          etl::timer<>::id::type test_id = begin();
 
-          while (test_id != etl::timer::id::NO_TIMER)
+          while (test_id != etl::timer<>::id::NO_TIMER)
           {
             timer_data& test = ptimers[test_id];
 
@@ -509,7 +509,7 @@ namespace etl
               // Adjust the next delta to compensate.
               test.delta -= timer.delta;
 
-              if (timer.previous != etl::timer::id::NO_TIMER)
+              if (timer.previous != etl::timer<>::id::NO_TIMER)
               {
                 ptimers[timer.previous].next = timer.id;
               }
@@ -524,19 +524,19 @@ namespace etl
           }
 
           // Reached the end?
-          if (test_id == etl::timer::id::NO_TIMER)
+          if (test_id == etl::timer<>::id::NO_TIMER)
           {
             // Tag on to the tail.
             ptimers[tail].next = timer.id;
             timer.previous = tail;
-            timer.next = etl::timer::id::NO_TIMER;
+            timer.next = etl::timer<>::id::NO_TIMER;
             tail = timer.id;
           }
         }
       }
 
       //*******************************
-      void remove(etl::timer::id::type id_, bool has_expired)
+      void remove(etl::timer<>::id::type id_, bool has_expired)
       {
         timer_data& timer = ptimers[id_];
 
@@ -561,15 +561,15 @@ namespace etl
         if (!has_expired)
         {
           // Adjust the next delta.
-          if (timer.next != etl::timer::id::NO_TIMER)
+          if (timer.next != etl::timer<>::id::NO_TIMER)
           {
             ptimers[timer.next].delta += timer.delta;
           }
         }
 
-        timer.previous = etl::timer::id::NO_TIMER;
-        timer.next = etl::timer::id::NO_TIMER;
-        timer.delta = etl::timer::state::Inactive;
+        timer.previous = etl::timer<>::id::NO_TIMER;
+        timer.next = etl::timer<>::id::NO_TIMER;
+        timer.delta = etl::timer<>::state::Inactive;
       }
 
       //*******************************
@@ -585,21 +585,21 @@ namespace etl
       }
 
       //*******************************
-      etl::timer::id::type begin()
+      etl::timer<>::id::type begin()
       {
         current = head;
         return current;
       }
 
       //*******************************
-      etl::timer::id::type previous(etl::timer::id::type last)
+      etl::timer<>::id::type previous(etl::timer<>::id::type last)
       {
         current = ptimers[last].previous;
         return current;
       }
 
       //*******************************
-      etl::timer::id::type next(etl::timer::id::type last)
+      etl::timer<>::id::type next(etl::timer<>::id::type last)
       {
         current = ptimers[last].next;
         return current;
@@ -608,25 +608,25 @@ namespace etl
       //*******************************
       void clear()
       {
-        etl::timer::id::type id = begin();
+        etl::timer<>::id::type id = begin();
 
-        while (id != etl::timer::id::NO_TIMER)
+        while (id != etl::timer<>::id::NO_TIMER)
         {
           timer_data& timer = ptimers[id];
           id = next(id);
-          timer.next = etl::timer::id::NO_TIMER;
+          timer.next = etl::timer<>::id::NO_TIMER;
         }
 
-        head = etl::timer::id::NO_TIMER;
-        tail = etl::timer::id::NO_TIMER;
-        current = etl::timer::id::NO_TIMER;
+        head = etl::timer<>::id::NO_TIMER;
+        tail = etl::timer<>::id::NO_TIMER;
+        current = etl::timer<>::id::NO_TIMER;
       }
 
     private:
 
-      etl::timer::id::type head;
-      etl::timer::id::type tail;
-      etl::timer::id::type current;
+      etl::timer<>::id::type head;
+      etl::timer<>::id::type tail;
+      etl::timer<>::id::type current;
 
       timer_data* const ptimers;
     };
@@ -634,7 +634,7 @@ namespace etl
     //*******************************************
     /// Check that the timer id is valid.
     //*******************************************
-    bool is_valid_timer_id(etl::timer::id::type id_) const
+    bool is_valid_timer_id(etl::timer<>::id::type id_) const
     {
       return (id_ < MAX_TIMERS);
     }

--- a/include/etl/message_timer_atomic.h
+++ b/include/etl/message_timer_atomic.h
@@ -57,13 +57,13 @@ namespace etl
     //*******************************************
     /// Register a timer.
     //*******************************************
-    etl::timer::id::type register_timer(const etl::imessage&     message_,
+    etl::timer<>::id::type register_timer(const etl::imessage&     message_,
                                         etl::imessage_router&    router_,
                                         uint32_t                 period_,
                                         bool                     repeating_,
                                         etl::message_router_id_t destination_router_id_ = etl::imessage_router::ALL_MESSAGE_ROUTERS)
     {
-      etl::timer::id::type id = etl::timer::id::NO_TIMER;
+      etl::timer<>::id::type id = etl::timer<>::id::NO_TIMER;
 
       bool is_space = (registered_timers < MAX_TIMERS);
 
@@ -77,7 +77,7 @@ namespace etl
           {
             timer_data& timer = timer_array[i];
 
-            if (timer.id == etl::timer::id::NO_TIMER)
+            if (timer.id == etl::timer<>::id::NO_TIMER)
             {
               // Create in-place.
               new (&timer) timer_data(i, message_, router_, period_, repeating_, destination_router_id_);
@@ -95,15 +95,15 @@ namespace etl
     //*******************************************
     /// Unregister a timer.
     //*******************************************
-    bool unregister_timer(etl::timer::id::type id_)
+    bool unregister_timer(etl::timer<>::id::type id_)
     {
       bool result = false;
 
-      if (id_ != etl::timer::id::NO_TIMER)
+      if (id_ != etl::timer<>::id::NO_TIMER)
       {
         timer_data& timer = timer_array[id_];
 
-        if (timer.id != etl::timer::id::NO_TIMER)
+        if (timer.id != etl::timer<>::id::NO_TIMER)
         {
           if (timer.is_active())
           {
@@ -212,20 +212,20 @@ namespace etl
     //*******************************************
     /// Starts a timer.
     //*******************************************
-    bool start(etl::timer::id::type id_, bool immediate_ = false)
+    bool start(etl::timer<>::id::type id_, bool immediate_ = false)
     {
       bool result = false;
 
       // Valid timer id?
-      if (id_ != etl::timer::id::NO_TIMER)
+      if (id_ != etl::timer<>::id::NO_TIMER)
       {
         timer_data& timer = timer_array[id_];
 
         // Registered timer?
-        if (timer.id != etl::timer::id::NO_TIMER)
+        if (timer.id != etl::timer<>::id::NO_TIMER)
         {
           // Has a valid period.
-          if (timer.period != etl::timer::state::Inactive)
+          if (timer.period != etl::timer<>::state::Inactive)
           {
             ++process_semaphore;
             if (timer.is_active())
@@ -248,17 +248,17 @@ namespace etl
     //*******************************************
     /// Stops a timer.
     //*******************************************
-    bool stop(etl::timer::id::type id_)
+    bool stop(etl::timer<>::id::type id_)
     {
       bool result = false;
 
       // Valid timer id?
-      if (id_ != etl::timer::id::NO_TIMER)
+      if (id_ != etl::timer<>::id::NO_TIMER)
       {
         timer_data& timer = timer_array[id_];
 
         // Registered timer?
-        if (timer.id != etl::timer::id::NO_TIMER)
+        if (timer.id != etl::timer<>::id::NO_TIMER)
         {
           if (timer.is_active())
           {
@@ -277,7 +277,7 @@ namespace etl
     //*******************************************
     /// Sets a timer's period.
     //*******************************************
-    bool set_period(etl::timer::id::type id_, uint32_t period_)
+    bool set_period(etl::timer<>::id::type id_, uint32_t period_)
     {
       if (stop(id_))
       {
@@ -291,7 +291,7 @@ namespace etl
     //*******************************************
     /// Sets a timer's mode.
     //*******************************************
-    bool set_mode(etl::timer::id::type id_, bool repeating_)
+    bool set_mode(etl::timer<>::id::type id_, bool repeating_)
     {
       if (stop(id_))
       {
@@ -316,11 +316,11 @@ namespace etl
 
     //*******************************************
     /// Get the time to the next timer event.
-    /// Returns etl::timer::interval::No_Active_Interval if there is no active timer.
+    /// Returns etl::timer<>::interval::No_Active_Interval if there is no active timer.
     //*******************************************
     uint32_t time_to_next() const
     {
-      uint32_t delta = static_cast<uint32_t>(etl::timer::interval::No_Active_Interval);
+      uint32_t delta = static_cast<uint32_t>(etl::timer<>::interval::No_Active_Interval);
 
       ++process_semaphore;
       if (!active_list.empty())
@@ -343,17 +343,17 @@ namespace etl
         : p_message(ETL_NULLPTR)
         , p_router(ETL_NULLPTR)
         , period(0U)
-        , delta(etl::timer::state::Inactive)
+        , delta(etl::timer<>::state::Inactive)
         , destination_router_id(etl::imessage_bus::ALL_MESSAGE_ROUTERS)
-        , id(etl::timer::id::NO_TIMER)
-        , previous(etl::timer::id::NO_TIMER)
-        , next(etl::timer::id::NO_TIMER)
+        , id(etl::timer<>::id::NO_TIMER)
+        , previous(etl::timer<>::id::NO_TIMER)
+        , next(etl::timer<>::id::NO_TIMER)
         , repeating(true)
       {
       }
 
       //*******************************************
-      timer_data(etl::timer::id::type     id_,
+      timer_data(etl::timer<>::id::type     id_,
         const etl::imessage& message_,
         etl::imessage_router& irouter_,
         uint32_t                 period_,
@@ -362,11 +362,11 @@ namespace etl
         : p_message(&message_)
         , p_router(&irouter_)
         , period(period_)
-        , delta(etl::timer::state::Inactive)
+        , delta(etl::timer<>::state::Inactive)
         , destination_router_id(destination_router_id_)
         , id(id_)
-        , previous(etl::timer::id::NO_TIMER)
-        , next(etl::timer::id::NO_TIMER)
+        , previous(etl::timer<>::id::NO_TIMER)
+        , next(etl::timer<>::id::NO_TIMER)
         , repeating(repeating_)
       {
       }
@@ -376,7 +376,7 @@ namespace etl
       //*******************************************
       bool is_active() const
       {
-        return delta != etl::timer::state::Inactive;
+        return delta != etl::timer<>::state::Inactive;
       }
 
       //*******************************************
@@ -384,7 +384,7 @@ namespace etl
       //*******************************************
       void set_inactive()
       {
-        delta = etl::timer::state::Inactive;
+        delta = etl::timer<>::state::Inactive;
       }
 
       const etl::imessage*     p_message;
@@ -392,7 +392,7 @@ namespace etl
       uint32_t                 period;
       uint32_t                 delta;
       etl::message_router_id_t destination_router_id;
-      etl::timer::id::type     id;
+      etl::timer<>::id::type     id;
       uint_least8_t            previous;
       uint_least8_t            next;
       bool                     repeating;
@@ -435,9 +435,9 @@ namespace etl
 
       //*******************************
       timer_list(timer_data* ptimers_)
-        : head(etl::timer::id::NO_TIMER)
-        , tail(etl::timer::id::NO_TIMER)
-        , current(etl::timer::id::NO_TIMER)
+        : head(etl::timer<>::id::NO_TIMER)
+        , tail(etl::timer<>::id::NO_TIMER)
+        , current(etl::timer<>::id::NO_TIMER)
         , ptimers(ptimers_)
       {
       }
@@ -445,30 +445,30 @@ namespace etl
       //*******************************
       bool empty() const
       {
-        return head == etl::timer::id::NO_TIMER;
+        return head == etl::timer<>::id::NO_TIMER;
       }
 
       //*******************************
       // Inserts the timer at the correct delta position
       //*******************************
-      void insert(etl::timer::id::type id_)
+      void insert(etl::timer<>::id::type id_)
       {
         timer_data& timer = ptimers[id_];
 
-        if (head == etl::timer::id::NO_TIMER)
+        if (head == etl::timer<>::id::NO_TIMER)
         {
           // No entries yet.
           head = id_;
           tail = id_;
-          timer.previous = etl::timer::id::NO_TIMER;
-          timer.next = etl::timer::id::NO_TIMER;
+          timer.previous = etl::timer<>::id::NO_TIMER;
+          timer.next = etl::timer<>::id::NO_TIMER;
         }
         else
         {
           // We already have entries.
-          etl::timer::id::type test_id = begin();
+          etl::timer<>::id::type test_id = begin();
 
-          while (test_id != etl::timer::id::NO_TIMER)
+          while (test_id != etl::timer<>::id::NO_TIMER)
           {
             timer_data& test = ptimers[test_id];
 
@@ -488,7 +488,7 @@ namespace etl
               // Adjust the next delta to compensate.
               test.delta -= timer.delta;
 
-              if (timer.previous != etl::timer::id::NO_TIMER)
+              if (timer.previous != etl::timer<>::id::NO_TIMER)
               {
                 ptimers[timer.previous].next = timer.id;
               }
@@ -503,19 +503,19 @@ namespace etl
           }
 
           // Reached the end?
-          if (test_id == etl::timer::id::NO_TIMER)
+          if (test_id == etl::timer<>::id::NO_TIMER)
           {
             // Tag on to the tail.
             ptimers[tail].next = timer.id;
             timer.previous = tail;
-            timer.next = etl::timer::id::NO_TIMER;
+            timer.next = etl::timer<>::id::NO_TIMER;
             tail = timer.id;
           }
         }
       }
 
       //*******************************
-      void remove(etl::timer::id::type id_, bool has_expired)
+      void remove(etl::timer<>::id::type id_, bool has_expired)
       {
         timer_data& timer = ptimers[id_];
 
@@ -540,15 +540,15 @@ namespace etl
         if (!has_expired)
         {
           // Adjust the next delta.
-          if (timer.next != etl::timer::id::NO_TIMER)
+          if (timer.next != etl::timer<>::id::NO_TIMER)
           {
             ptimers[timer.next].delta += timer.delta;
           }
         }
 
-        timer.previous = etl::timer::id::NO_TIMER;
-        timer.next = etl::timer::id::NO_TIMER;
-        timer.delta = etl::timer::state::Inactive;
+        timer.previous = etl::timer<>::id::NO_TIMER;
+        timer.next = etl::timer<>::id::NO_TIMER;
+        timer.delta = etl::timer<>::state::Inactive;
       }
 
       //*******************************
@@ -564,21 +564,21 @@ namespace etl
       }
 
       //*******************************
-      etl::timer::id::type begin()
+      etl::timer<>::id::type begin()
       {
         current = head;
         return current;
       }
 
       //*******************************
-      etl::timer::id::type previous(etl::timer::id::type last)
+      etl::timer<>::id::type previous(etl::timer<>::id::type last)
       {
         current = ptimers[last].previous;
         return current;
       }
 
       //*******************************
-      etl::timer::id::type next(etl::timer::id::type last)
+      etl::timer<>::id::type next(etl::timer<>::id::type last)
       {
         current = ptimers[last].next;
         return current;
@@ -587,25 +587,25 @@ namespace etl
       //*******************************
       void clear()
       {
-        etl::timer::id::type id = begin();
+        etl::timer<>::id::type id = begin();
 
-        while (id != etl::timer::id::NO_TIMER)
+        while (id != etl::timer<>::id::NO_TIMER)
         {
           timer_data& timer = ptimers[id];
           id = next(id);
-          timer.next = etl::timer::id::NO_TIMER;
+          timer.next = etl::timer<>::id::NO_TIMER;
         }
 
-        head = etl::timer::id::NO_TIMER;
-        tail = etl::timer::id::NO_TIMER;
-        current = etl::timer::id::NO_TIMER;
+        head = etl::timer<>::id::NO_TIMER;
+        tail = etl::timer<>::id::NO_TIMER;
+        current = etl::timer<>::id::NO_TIMER;
       }
 
     private:
 
-      etl::timer::id::type head;
-      etl::timer::id::type tail;
-      etl::timer::id::type current;
+      etl::timer<>::id::type head;
+      etl::timer<>::id::type tail;
+      etl::timer<>::id::type current;
 
       timer_data* const ptimers;
     };

--- a/include/etl/message_timer_interrupt.h
+++ b/include/etl/message_timer_interrupt.h
@@ -59,13 +59,13 @@ namespace etl
     //*******************************************
     /// Register a timer.
     //*******************************************
-    etl::timer::id::type register_timer(const etl::imessage&     message_,
+    etl::timer<>::id::type register_timer(const etl::imessage&     message_,
                                         etl::imessage_router&    router_,
                                         uint32_t                 period_,
                                         bool                     repeating_,
                                         etl::message_router_id_t destination_router_id_ = etl::imessage_router::ALL_MESSAGE_ROUTERS)
     {
-      etl::timer::id::type id = etl::timer::id::NO_TIMER;
+      etl::timer<>::id::type id = etl::timer<>::id::NO_TIMER;
 
       bool is_space = (number_of_registered_timers < MAX_TIMERS);
 
@@ -79,7 +79,7 @@ namespace etl
           {
             timer_data& timer = timer_array[i];
 
-            if (timer.id == etl::timer::id::NO_TIMER)
+            if (timer.id == etl::timer<>::id::NO_TIMER)
             {
               TInterruptGuard guard;
               (void)guard; // Silence 'unused variable warnings.
@@ -100,15 +100,15 @@ namespace etl
     //*******************************************
     /// Unregister a timer.
     //*******************************************
-    bool unregister_timer(etl::timer::id::type id_)
+    bool unregister_timer(etl::timer<>::id::type id_)
     {
       bool result = false;
 
-      if (id_ != etl::timer::id::NO_TIMER)
+      if (id_ != etl::timer<>::id::NO_TIMER)
       {
         timer_data& timer = timer_array[id_];
 
-        if (timer.id != etl::timer::id::NO_TIMER)
+        if (timer.id != etl::timer<>::id::NO_TIMER)
         {
           if (timer.is_active())
           {
@@ -219,20 +219,20 @@ namespace etl
     //*******************************************
     /// Starts a timer.
     //*******************************************
-    bool start(etl::timer::id::type id_, bool immediate_ = false)
+    bool start(etl::timer<>::id::type id_, bool immediate_ = false)
     {
       bool result = false;
 
       // Valid timer id?
-      if (id_ != etl::timer::id::NO_TIMER)
+      if (id_ != etl::timer<>::id::NO_TIMER)
       {
         timer_data& timer = timer_array[id_];
 
         // Registered timer?
-        if (timer.id != etl::timer::id::NO_TIMER)
+        if (timer.id != etl::timer<>::id::NO_TIMER)
         {
           // Has a valid period.
-          if (timer.period != etl::timer::state::Inactive)
+          if (timer.period != etl::timer<>::state::Inactive)
           {
             TInterruptGuard guard;
             (void)guard; // Silence 'unused variable warnings.
@@ -256,17 +256,17 @@ namespace etl
     //*******************************************
     /// Stops a timer.
     //*******************************************
-    bool stop(etl::timer::id::type id_)
+    bool stop(etl::timer<>::id::type id_)
     {
       bool result = false;
 
       // Valid timer id?
-      if (id_ != etl::timer::id::NO_TIMER)
+      if (id_ != etl::timer<>::id::NO_TIMER)
       {
         timer_data& timer = timer_array[id_];
 
         // Registered timer?
-        if (timer.id != etl::timer::id::NO_TIMER)
+        if (timer.id != etl::timer<>::id::NO_TIMER)
         {
           if (timer.is_active())
           {
@@ -286,7 +286,7 @@ namespace etl
     //*******************************************
     /// Sets a timer's period.
     //*******************************************
-    bool set_period(etl::timer::id::type id_, uint32_t period_)
+    bool set_period(etl::timer<>::id::type id_, uint32_t period_)
     {
       if (stop(id_))
       {
@@ -300,7 +300,7 @@ namespace etl
     //*******************************************
     /// Sets a timer's mode.
     //*******************************************
-    bool set_mode(etl::timer::id::type id_, bool repeating_)
+    bool set_mode(etl::timer<>::id::type id_, bool repeating_)
     {
       if (stop(id_))
       {
@@ -323,11 +323,11 @@ namespace etl
 
     //*******************************************
     /// Get the time to the next timer event.
-    /// Returns etl::timer::interval::No_Active_Interval if there is no active timer.
+    /// Returns etl::timer<>::interval::No_Active_Interval if there is no active timer.
     //*******************************************
     uint32_t time_to_next() const
     {
-      uint32_t delta = static_cast<uint32_t>(etl::timer::interval::No_Active_Interval);
+      uint32_t delta = static_cast<uint32_t>(etl::timer<>::interval::No_Active_Interval);
 
       TInterruptGuard guard;
       (void)guard; // Silence 'unused variable warnings.
@@ -351,17 +351,17 @@ namespace etl
         : p_message(ETL_NULLPTR)
         , p_router(ETL_NULLPTR)
         , period(0)
-        , delta(etl::timer::state::Inactive)
+        , delta(etl::timer<>::state::Inactive)
         , destination_router_id(etl::imessage_bus::ALL_MESSAGE_ROUTERS)
-        , id(etl::timer::id::NO_TIMER)
-        , previous(etl::timer::id::NO_TIMER)
-        , next(etl::timer::id::NO_TIMER)
+        , id(etl::timer<>::id::NO_TIMER)
+        , previous(etl::timer<>::id::NO_TIMER)
+        , next(etl::timer<>::id::NO_TIMER)
         , repeating(true)
       {
       }
 
       //*******************************************
-      timer_data(etl::timer::id::type     id_,
+      timer_data(etl::timer<>::id::type     id_,
                  const etl::imessage&     message_,
                  etl::imessage_router&    irouter_,
                  uint32_t                 period_,
@@ -370,11 +370,11 @@ namespace etl
         : p_message(&message_)
         , p_router(&irouter_)
         , period(period_)
-        , delta(etl::timer::state::Inactive)
+        , delta(etl::timer<>::state::Inactive)
         , destination_router_id(destination_router_id_)
         , id(id_)
-        , previous(etl::timer::id::NO_TIMER)
-        , next(etl::timer::id::NO_TIMER)
+        , previous(etl::timer<>::id::NO_TIMER)
+        , next(etl::timer<>::id::NO_TIMER)
         , repeating(repeating_)
       {
       }
@@ -384,7 +384,7 @@ namespace etl
       //*******************************************
       bool is_active() const
       {
-        return delta != etl::timer::state::Inactive;
+        return delta != etl::timer<>::state::Inactive;
       }
 
       //*******************************************
@@ -392,7 +392,7 @@ namespace etl
       //*******************************************
       void set_inactive()
       {
-        delta = etl::timer::state::Inactive;
+        delta = etl::timer<>::state::Inactive;
       }
 
       const etl::imessage* p_message;
@@ -400,7 +400,7 @@ namespace etl
       uint32_t                 period;
       uint32_t                 delta;
       etl::message_router_id_t destination_router_id;
-      etl::timer::id::type     id;
+      etl::timer<>::id::type     id;
       uint_least8_t            previous;
       uint_least8_t            next;
       bool                     repeating;
@@ -442,9 +442,9 @@ namespace etl
 
       //*******************************
       timer_list(timer_data* ptimers_)
-        : head(etl::timer::id::NO_TIMER)
-        , tail(etl::timer::id::NO_TIMER)
-        , current(etl::timer::id::NO_TIMER)
+        : head(etl::timer<>::id::NO_TIMER)
+        , tail(etl::timer<>::id::NO_TIMER)
+        , current(etl::timer<>::id::NO_TIMER)
         , ptimers(ptimers_)
       {
       }
@@ -452,30 +452,30 @@ namespace etl
       //*******************************
       bool empty() const
       {
-        return head == etl::timer::id::NO_TIMER;
+        return head == etl::timer<>::id::NO_TIMER;
       }
 
       //*******************************
       // Inserts the timer at the correct delta position
       //*******************************
-      void insert(etl::timer::id::type id_)
+      void insert(etl::timer<>::id::type id_)
       {
         timer_data& timer = ptimers[id_];
 
-        if (head == etl::timer::id::NO_TIMER)
+        if (head == etl::timer<>::id::NO_TIMER)
         {
           // No entries yet.
           head = id_;
           tail = id_;
-          timer.previous = etl::timer::id::NO_TIMER;
-          timer.next = etl::timer::id::NO_TIMER;
+          timer.previous = etl::timer<>::id::NO_TIMER;
+          timer.next = etl::timer<>::id::NO_TIMER;
         }
         else
         {
           // We already have entries.
-          etl::timer::id::type test_id = begin();
+          etl::timer<>::id::type test_id = begin();
 
-          while (test_id != etl::timer::id::NO_TIMER)
+          while (test_id != etl::timer<>::id::NO_TIMER)
           {
             timer_data& test = ptimers[test_id];
 
@@ -495,7 +495,7 @@ namespace etl
               // Adjust the next delta to compensate.
               test.delta -= timer.delta;
 
-              if (timer.previous != etl::timer::id::NO_TIMER)
+              if (timer.previous != etl::timer<>::id::NO_TIMER)
               {
                 ptimers[timer.previous].next = timer.id;
               }
@@ -510,19 +510,19 @@ namespace etl
           }
 
           // Reached the end?
-          if (test_id == etl::timer::id::NO_TIMER)
+          if (test_id == etl::timer<>::id::NO_TIMER)
           {
             // Tag on to the tail.
             ptimers[tail].next = timer.id;
             timer.previous = tail;
-            timer.next = etl::timer::id::NO_TIMER;
+            timer.next = etl::timer<>::id::NO_TIMER;
             tail = timer.id;
           }
         }
       }
 
       //*******************************
-      void remove(etl::timer::id::type id_, bool has_expired)
+      void remove(etl::timer<>::id::type id_, bool has_expired)
       {
         timer_data& timer = ptimers[id_];
 
@@ -547,15 +547,15 @@ namespace etl
         if (!has_expired)
         {
           // Adjust the next delta.
-          if (timer.next != etl::timer::id::NO_TIMER)
+          if (timer.next != etl::timer<>::id::NO_TIMER)
           {
             ptimers[timer.next].delta += timer.delta;
           }
         }
 
-        timer.previous = etl::timer::id::NO_TIMER;
-        timer.next = etl::timer::id::NO_TIMER;
-        timer.delta = etl::timer::state::Inactive;
+        timer.previous = etl::timer<>::id::NO_TIMER;
+        timer.next = etl::timer<>::id::NO_TIMER;
+        timer.delta = etl::timer<>::state::Inactive;
       }
 
       //*******************************
@@ -571,21 +571,21 @@ namespace etl
       }
 
       //*******************************
-      etl::timer::id::type begin()
+      etl::timer<>::id::type begin()
       {
         current = head;
         return current;
       }
 
       //*******************************
-      etl::timer::id::type previous(etl::timer::id::type last)
+      etl::timer<>::id::type previous(etl::timer<>::id::type last)
       {
         current = ptimers[last].previous;
         return current;
       }
 
       //*******************************
-      etl::timer::id::type next(etl::timer::id::type last)
+      etl::timer<>::id::type next(etl::timer<>::id::type last)
       {
         current = ptimers[last].next;
         return current;
@@ -594,25 +594,25 @@ namespace etl
       //*******************************
       void clear()
       {
-        etl::timer::id::type id = begin();
+        etl::timer<>::id::type id = begin();
 
-        while (id != etl::timer::id::NO_TIMER)
+        while (id != etl::timer<>::id::NO_TIMER)
         {
           timer_data& timer = ptimers[id];
           id = next(id);
-          timer.next = etl::timer::id::NO_TIMER;
+          timer.next = etl::timer<>::id::NO_TIMER;
         }
 
-        head = etl::timer::id::NO_TIMER;
-        tail = etl::timer::id::NO_TIMER;
-        current = etl::timer::id::NO_TIMER;
+        head = etl::timer<>::id::NO_TIMER;
+        tail = etl::timer<>::id::NO_TIMER;
+        current = etl::timer<>::id::NO_TIMER;
       }
 
     private:
 
-      etl::timer::id::type head;
-      etl::timer::id::type tail;
-      etl::timer::id::type current;
+      etl::timer<>::id::type head;
+      etl::timer<>::id::type tail;
+      etl::timer<>::id::type current;
 
       timer_data* const ptimers;
     };

--- a/include/etl/message_timer_locked.h
+++ b/include/etl/message_timer_locked.h
@@ -61,13 +61,13 @@ namespace etl
     //*******************************************
     /// Register a timer.
     //*******************************************
-    etl::timer::id::type register_timer(const etl::imessage&     message_,
+    etl::timer<>::id::type register_timer(const etl::imessage&     message_,
                                         etl::imessage_router&    router_,
                                         uint32_t                 period_,
                                         bool                     repeating_,
                                         etl::message_router_id_t destination_router_id_ = etl::imessage_router::ALL_MESSAGE_ROUTERS)
     {
-      etl::timer::id::type id = etl::timer::id::NO_TIMER;
+      etl::timer<>::id::type id = etl::timer<>::id::NO_TIMER;
 
       bool is_space = (number_of_registered_timers < MAX_TIMERS);
 
@@ -81,7 +81,7 @@ namespace etl
           {
             timer_data& timer = timer_array[i];
 
-            if (timer.id == etl::timer::id::NO_TIMER)
+            if (timer.id == etl::timer<>::id::NO_TIMER)
             {
               // Create in-place.
               new (&timer) timer_data(i, message_, router_, period_, repeating_, destination_router_id_);
@@ -99,15 +99,15 @@ namespace etl
     //*******************************************
     /// Unregister a timer.
     //*******************************************
-    bool unregister_timer(etl::timer::id::type id_)
+    bool unregister_timer(etl::timer<>::id::type id_)
     {
       bool result = false;
 
-      if (id_ != etl::timer::id::NO_TIMER)
+      if (id_ != etl::timer<>::id::NO_TIMER)
       {
         timer_data& timer = timer_array[id_];
 
-        if (timer.id != etl::timer::id::NO_TIMER)
+        if (timer.id != etl::timer<>::id::NO_TIMER)
         {
           if (timer.is_active())
           {
@@ -218,20 +218,20 @@ namespace etl
     //*******************************************
     /// Starts a timer.
     //*******************************************
-    bool start(etl::timer::id::type id_, bool immediate_ = false)
+    bool start(etl::timer<>::id::type id_, bool immediate_ = false)
     {
       bool result = false;
 
       // Valid timer id?
-      if (id_ != etl::timer::id::NO_TIMER)
+      if (id_ != etl::timer<>::id::NO_TIMER)
       {
         timer_data& timer = timer_array[id_];
 
         // Registered timer?
-        if (timer.id != etl::timer::id::NO_TIMER)
+        if (timer.id != etl::timer<>::id::NO_TIMER)
         {
           // Has a valid period.
-          if (timer.period != etl::timer::state::Inactive)
+          if (timer.period != etl::timer<>::state::Inactive)
           {
             lock();
             if (timer.is_active())
@@ -254,17 +254,17 @@ namespace etl
     //*******************************************
     /// Stops a timer.
     //*******************************************
-    bool stop(etl::timer::id::type id_)
+    bool stop(etl::timer<>::id::type id_)
     {
       bool result = false;
 
       // Valid timer id?
-      if (id_ != etl::timer::id::NO_TIMER)
+      if (id_ != etl::timer<>::id::NO_TIMER)
       {
         timer_data& timer = timer_array[id_];
 
         // Registered timer?
-        if (timer.id != etl::timer::id::NO_TIMER)
+        if (timer.id != etl::timer<>::id::NO_TIMER)
         {
           if (timer.is_active())
           {
@@ -283,7 +283,7 @@ namespace etl
     //*******************************************
     /// Sets a timer's period.
     //*******************************************
-    bool set_period(etl::timer::id::type id_, uint32_t period_)
+    bool set_period(etl::timer<>::id::type id_, uint32_t period_)
     {
       if (stop(id_))
       {
@@ -297,7 +297,7 @@ namespace etl
     //*******************************************
     /// Sets a timer's mode.
     //*******************************************
-    bool set_mode(etl::timer::id::type id_, bool repeating_)
+    bool set_mode(etl::timer<>::id::type id_, bool repeating_)
     {
       if (stop(id_))
       {
@@ -332,11 +332,11 @@ namespace etl
 
     //*******************************************
     /// Get the time to the next timer event.
-    /// Returns etl::timer::interval::No_Active_Interval if there is no active timer.
+    /// Returns etl::timer<>::interval::No_Active_Interval if there is no active timer.
     //*******************************************
     uint32_t time_to_next() const
     {
-      uint32_t delta = static_cast<uint32_t>(etl::timer::interval::No_Active_Interval);
+      uint32_t delta = static_cast<uint32_t>(etl::timer<>::interval::No_Active_Interval);
 
       lock();
       if (!active_list.empty())
@@ -359,17 +359,17 @@ namespace etl
         : p_message(ETL_NULLPTR)
         , p_router(ETL_NULLPTR)
         , period(0)
-        , delta(etl::timer::state::Inactive)
+        , delta(etl::timer<>::state::Inactive)
         , destination_router_id(etl::imessage_bus::ALL_MESSAGE_ROUTERS)
-        , id(etl::timer::id::NO_TIMER)
-        , previous(etl::timer::id::NO_TIMER)
-        , next(etl::timer::id::NO_TIMER)
+        , id(etl::timer<>::id::NO_TIMER)
+        , previous(etl::timer<>::id::NO_TIMER)
+        , next(etl::timer<>::id::NO_TIMER)
         , repeating(true)
       {
       }
 
       //*******************************************
-      timer_data(etl::timer::id::type     id_,
+      timer_data(etl::timer<>::id::type     id_,
                  const etl::imessage&     message_,
                  etl::imessage_router&    irouter_,
                  uint32_t                 period_,
@@ -378,11 +378,11 @@ namespace etl
         : p_message(&message_)
         , p_router(&irouter_)
         , period(period_)
-        , delta(etl::timer::state::Inactive)
+        , delta(etl::timer<>::state::Inactive)
         , destination_router_id(destination_router_id_)
         , id(id_)
-        , previous(etl::timer::id::NO_TIMER)
-        , next(etl::timer::id::NO_TIMER)
+        , previous(etl::timer<>::id::NO_TIMER)
+        , next(etl::timer<>::id::NO_TIMER)
         , repeating(repeating_)
       {
       }
@@ -392,7 +392,7 @@ namespace etl
       //*******************************************
       bool is_active() const
       {
-        return delta != etl::timer::state::Inactive;
+        return delta != etl::timer<>::state::Inactive;
       }
 
       //*******************************************
@@ -400,7 +400,7 @@ namespace etl
       //*******************************************
       void set_inactive()
       {
-        delta = etl::timer::state::Inactive;
+        delta = etl::timer<>::state::Inactive;
       }
 
       const etl::imessage* p_message;
@@ -408,7 +408,7 @@ namespace etl
       uint32_t                 period;
       uint32_t                 delta;
       etl::message_router_id_t destination_router_id;
-      etl::timer::id::type     id;
+      etl::timer<>::id::type     id;
       uint_least8_t            previous;
       uint_least8_t            next;
       bool                     repeating;
@@ -450,9 +450,9 @@ namespace etl
 
       //*******************************
       timer_list(timer_data* ptimers_)
-        : head(etl::timer::id::NO_TIMER)
-        , tail(etl::timer::id::NO_TIMER)
-        , current(etl::timer::id::NO_TIMER)
+        : head(etl::timer<>::id::NO_TIMER)
+        , tail(etl::timer<>::id::NO_TIMER)
+        , current(etl::timer<>::id::NO_TIMER)
         , ptimers(ptimers_)
       {
       }
@@ -460,30 +460,30 @@ namespace etl
       //*******************************
       bool empty() const
       {
-        return head == etl::timer::id::NO_TIMER;
+        return head == etl::timer<>::id::NO_TIMER;
       }
 
       //*******************************
       // Inserts the timer at the correct delta position
       //*******************************
-      void insert(etl::timer::id::type id_)
+      void insert(etl::timer<>::id::type id_)
       {
         timer_data& timer = ptimers[id_];
 
-        if (head == etl::timer::id::NO_TIMER)
+        if (head == etl::timer<>::id::NO_TIMER)
         {
           // No entries yet.
           head = id_;
           tail = id_;
-          timer.previous = etl::timer::id::NO_TIMER;
-          timer.next = etl::timer::id::NO_TIMER;
+          timer.previous = etl::timer<>::id::NO_TIMER;
+          timer.next = etl::timer<>::id::NO_TIMER;
         }
         else
         {
           // We already have entries.
-          etl::timer::id::type test_id = begin();
+          etl::timer<>::id::type test_id = begin();
 
-          while (test_id != etl::timer::id::NO_TIMER)
+          while (test_id != etl::timer<>::id::NO_TIMER)
           {
             timer_data& test = ptimers[test_id];
 
@@ -503,7 +503,7 @@ namespace etl
               // Adjust the next delta to compensate.
               test.delta -= timer.delta;
 
-              if (timer.previous != etl::timer::id::NO_TIMER)
+              if (timer.previous != etl::timer<>::id::NO_TIMER)
               {
                 ptimers[timer.previous].next = timer.id;
               }
@@ -518,19 +518,19 @@ namespace etl
           }
 
           // Reached the end?
-          if (test_id == etl::timer::id::NO_TIMER)
+          if (test_id == etl::timer<>::id::NO_TIMER)
           {
             // Tag on to the tail.
             ptimers[tail].next = timer.id;
             timer.previous = tail;
-            timer.next = etl::timer::id::NO_TIMER;
+            timer.next = etl::timer<>::id::NO_TIMER;
             tail = timer.id;
           }
         }
       }
 
       //*******************************
-      void remove(etl::timer::id::type id_, bool has_expired)
+      void remove(etl::timer<>::id::type id_, bool has_expired)
       {
         timer_data& timer = ptimers[id_];
 
@@ -555,15 +555,15 @@ namespace etl
         if (!has_expired)
         {
           // Adjust the next delta.
-          if (timer.next != etl::timer::id::NO_TIMER)
+          if (timer.next != etl::timer<>::id::NO_TIMER)
           {
             ptimers[timer.next].delta += timer.delta;
           }
         }
 
-        timer.previous = etl::timer::id::NO_TIMER;
-        timer.next = etl::timer::id::NO_TIMER;
-        timer.delta = etl::timer::state::Inactive;
+        timer.previous = etl::timer<>::id::NO_TIMER;
+        timer.next = etl::timer<>::id::NO_TIMER;
+        timer.delta = etl::timer<>::state::Inactive;
       }
 
       //*******************************
@@ -579,21 +579,21 @@ namespace etl
       }
 
       //*******************************
-      etl::timer::id::type begin()
+      etl::timer<>::id::type begin()
       {
         current = head;
         return current;
       }
 
       //*******************************
-      etl::timer::id::type previous(etl::timer::id::type last)
+      etl::timer<>::id::type previous(etl::timer<>::id::type last)
       {
         current = ptimers[last].previous;
         return current;
       }
 
       //*******************************
-      etl::timer::id::type next(etl::timer::id::type last)
+      etl::timer<>::id::type next(etl::timer<>::id::type last)
       {
         current = ptimers[last].next;
         return current;
@@ -602,25 +602,25 @@ namespace etl
       //*******************************
       void clear()
       {
-        etl::timer::id::type id = begin();
+        etl::timer<>::id::type id = begin();
 
-        while (id != etl::timer::id::NO_TIMER)
+        while (id != etl::timer<>::id::NO_TIMER)
         {
           timer_data& timer = ptimers[id];
           id = next(id);
-          timer.next = etl::timer::id::NO_TIMER;
+          timer.next = etl::timer<>::id::NO_TIMER;
         }
 
-        head = etl::timer::id::NO_TIMER;
-        tail = etl::timer::id::NO_TIMER;
-        current = etl::timer::id::NO_TIMER;
+        head = etl::timer<>::id::NO_TIMER;
+        tail = etl::timer<>::id::NO_TIMER;
+        current = etl::timer<>::id::NO_TIMER;
       }
 
     private:
 
-      etl::timer::id::type head;
-      etl::timer::id::type tail;
-      etl::timer::id::type current;
+      etl::timer<>::id::type head;
+      etl::timer<>::id::type tail;
+      etl::timer<>::id::type current;
 
       timer_data* const ptimers;
     };

--- a/include/etl/timer.h
+++ b/include/etl/timer.h
@@ -31,6 +31,7 @@ SOFTWARE.
 
 #include "platform.h"
 #include "atomic.h"
+#include "timer_model.h"
 
 #include <stdint.h>
 
@@ -50,9 +51,11 @@ namespace etl
 
   //***************************************************************************
   /// Common definitions for the timer framework.
+  /// \tparam TIMER_MODEL Determines the type of the internal timer types determining the tick resolution.
   //***************************************************************************
+  template<const size_t TIMER_MODEL = etl::timer_model::TIMER_MODEL_LARGE>
   struct timer
-  {
+  {  
     // Timer modes.
     struct mode
     {
@@ -100,8 +103,8 @@ namespace etl
     {
       enum
       {
-        INACTIVE = 0xFFFFFFFFUL,
-        Inactive = 0xFFFFFFFFUL
+        INACTIVE = etl::size_type_lookup<TIMER_MODEL>::range::MAX,
+        Inactive = etl::size_type_lookup<TIMER_MODEL>::range::MAX
       };
     };
 
@@ -110,10 +113,10 @@ namespace etl
     {
       enum
       {
-        No_Active_Interval = 0xFFFFFFFFUL
+        No_Active_Interval = etl::size_type_lookup<TIMER_MODEL>::range::MAX
       };
 
-      typedef uint32_t type;
+      typedef etl::size_type_lookup<TIMER_MODEL>::type type;
     };
   };
 }

--- a/include/etl/timer_model.h
+++ b/include/etl/timer_model.h
@@ -1,0 +1,122 @@
+///\file
+
+/******************************************************************************
+The MIT License(MIT)
+
+Embedded Template Library.
+https://github.com/ETLCPP/etl
+https://www.etlcpp.com
+
+Copyright(c) 2024 John Wellbelove
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files(the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions :
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+******************************************************************************/
+
+#ifndef ETL_TIMER_MODEL_INCLUDED
+#define ETL_TIMER_MODEL_INCLUDED
+
+#include "platform.h"
+#include "user_type.h"
+#include "type_lookup.h"
+
+#include <stdint.h>
+
+namespace etl
+{
+  ETL_DECLARE_USER_TYPE(timer_model, int)
+  ETL_USER_TYPE(TIMER_MODEL_SMALL,  0)
+  ETL_USER_TYPE(TIMER_MODEL_MEDIUM, 1)
+  ETL_USER_TYPE(TIMER_MODEL_LARGE,  2)
+  ETL_USER_TYPE(TIMER_MODEL_HUGE,   3)
+  ETL_END_USER_TYPE(timer_model)
+
+  template <size_t timer_model>
+  struct size_type_lookup;
+
+  template <>
+  struct size_type_lookup<etl::timer_model::TIMER_MODEL_SMALL>
+  {
+    typedef uint_least8_t type;
+
+    // value range given specific width
+    struct range
+    {
+      enum
+      {
+        MAX = 0xFFU,
+        Max = 0xFFU
+      };
+    };
+  
+  };
+
+  template <>
+  struct size_type_lookup<etl::timer_model::TIMER_MODEL_MEDIUM>
+  {
+    typedef uint_least16_t type;
+
+    // value range given specific width
+    struct range
+    {
+      enum
+      {
+        MAX = 0xFFFFU,
+        Max = 0xFFFFU
+      };
+    };
+  
+  };
+
+  template <>
+  struct size_type_lookup<etl::timer_model::TIMER_MODEL_LARGE>
+  {
+    typedef uint_least32_t type;
+
+    // value range given specific width
+    struct range
+    {
+      enum
+      {
+        MAX = 0xFFFFFFFFU,
+        Max = 0xFFFFFFFFU
+      };
+    };
+  
+  };
+
+  template <>
+  struct size_type_lookup<etl::timer_model::TIMER_MODEL_HUGE>
+  {
+    typedef uint_least64_t type;
+
+    // value range given specific width
+    struct range
+    {
+      enum
+      {
+        MAX = 0xFFFFFFFFFFFFFFFFU,
+        Max = 0xFFFFFFFFFFFFFFFFU
+      };
+    };
+
+  };
+}
+
+#endif
+

--- a/test/test_callback_timer.cpp
+++ b/test/test_callback_timer.cpp
@@ -114,17 +114,17 @@ namespace
     {
       etl::callback_timer<2> timer_controller;
 
-      etl::timer::id::type id1 = timer_controller.register_timer(member_callback,        37, etl::timer::mode::Single_Shot);
-      etl::timer::id::type id2 = timer_controller.register_timer(free_function_callback, 23, etl::timer::mode::Single_Shot);
-      etl::timer::id::type id3 = timer_controller.register_timer(free_callback2,         11, etl::timer::mode::Single_Shot);
+      etl::timer<>::id::type id1 = timer_controller.register_timer(member_callback,        37, etl::timer<>::mode::Single_Shot);
+      etl::timer<>::id::type id2 = timer_controller.register_timer(free_function_callback, 23, etl::timer<>::mode::Single_Shot);
+      etl::timer<>::id::type id3 = timer_controller.register_timer(free_callback2,         11, etl::timer<>::mode::Single_Shot);
 
-      CHECK(id1 != etl::timer::id::NO_TIMER);
-      CHECK(id2 != etl::timer::id::NO_TIMER);
-      CHECK(id3 == etl::timer::id::NO_TIMER);
+      CHECK(id1 != etl::timer<>::id::NO_TIMER);
+      CHECK(id2 != etl::timer<>::id::NO_TIMER);
+      CHECK(id3 == etl::timer<>::id::NO_TIMER);
 
       timer_controller.clear();
-      id3 = timer_controller.register_timer(free_callback2, 11, etl::timer::mode::Single_Shot);
-      CHECK(id3 != etl::timer::id::NO_TIMER);
+      id3 = timer_controller.register_timer(free_callback2, 11, etl::timer<>::mode::Single_Shot);
+      CHECK(id3 != etl::timer<>::id::NO_TIMER);
     }
 
     //*************************************************************************
@@ -132,9 +132,9 @@ namespace
     {
       etl::callback_timer<4> timer_controller;
 
-      etl::timer::id::type id1 = timer_controller.register_timer(member_callback,        37, etl::timer::mode::Single_Shot);
-      etl::timer::id::type id2 = timer_controller.register_timer(free_function_callback, 23, etl::timer::mode::Single_Shot);
-      etl::timer::id::type id3 = timer_controller.register_timer(free_callback2,         11, etl::timer::mode::Single_Shot);
+      etl::timer<>::id::type id1 = timer_controller.register_timer(member_callback,        37, etl::timer<>::mode::Single_Shot);
+      etl::timer<>::id::type id2 = timer_controller.register_timer(free_function_callback, 23, etl::timer<>::mode::Single_Shot);
+      etl::timer<>::id::type id3 = timer_controller.register_timer(free_callback2,         11, etl::timer<>::mode::Single_Shot);
 
       object.tick_list.clear();
       free_tick_list1.clear();
@@ -174,7 +174,7 @@ namespace
     {
       etl::callback_timer<1> timer_controller;
 
-      etl::timer::id::type id1 = timer_controller.register_timer(member_callback, 37, etl::timer::mode::Single_Shot);
+      etl::timer<>::id::type id1 = timer_controller.register_timer(member_callback, 37, etl::timer<>::mode::Single_Shot);
       object.tick_list.clear();
 
       timer_controller.start(id1);
@@ -220,9 +220,9 @@ namespace
     {
       etl::callback_timer<3> timer_controller;
 
-      etl::timer::id::type id1 = timer_controller.register_timer(member_callback,        37, etl::timer::mode::Repeating);
-      etl::timer::id::type id2 = timer_controller.register_timer(free_function_callback, 23, etl::timer::mode::Repeating);
-      etl::timer::id::type id3 = timer_controller.register_timer(free_callback2,         11, etl::timer::mode::Repeating);
+      etl::timer<>::id::type id1 = timer_controller.register_timer(member_callback,        37, etl::timer<>::mode::Repeating);
+      etl::timer<>::id::type id2 = timer_controller.register_timer(free_function_callback, 23, etl::timer<>::mode::Repeating);
+      etl::timer<>::id::type id3 = timer_controller.register_timer(free_callback2,         11, etl::timer<>::mode::Repeating);
 
       object.tick_list.clear();
       free_tick_list1.clear();
@@ -262,9 +262,9 @@ namespace
     {
       etl::callback_timer<3> timer_controller;
 
-      etl::timer::id::type id1 = timer_controller.register_timer(member_callback,        37, etl::timer::mode::Repeating);
-      etl::timer::id::type id2 = timer_controller.register_timer(free_function_callback, 23, etl::timer::mode::Repeating);
-      etl::timer::id::type id3 = timer_controller.register_timer(free_callback2,         11, etl::timer::mode::Repeating);
+      etl::timer<>::id::type id1 = timer_controller.register_timer(member_callback,        37, etl::timer<>::mode::Repeating);
+      etl::timer<>::id::type id2 = timer_controller.register_timer(free_function_callback, 23, etl::timer<>::mode::Repeating);
+      etl::timer<>::id::type id3 = timer_controller.register_timer(free_callback2,         11, etl::timer<>::mode::Repeating);
 
       object.tick_list.clear();
       free_tick_list1.clear();
@@ -308,9 +308,9 @@ namespace
     {
       etl::callback_timer<3> timer_controller;
 
-      etl::timer::id::type id1 = timer_controller.register_timer(member_callback,        37, etl::timer::mode::Repeating);
-      etl::timer::id::type id2 = timer_controller.register_timer(free_function_callback, 23, etl::timer::mode::Repeating);
-      etl::timer::id::type id3 = timer_controller.register_timer(free_callback2,         11, etl::timer::mode::Repeating);
+      etl::timer<>::id::type id1 = timer_controller.register_timer(member_callback,        37, etl::timer<>::mode::Repeating);
+      etl::timer<>::id::type id2 = timer_controller.register_timer(free_function_callback, 23, etl::timer<>::mode::Repeating);
+      etl::timer<>::id::type id3 = timer_controller.register_timer(free_callback2,         11, etl::timer<>::mode::Repeating);
 
       object.tick_list.clear();
       free_tick_list1.clear();
@@ -361,9 +361,9 @@ namespace
     {
       etl::callback_timer<3> timer_controller;
 
-      etl::timer::id::type id1 = timer_controller.register_timer(member_callback2, 100, etl::timer::mode::Single_Shot);
-      etl::timer::id::type id2 = timer_controller.register_timer(member_callback, 10, etl::timer::mode::Single_Shot);
-      etl::timer::id::type id3 = timer_controller.register_timer(member_callback, 22, etl::timer::mode::Single_Shot);
+      etl::timer<>::id::type id1 = timer_controller.register_timer(member_callback2, 100, etl::timer<>::mode::Single_Shot);
+      etl::timer<>::id::type id2 = timer_controller.register_timer(member_callback, 10, etl::timer<>::mode::Single_Shot);
+      etl::timer<>::id::type id3 = timer_controller.register_timer(member_callback, 22, etl::timer<>::mode::Single_Shot);
 
       (void)id2;
       (void)id3;
@@ -398,9 +398,9 @@ namespace
     {
       etl::callback_timer<3> timer_controller;
 
-      etl::timer::id::type id1 = timer_controller.register_timer(member_callback2, 100, etl::timer::mode::Single_Shot);
-      etl::timer::id::type id2 = timer_controller.register_timer(member_callback,   10, etl::timer::mode::Single_Shot);
-      etl::timer::id::type id3 = timer_controller.register_timer(member_callback,   22, etl::timer::mode::Single_Shot);
+      etl::timer<>::id::type id1 = timer_controller.register_timer(member_callback2, 100, etl::timer<>::mode::Single_Shot);
+      etl::timer<>::id::type id2 = timer_controller.register_timer(member_callback,   10, etl::timer<>::mode::Single_Shot);
+      etl::timer<>::id::type id3 = timer_controller.register_timer(member_callback,   22, etl::timer<>::mode::Single_Shot);
 
       (void)id2;
       (void)id3;
@@ -435,9 +435,9 @@ namespace
     {
       etl::callback_timer<3> timer_controller;
 
-      etl::timer::id::type id1;
-      etl::timer::id::type id2 = timer_controller.register_timer(free_function_callback, 23, etl::timer::mode::Repeating);
-      etl::timer::id::type id3 = timer_controller.register_timer(free_callback2,         11, etl::timer::mode::Repeating);
+      etl::timer<>::id::type id1;
+      etl::timer<>::id::type id2 = timer_controller.register_timer(free_function_callback, 23, etl::timer<>::mode::Repeating);
+      etl::timer<>::id::type id3 = timer_controller.register_timer(free_callback2,         11, etl::timer<>::mode::Repeating);
 
       object.tick_list.clear();
       free_tick_list1.clear();
@@ -458,7 +458,7 @@ namespace
         {
           timer_controller.unregister_timer(id2);
 
-          id1 = timer_controller.register_timer(member_callback, 37, etl::timer::mode::Repeating);
+          id1 = timer_controller.register_timer(member_callback, 37, etl::timer<>::mode::Repeating);
           timer_controller.start(id1);
         }
 
@@ -484,9 +484,9 @@ namespace
     {
       etl::callback_timer<3> timer_controller;
 
-      etl::timer::id::type id1 = timer_controller.register_timer(member_callback,        37, etl::timer::mode::Repeating);
-      etl::timer::id::type id2 = timer_controller.register_timer(free_function_callback, 23, etl::timer::mode::Repeating);
-      etl::timer::id::type id3 = timer_controller.register_timer(free_callback2,         11, etl::timer::mode::Repeating);
+      etl::timer<>::id::type id1 = timer_controller.register_timer(member_callback,        37, etl::timer<>::mode::Repeating);
+      etl::timer<>::id::type id2 = timer_controller.register_timer(free_function_callback, 23, etl::timer<>::mode::Repeating);
+      etl::timer<>::id::type id3 = timer_controller.register_timer(free_callback2,         11, etl::timer<>::mode::Repeating);
 
       object.tick_list.clear();
       free_tick_list1.clear();
@@ -532,9 +532,9 @@ namespace
     {
       etl::callback_timer<3> timer_controller;
 
-      etl::timer::id::type id1 = timer_controller.register_timer(member_callback,        37, etl::timer::mode::Repeating);
-      etl::timer::id::type id2 = timer_controller.register_timer(free_function_callback, 23, etl::timer::mode::Repeating);
-      etl::timer::id::type id3 = timer_controller.register_timer(free_callback2,         11, etl::timer::mode::Repeating);
+      etl::timer<>::id::type id1 = timer_controller.register_timer(member_callback,        37, etl::timer<>::mode::Repeating);
+      etl::timer<>::id::type id2 = timer_controller.register_timer(free_function_callback, 23, etl::timer<>::mode::Repeating);
+      etl::timer<>::id::type id3 = timer_controller.register_timer(free_callback2,         11, etl::timer<>::mode::Repeating);
 
       object.tick_list.clear();
       free_tick_list1.clear();
@@ -545,9 +545,9 @@ namespace
       ticks = 5;
       timer_controller.tick(uint32_t(ticks));
 
-      timer_controller.start(id1, etl::timer::start::Immediate);
-      timer_controller.start(id2, etl::timer::start::Immediate);
-      timer_controller.start(id3, etl::timer::start::Delayed);
+      timer_controller.start(id1, etl::timer<>::start::Immediate);
+      timer_controller.start(id2, etl::timer<>::start::Immediate);
+      timer_controller.start(id3, etl::timer<>::start::Delayed);
 
       const uint32_t step = 1U;
 
@@ -575,8 +575,8 @@ namespace
     {
       etl::callback_timer<3> timer_controller;
 
-      etl::timer::id::type id1 = timer_controller.register_timer(free_callback1, 15, etl::timer::mode::Single_Shot);
-      etl::timer::id::type id2 = timer_controller.register_timer(free_callback2, 5,  etl::timer::mode::Repeating);
+      etl::timer<>::id::type id1 = timer_controller.register_timer(free_callback1, 15, etl::timer<>::mode::Single_Shot);
+      etl::timer<>::id::type id2 = timer_controller.register_timer(free_callback2, 5,  etl::timer<>::mode::Repeating);
 
       free_tick_list1.clear();
       free_tick_list2.clear();
@@ -611,7 +611,7 @@ namespace
     {
       etl::callback_timer<3> timer_controller;
 
-      etl::timer::id::type id1 = timer_controller.register_timer(free_callback1, 5, etl::timer::mode::Single_Shot);
+      etl::timer<>::id::type id1 = timer_controller.register_timer(free_callback1, 5, etl::timer<>::mode::Single_Shot);
 
       free_tick_list1.clear();
 
@@ -651,9 +651,9 @@ namespace
     {
       etl::callback_timer<3> timer_controller;
 
-      etl::timer::id::type id1 = timer_controller.register_timer(member_callback,        37, etl::timer::mode::Repeating);
-      etl::timer::id::type id2 = timer_controller.register_timer(free_function_callback, 23, etl::timer::mode::Repeating);
-      etl::timer::id::type id3 = timer_controller.register_timer(free_callback2,         11, etl::timer::mode::Repeating);
+      etl::timer<>::id::type id1 = timer_controller.register_timer(member_callback,        37, etl::timer<>::mode::Repeating);
+      etl::timer<>::id::type id2 = timer_controller.register_timer(free_function_callback, 23, etl::timer<>::mode::Repeating);
+      etl::timer<>::id::type id3 = timer_controller.register_timer(free_callback2,         11, etl::timer<>::mode::Repeating);
 
       timer_controller.start(id1);
       timer_controller.start(id3);
@@ -699,9 +699,9 @@ namespace
     {
       etl::callback_timer<3> timer_controller;
 
-      etl::timer::id::type id1 = timer_controller.register_timer(member_callback, 37, etl::timer::mode::Single_Shot);
-      etl::timer::id::type id2 = timer_controller.register_timer(free_function_callback, 23, etl::timer::mode::Single_Shot);
-      etl::timer::id::type id3 = timer_controller.register_timer(free_callback2, 11, etl::timer::mode::Single_Shot);
+      etl::timer<>::id::type id1 = timer_controller.register_timer(member_callback, 37, etl::timer<>::mode::Single_Shot);
+      etl::timer<>::id::type id2 = timer_controller.register_timer(free_function_callback, 23, etl::timer<>::mode::Single_Shot);
+      etl::timer<>::id::type id3 = timer_controller.register_timer(free_callback2, 11, etl::timer<>::mode::Single_Shot);
 
       timer_controller.start(id1);
       timer_controller.start(id3);
@@ -722,7 +722,7 @@ namespace
       CHECK_TRUE(timer_controller.has_active_timer());
 
       timer_controller.tick(1);
-      CHECK_EQUAL(static_cast<etl::timer::interval::type>(etl::timer::interval::No_Active_Interval), timer_controller.time_to_next());
+      CHECK_EQUAL(static_cast<etl::timer<>::interval::type>(etl::timer<>::interval::No_Active_Interval), timer_controller.time_to_next());
       CHECK_FALSE(timer_controller.has_active_timer());
     }
 
@@ -749,7 +749,7 @@ namespace
 
         timer_controller.enable(true);
 
-        etl::timer::id::type id = timer_controller.register_timer(delegate_callback, 5, etl::timer::mode::Single_Shot);
+        etl::timer<>::id::type id = timer_controller.register_timer(delegate_callback, 5, etl::timer<>::mode::Single_Shot);
         timer_controller.start(id);
 
         timer_controller.tick(4);
@@ -764,9 +764,9 @@ namespace
     {
       etl::callback_timer<4> timer_controller;
 
-      etl::timer::id::type id1 = timer_controller.register_timer(member_callback,        37, etl::timer::mode::Single_Shot);
-      etl::timer::id::type id2 = timer_controller.register_timer(free_function_callback, 23, etl::timer::mode::Single_Shot);
-      etl::timer::id::type id3 = timer_controller.register_timer(free_callback2,         11, etl::timer::mode::Single_Shot);
+      etl::timer<>::id::type id1 = timer_controller.register_timer(member_callback,        37, etl::timer<>::mode::Single_Shot);
+      etl::timer<>::id::type id2 = timer_controller.register_timer(free_function_callback, 23, etl::timer<>::mode::Single_Shot);
+      etl::timer<>::id::type id3 = timer_controller.register_timer(free_callback2,         11, etl::timer<>::mode::Single_Shot);
 
       timer_controller.start(id1);
       timer_controller.start(id3);
@@ -837,9 +837,9 @@ namespace
     {
       FIX_PROCESSOR_AFFINITY;
 
-      etl::timer::id::type id1 = controller.register_timer(member_callback,        400, etl::timer::mode::Single_Shot);
-      etl::timer::id::type id2 = controller.register_timer(free_function_callback, 100, etl::timer::mode::Repeating);
-      etl::timer::id::type id3 = controller.register_timer(free_callback2,          10, etl::timer::mode::Repeating);
+      etl::timer<>::id::type id1 = controller.register_timer(member_callback,        400, etl::timer<>::mode::Single_Shot);
+      etl::timer<>::id::type id2 = controller.register_timer(free_function_callback, 100, etl::timer<>::mode::Repeating);
+      etl::timer<>::id::type id3 = controller.register_timer(free_callback2,          10, etl::timer<>::mode::Repeating);
 
       object.tick_list.clear();
       free_tick_list1.clear();

--- a/test/test_callback_timer_atomic.cpp
+++ b/test/test_callback_timer_atomic.cpp
@@ -121,17 +121,17 @@ namespace
     {
       etl::callback_timer_atomic<2, std::atomic_uint32_t> timer_controller;
 
-      etl::timer::id::type id1 = timer_controller.register_timer(member_callback1,        37, etl::timer::mode::Single_Shot);
-      etl::timer::id::type id2 = timer_controller.register_timer(free_function_callback1, 23, etl::timer::mode::Single_Shot);
-      etl::timer::id::type id3 = timer_controller.register_timer(free_function_callback2, 11, etl::timer::mode::Single_Shot);
+      etl::timer<>::id::type id1 = timer_controller.register_timer(member_callback1,        37, etl::timer<>::mode::Single_Shot);
+      etl::timer<>::id::type id2 = timer_controller.register_timer(free_function_callback1, 23, etl::timer<>::mode::Single_Shot);
+      etl::timer<>::id::type id3 = timer_controller.register_timer(free_function_callback2, 11, etl::timer<>::mode::Single_Shot);
 
-      CHECK(id1 != etl::timer::id::NO_TIMER);
-      CHECK(id2 != etl::timer::id::NO_TIMER);
-      CHECK(id3 == etl::timer::id::NO_TIMER);
+      CHECK(id1 != etl::timer<>::id::NO_TIMER);
+      CHECK(id2 != etl::timer<>::id::NO_TIMER);
+      CHECK(id3 == etl::timer<>::id::NO_TIMER);
 
       timer_controller.clear();
-      id3 = timer_controller.register_timer(free_function_callback2, 11, etl::timer::mode::Single_Shot);
-      CHECK(id3 != etl::timer::id::NO_TIMER);
+      id3 = timer_controller.register_timer(free_function_callback2, 11, etl::timer<>::mode::Single_Shot);
+      CHECK(id3 != etl::timer<>::id::NO_TIMER);
     }
 
     //*************************************************************************
@@ -139,9 +139,9 @@ namespace
     {
       etl::callback_timer_atomic<4, std::atomic_uint32_t> timer_controller;
 
-      etl::timer::id::type id1 = timer_controller.register_timer(member_callback1,        37, etl::timer::mode::Single_Shot);
-      etl::timer::id::type id2 = timer_controller.register_timer(free_function_callback1, 23, etl::timer::mode::Single_Shot);
-      etl::timer::id::type id3 = timer_controller.register_timer(free_function_callback2, 11, etl::timer::mode::Single_Shot);
+      etl::timer<>::id::type id1 = timer_controller.register_timer(member_callback1,        37, etl::timer<>::mode::Single_Shot);
+      etl::timer<>::id::type id2 = timer_controller.register_timer(free_function_callback1, 23, etl::timer<>::mode::Single_Shot);
+      etl::timer<>::id::type id3 = timer_controller.register_timer(free_function_callback2, 11, etl::timer<>::mode::Single_Shot);
 
       object.tick_list.clear();
       free_tick_list1.clear();
@@ -181,7 +181,7 @@ namespace
     {
       etl::callback_timer_atomic<1, std::atomic_uint32_t> timer_controller;
 
-      etl::timer::id::type id1 = timer_controller.register_timer(member_callback1, 37, etl::timer::mode::Single_Shot);
+      etl::timer<>::id::type id1 = timer_controller.register_timer(member_callback1, 37, etl::timer<>::mode::Single_Shot);
       object.tick_list.clear();
 
       timer_controller.start(id1);
@@ -227,9 +227,9 @@ namespace
     {
       etl::callback_timer_atomic<3, std::atomic_uint32_t> timer_controller;
 
-      etl::timer::id::type id1 = timer_controller.register_timer(member_callback1,        37, etl::timer::mode::Repeating);
-      etl::timer::id::type id2 = timer_controller.register_timer(free_function_callback1, 23, etl::timer::mode::Repeating);
-      etl::timer::id::type id3 = timer_controller.register_timer(free_function_callback2, 11, etl::timer::mode::Repeating);
+      etl::timer<>::id::type id1 = timer_controller.register_timer(member_callback1,        37, etl::timer<>::mode::Repeating);
+      etl::timer<>::id::type id2 = timer_controller.register_timer(free_function_callback1, 23, etl::timer<>::mode::Repeating);
+      etl::timer<>::id::type id3 = timer_controller.register_timer(free_function_callback2, 11, etl::timer<>::mode::Repeating);
 
       object.tick_list.clear();
       free_tick_list1.clear();
@@ -269,9 +269,9 @@ namespace
     {
       etl::callback_timer_atomic<3, std::atomic_uint32_t> timer_controller;
 
-      etl::timer::id::type id1 = timer_controller.register_timer(member_callback1,        37, etl::timer::mode::Repeating);
-      etl::timer::id::type id2 = timer_controller.register_timer(free_function_callback1, 23, etl::timer::mode::Repeating);
-      etl::timer::id::type id3 = timer_controller.register_timer(free_function_callback2, 11, etl::timer::mode::Repeating);
+      etl::timer<>::id::type id1 = timer_controller.register_timer(member_callback1,        37, etl::timer<>::mode::Repeating);
+      etl::timer<>::id::type id2 = timer_controller.register_timer(free_function_callback1, 23, etl::timer<>::mode::Repeating);
+      etl::timer<>::id::type id3 = timer_controller.register_timer(free_function_callback2, 11, etl::timer<>::mode::Repeating);
 
       object.tick_list.clear();
       free_tick_list1.clear();
@@ -315,9 +315,9 @@ namespace
     {
       etl::callback_timer_atomic<3, std::atomic_uint32_t> timer_controller;
 
-      etl::timer::id::type id1 = timer_controller.register_timer(member_callback1,        37, etl::timer::mode::Repeating);
-      etl::timer::id::type id2 = timer_controller.register_timer(free_function_callback1, 23, etl::timer::mode::Repeating);
-      etl::timer::id::type id3 = timer_controller.register_timer(free_function_callback2, 11, etl::timer::mode::Repeating);
+      etl::timer<>::id::type id1 = timer_controller.register_timer(member_callback1,        37, etl::timer<>::mode::Repeating);
+      etl::timer<>::id::type id2 = timer_controller.register_timer(free_function_callback1, 23, etl::timer<>::mode::Repeating);
+      etl::timer<>::id::type id3 = timer_controller.register_timer(free_function_callback2, 11, etl::timer<>::mode::Repeating);
 
       object.tick_list.clear();
       free_tick_list1.clear();
@@ -368,9 +368,9 @@ namespace
     {
       etl::callback_timer_atomic<3, std::atomic_uint32_t> timer_controller;
 
-      etl::timer::id::type id1 = timer_controller.register_timer(member_callback2, 100, etl::timer::mode::Single_Shot);
-      etl::timer::id::type id2 = timer_controller.register_timer(member_callback1, 10, etl::timer::mode::Single_Shot);
-      etl::timer::id::type id3 = timer_controller.register_timer(member_callback1, 22, etl::timer::mode::Single_Shot);
+      etl::timer<>::id::type id1 = timer_controller.register_timer(member_callback2, 100, etl::timer<>::mode::Single_Shot);
+      etl::timer<>::id::type id2 = timer_controller.register_timer(member_callback1, 10, etl::timer<>::mode::Single_Shot);
+      etl::timer<>::id::type id3 = timer_controller.register_timer(member_callback1, 22, etl::timer<>::mode::Single_Shot);
 
       (void)id2;
       (void)id3;
@@ -405,9 +405,9 @@ namespace
     {
       etl::callback_timer_atomic<3, std::atomic_uint32_t> timer_controller;
 
-      etl::timer::id::type id1 = timer_controller.register_timer(member_callback2, 100, etl::timer::mode::Single_Shot);
-      etl::timer::id::type id2 = timer_controller.register_timer(member_callback1,   10, etl::timer::mode::Single_Shot);
-      etl::timer::id::type id3 = timer_controller.register_timer(member_callback1,   22, etl::timer::mode::Single_Shot);
+      etl::timer<>::id::type id1 = timer_controller.register_timer(member_callback2, 100, etl::timer<>::mode::Single_Shot);
+      etl::timer<>::id::type id2 = timer_controller.register_timer(member_callback1,   10, etl::timer<>::mode::Single_Shot);
+      etl::timer<>::id::type id3 = timer_controller.register_timer(member_callback1,   22, etl::timer<>::mode::Single_Shot);
 
       (void)id2;
       (void)id3;
@@ -442,9 +442,9 @@ namespace
     {
       etl::callback_timer_atomic<3, std::atomic_uint32_t> timer_controller;
 
-      etl::timer::id::type id1;
-      etl::timer::id::type id2 = timer_controller.register_timer(free_function_callback1, 23, etl::timer::mode::Repeating);
-      etl::timer::id::type id3 = timer_controller.register_timer(free_function_callback2, 11, etl::timer::mode::Repeating);
+      etl::timer<>::id::type id1;
+      etl::timer<>::id::type id2 = timer_controller.register_timer(free_function_callback1, 23, etl::timer<>::mode::Repeating);
+      etl::timer<>::id::type id3 = timer_controller.register_timer(free_function_callback2, 11, etl::timer<>::mode::Repeating);
 
       object.tick_list.clear();
       free_tick_list1.clear();
@@ -465,7 +465,7 @@ namespace
         {
           timer_controller.unregister_timer(id2);
 
-          id1 = timer_controller.register_timer(member_callback1, 37, etl::timer::mode::Repeating);
+          id1 = timer_controller.register_timer(member_callback1, 37, etl::timer<>::mode::Repeating);
           timer_controller.start(id1);
         }
 
@@ -491,9 +491,9 @@ namespace
     {
       etl::callback_timer_atomic<3, std::atomic_uint32_t> timer_controller;
 
-      etl::timer::id::type id1 = timer_controller.register_timer(member_callback1,        37, etl::timer::mode::Repeating);
-      etl::timer::id::type id2 = timer_controller.register_timer(free_function_callback1, 23, etl::timer::mode::Repeating);
-      etl::timer::id::type id3 = timer_controller.register_timer(free_function_callback2,         11, etl::timer::mode::Repeating);
+      etl::timer<>::id::type id1 = timer_controller.register_timer(member_callback1,        37, etl::timer<>::mode::Repeating);
+      etl::timer<>::id::type id2 = timer_controller.register_timer(free_function_callback1, 23, etl::timer<>::mode::Repeating);
+      etl::timer<>::id::type id3 = timer_controller.register_timer(free_function_callback2,         11, etl::timer<>::mode::Repeating);
 
       object.tick_list.clear();
       free_tick_list1.clear();
@@ -539,9 +539,9 @@ namespace
     {
       etl::callback_timer_atomic<3, std::atomic_uint32_t> timer_controller;
 
-      etl::timer::id::type id1 = timer_controller.register_timer(member_callback1,        37, etl::timer::mode::Repeating);
-      etl::timer::id::type id2 = timer_controller.register_timer(free_function_callback1, 23, etl::timer::mode::Repeating);
-      etl::timer::id::type id3 = timer_controller.register_timer(free_function_callback2, 11, etl::timer::mode::Repeating);
+      etl::timer<>::id::type id1 = timer_controller.register_timer(member_callback1,        37, etl::timer<>::mode::Repeating);
+      etl::timer<>::id::type id2 = timer_controller.register_timer(free_function_callback1, 23, etl::timer<>::mode::Repeating);
+      etl::timer<>::id::type id3 = timer_controller.register_timer(free_function_callback2, 11, etl::timer<>::mode::Repeating);
 
       object.tick_list.clear();
       free_tick_list1.clear();
@@ -552,9 +552,9 @@ namespace
       ticks = 5;
       timer_controller.tick(uint32_t(ticks));
 
-      timer_controller.start(id1, etl::timer::start::Immediate);
-      timer_controller.start(id2, etl::timer::start::Immediate);
-      timer_controller.start(id3, etl::timer::start::Delayed);
+      timer_controller.start(id1, etl::timer<>::start::Immediate);
+      timer_controller.start(id2, etl::timer<>::start::Immediate);
+      timer_controller.start(id3, etl::timer<>::start::Delayed);
 
       const uint32_t step = 1U;
 
@@ -582,8 +582,8 @@ namespace
     {
       etl::callback_timer_atomic<3, std::atomic_uint32_t> timer_controller;
 
-      etl::timer::id::type id1 = timer_controller.register_timer(free_function_callback1, 15, etl::timer::mode::Single_Shot);
-      etl::timer::id::type id2 = timer_controller.register_timer(free_function_callback2, 5,  etl::timer::mode::Repeating);
+      etl::timer<>::id::type id1 = timer_controller.register_timer(free_function_callback1, 15, etl::timer<>::mode::Single_Shot);
+      etl::timer<>::id::type id2 = timer_controller.register_timer(free_function_callback2, 5,  etl::timer<>::mode::Repeating);
 
       free_tick_list1.clear();
       free_tick_list2.clear();
@@ -618,7 +618,7 @@ namespace
     {
       etl::callback_timer_atomic<3, std::atomic_uint32_t> timer_controller;
 
-      etl::timer::id::type id1 = timer_controller.register_timer(free_function_callback1, 5, etl::timer::mode::Single_Shot);
+      etl::timer<>::id::type id1 = timer_controller.register_timer(free_function_callback1, 5, etl::timer<>::mode::Single_Shot);
 
       free_tick_list1.clear();
 
@@ -658,9 +658,9 @@ namespace
     {
       etl::callback_timer_atomic<3, std::atomic_uint32_t> timer_controller;
 
-      etl::timer::id::type id1 = timer_controller.register_timer(member_callback1,        37, etl::timer::mode::Repeating);
-      etl::timer::id::type id2 = timer_controller.register_timer(free_function_callback1, 23, etl::timer::mode::Repeating);
-      etl::timer::id::type id3 = timer_controller.register_timer(free_function_callback2, 11, etl::timer::mode::Repeating);
+      etl::timer<>::id::type id1 = timer_controller.register_timer(member_callback1,        37, etl::timer<>::mode::Repeating);
+      etl::timer<>::id::type id2 = timer_controller.register_timer(free_function_callback1, 23, etl::timer<>::mode::Repeating);
+      etl::timer<>::id::type id3 = timer_controller.register_timer(free_function_callback2, 11, etl::timer<>::mode::Repeating);
 
       timer_controller.start(id1);
       timer_controller.start(id3);
@@ -706,9 +706,9 @@ namespace
     {
       etl::callback_timer_atomic<3, std::atomic_uint32_t> timer_controller;
 
-      etl::timer::id::type id1 = timer_controller.register_timer(member_callback1, 37, etl::timer::mode::Single_Shot);
-      etl::timer::id::type id2 = timer_controller.register_timer(free_function_callback1, 23, etl::timer::mode::Single_Shot);
-      etl::timer::id::type id3 = timer_controller.register_timer(free_function_callback2, 11, etl::timer::mode::Single_Shot);
+      etl::timer<>::id::type id1 = timer_controller.register_timer(member_callback1, 37, etl::timer<>::mode::Single_Shot);
+      etl::timer<>::id::type id2 = timer_controller.register_timer(free_function_callback1, 23, etl::timer<>::mode::Single_Shot);
+      etl::timer<>::id::type id3 = timer_controller.register_timer(free_function_callback2, 11, etl::timer<>::mode::Single_Shot);
 
       timer_controller.start(id1);
       timer_controller.start(id3);
@@ -729,7 +729,7 @@ namespace
       CHECK_TRUE(timer_controller.has_active_timer());
 
       timer_controller.tick(1);
-      CHECK_EQUAL(static_cast<etl::timer::interval::type>(etl::timer::interval::No_Active_Interval), timer_controller.time_to_next());
+      CHECK_EQUAL(static_cast<etl::timer<>::interval::type>(etl::timer<>::interval::No_Active_Interval), timer_controller.time_to_next());
       CHECK_FALSE(timer_controller.has_active_timer());
     }
 
@@ -754,7 +754,7 @@ namespace
 
         timer_controller.enable(true);
 
-        etl::timer::id::type id = timer_controller.register_timer(delegate_callback, 5, etl::timer::mode::Single_Shot);
+        etl::timer<>::id::type id = timer_controller.register_timer(delegate_callback, 5, etl::timer<>::mode::Single_Shot);
         timer_controller.start(id);
 
         timer_controller.tick(4);
@@ -769,9 +769,9 @@ namespace
     {
       etl::callback_timer_atomic<3, std::atomic_uint32_t> timer_controller;
 
-      etl::timer::id::type id1 = timer_controller.register_timer(member_callback1,        37, etl::timer::mode::Single_Shot);
-      etl::timer::id::type id2 = timer_controller.register_timer(free_function_callback1, 23, etl::timer::mode::Single_Shot);
-      etl::timer::id::type id3 = timer_controller.register_timer(free_function_callback2, 11, etl::timer::mode::Single_Shot);
+      etl::timer<>::id::type id1 = timer_controller.register_timer(member_callback1,        37, etl::timer<>::mode::Single_Shot);
+      etl::timer<>::id::type id2 = timer_controller.register_timer(free_function_callback1, 23, etl::timer<>::mode::Single_Shot);
+      etl::timer<>::id::type id3 = timer_controller.register_timer(free_function_callback2, 11, etl::timer<>::mode::Single_Shot);
 
       timer_controller.start(id1);
       timer_controller.start(id3);
@@ -843,9 +843,9 @@ namespace
     {
       FIX_PROCESSOR_AFFINITY;
 
-      etl::timer::id::type id1 = controller.register_timer(member_callback1,        400, etl::timer::mode::Single_Shot);
-      etl::timer::id::type id2 = controller.register_timer(free_function_callback1, 100, etl::timer::mode::Repeating);
-      etl::timer::id::type id3 = controller.register_timer(free_function_callback2,  10, etl::timer::mode::Repeating);
+      etl::timer<>::id::type id1 = controller.register_timer(member_callback1,        400, etl::timer<>::mode::Single_Shot);
+      etl::timer<>::id::type id2 = controller.register_timer(free_function_callback1, 100, etl::timer<>::mode::Repeating);
+      etl::timer<>::id::type id3 = controller.register_timer(free_function_callback2,  10, etl::timer<>::mode::Repeating);
 
       object.tick_list.clear();
       free_tick_list1.clear();

--- a/test/test_callback_timer_interrupt.cpp
+++ b/test/test_callback_timer_interrupt.cpp
@@ -58,7 +58,7 @@ namespace
   //***************************************************************************
   struct TimerLogEntry
   {
-    etl::timer::id::type id;
+    etl::timer<>::id::type id;
     uint64_t time_called;
   };
 
@@ -134,17 +134,17 @@ namespace
     {
       etl::callback_timer_interrupt<2, ScopedGuard> timer_controller;
 
-      etl::timer::id::type id1 = timer_controller.register_timer(member_callback,         37, etl::timer::mode::Single_Shot);
-      etl::timer::id::type id2 = timer_controller.register_timer(free_function_callback,  23, etl::timer::mode::Single_Shot);
-      etl::timer::id::type id3 = timer_controller.register_timer(free_function_callback2, 11, etl::timer::mode::Single_Shot);
+      etl::timer<>::id::type id1 = timer_controller.register_timer(member_callback,         37, etl::timer<>::mode::Single_Shot);
+      etl::timer<>::id::type id2 = timer_controller.register_timer(free_function_callback,  23, etl::timer<>::mode::Single_Shot);
+      etl::timer<>::id::type id3 = timer_controller.register_timer(free_function_callback2, 11, etl::timer<>::mode::Single_Shot);
 
-      CHECK(id1 != etl::timer::id::NO_TIMER);
-      CHECK(id2 != etl::timer::id::NO_TIMER);
-      CHECK(id3 == etl::timer::id::NO_TIMER);
+      CHECK(id1 != etl::timer<>::id::NO_TIMER);
+      CHECK(id2 != etl::timer<>::id::NO_TIMER);
+      CHECK(id3 == etl::timer<>::id::NO_TIMER);
 
       timer_controller.clear();
-      id3 = timer_controller.register_timer(free_function_callback2, 11, etl::timer::mode::Single_Shot);
-      CHECK(id3 != etl::timer::id::NO_TIMER);
+      id3 = timer_controller.register_timer(free_function_callback2, 11, etl::timer<>::mode::Single_Shot);
+      CHECK(id3 != etl::timer<>::id::NO_TIMER);
 
       CHECK_EQUAL(0U, ScopedGuard::guard_count);
     }
@@ -154,9 +154,9 @@ namespace
     {
       etl::callback_timer_interrupt<4, ScopedGuard> timer_controller;
 
-      etl::timer::id::type id1 = timer_controller.register_timer(member_callback,         37, etl::timer::mode::Single_Shot);
-      etl::timer::id::type id2 = timer_controller.register_timer(free_function_callback,  23, etl::timer::mode::Single_Shot);
-      etl::timer::id::type id3 = timer_controller.register_timer(free_function_callback2, 11, etl::timer::mode::Single_Shot);
+      etl::timer<>::id::type id1 = timer_controller.register_timer(member_callback,         37, etl::timer<>::mode::Single_Shot);
+      etl::timer<>::id::type id2 = timer_controller.register_timer(free_function_callback,  23, etl::timer<>::mode::Single_Shot);
+      etl::timer<>::id::type id3 = timer_controller.register_timer(free_function_callback2, 11, etl::timer<>::mode::Single_Shot);
 
       object.tick_list.clear();
       free_tick_list1.clear();
@@ -198,7 +198,7 @@ namespace
     {
       etl::callback_timer_interrupt<1, ScopedGuard> timer_controller;
 
-      etl::timer::id::type id1 = timer_controller.register_timer(member_callback, 37, etl::timer::mode::Single_Shot);
+      etl::timer<>::id::type id1 = timer_controller.register_timer(member_callback, 37, etl::timer<>::mode::Single_Shot);
       object.tick_list.clear();
 
       timer_controller.start(id1);
@@ -246,9 +246,9 @@ namespace
     {
       etl::callback_timer_interrupt<3, ScopedGuard> timer_controller;
 
-      etl::timer::id::type id1 = timer_controller.register_timer(member_callback,         37, etl::timer::mode::Repeating);
-      etl::timer::id::type id2 = timer_controller.register_timer(free_function_callback,  23, etl::timer::mode::Repeating);
-      etl::timer::id::type id3 = timer_controller.register_timer(free_function_callback2, 11, etl::timer::mode::Repeating);
+      etl::timer<>::id::type id1 = timer_controller.register_timer(member_callback,         37, etl::timer<>::mode::Repeating);
+      etl::timer<>::id::type id2 = timer_controller.register_timer(free_function_callback,  23, etl::timer<>::mode::Repeating);
+      etl::timer<>::id::type id3 = timer_controller.register_timer(free_function_callback2, 11, etl::timer<>::mode::Repeating);
 
       object.tick_list.clear();
       free_tick_list1.clear();
@@ -290,9 +290,9 @@ namespace
     {
       etl::callback_timer_interrupt<3, ScopedGuard> timer_controller;
 
-      etl::timer::id::type id1 = timer_controller.register_timer(member_callback,         37, etl::timer::mode::Repeating);
-      etl::timer::id::type id2 = timer_controller.register_timer(free_function_callback,  23, etl::timer::mode::Repeating);
-      etl::timer::id::type id3 = timer_controller.register_timer(free_function_callback2, 11, etl::timer::mode::Repeating);
+      etl::timer<>::id::type id1 = timer_controller.register_timer(member_callback,         37, etl::timer<>::mode::Repeating);
+      etl::timer<>::id::type id2 = timer_controller.register_timer(free_function_callback,  23, etl::timer<>::mode::Repeating);
+      etl::timer<>::id::type id3 = timer_controller.register_timer(free_function_callback2, 11, etl::timer<>::mode::Repeating);
 
       object.tick_list.clear();
       free_tick_list1.clear();
@@ -338,9 +338,9 @@ namespace
     {
       etl::callback_timer_interrupt<3, ScopedGuard> timer_controller;
 
-      etl::timer::id::type id1 = timer_controller.register_timer(member_callback,         37, etl::timer::mode::Repeating);
-      etl::timer::id::type id2 = timer_controller.register_timer(free_function_callback,  23, etl::timer::mode::Repeating);
-      etl::timer::id::type id3 = timer_controller.register_timer(free_function_callback2, 11, etl::timer::mode::Repeating);
+      etl::timer<>::id::type id1 = timer_controller.register_timer(member_callback,         37, etl::timer<>::mode::Repeating);
+      etl::timer<>::id::type id2 = timer_controller.register_timer(free_function_callback,  23, etl::timer<>::mode::Repeating);
+      etl::timer<>::id::type id3 = timer_controller.register_timer(free_function_callback2, 11, etl::timer<>::mode::Repeating);
 
       object.tick_list.clear();
       free_tick_list1.clear();
@@ -393,9 +393,9 @@ namespace
     {
       etl::callback_timer_interrupt<3, ScopedGuard> timer_controller;
 
-      etl::timer::id::type id1 = timer_controller.register_timer(member_callback2, 100, etl::timer::mode::Single_Shot);
-      etl::timer::id::type id2 = timer_controller.register_timer(member_callback, 10, etl::timer::mode::Single_Shot);
-      etl::timer::id::type id3 = timer_controller.register_timer(member_callback, 22, etl::timer::mode::Single_Shot);
+      etl::timer<>::id::type id1 = timer_controller.register_timer(member_callback2, 100, etl::timer<>::mode::Single_Shot);
+      etl::timer<>::id::type id2 = timer_controller.register_timer(member_callback, 10, etl::timer<>::mode::Single_Shot);
+      etl::timer<>::id::type id3 = timer_controller.register_timer(member_callback, 22, etl::timer<>::mode::Single_Shot);
 
       (void)id2;
       (void)id3;
@@ -432,9 +432,9 @@ namespace
     {
       etl::callback_timer_interrupt<3, ScopedGuard> timer_controller;
 
-      etl::timer::id::type id1 = timer_controller.register_timer(member_callback2, 100, etl::timer::mode::Single_Shot);
-      etl::timer::id::type id2 = timer_controller.register_timer(member_callback,   10, etl::timer::mode::Single_Shot);
-      etl::timer::id::type id3 = timer_controller.register_timer(member_callback,   22, etl::timer::mode::Single_Shot);
+      etl::timer<>::id::type id1 = timer_controller.register_timer(member_callback2, 100, etl::timer<>::mode::Single_Shot);
+      etl::timer<>::id::type id2 = timer_controller.register_timer(member_callback,   10, etl::timer<>::mode::Single_Shot);
+      etl::timer<>::id::type id3 = timer_controller.register_timer(member_callback,   22, etl::timer<>::mode::Single_Shot);
 
       (void)id2;
       (void)id3;
@@ -471,9 +471,9 @@ namespace
     {
       etl::callback_timer_interrupt<3, ScopedGuard> timer_controller;
 
-      etl::timer::id::type id1;
-      etl::timer::id::type id2 = timer_controller.register_timer(free_function_callback,  23, etl::timer::mode::Repeating);
-      etl::timer::id::type id3 = timer_controller.register_timer(free_function_callback2, 11, etl::timer::mode::Repeating);
+      etl::timer<>::id::type id1;
+      etl::timer<>::id::type id2 = timer_controller.register_timer(free_function_callback,  23, etl::timer<>::mode::Repeating);
+      etl::timer<>::id::type id3 = timer_controller.register_timer(free_function_callback2, 11, etl::timer<>::mode::Repeating);
 
       object.tick_list.clear();
       free_tick_list1.clear();
@@ -494,7 +494,7 @@ namespace
         {
           timer_controller.unregister_timer(id2);
 
-          id1 = timer_controller.register_timer(member_callback, 37, etl::timer::mode::Repeating);
+          id1 = timer_controller.register_timer(member_callback, 37, etl::timer<>::mode::Repeating);
           timer_controller.start(id1);
         }
 
@@ -522,9 +522,9 @@ namespace
     {
       etl::callback_timer_interrupt<3, ScopedGuard> timer_controller;
 
-      etl::timer::id::type id1 = timer_controller.register_timer(member_callback,         37, etl::timer::mode::Repeating);
-      etl::timer::id::type id2 = timer_controller.register_timer(free_function_callback,  23, etl::timer::mode::Repeating);
-      etl::timer::id::type id3 = timer_controller.register_timer(free_function_callback2, 11, etl::timer::mode::Repeating);
+      etl::timer<>::id::type id1 = timer_controller.register_timer(member_callback,         37, etl::timer<>::mode::Repeating);
+      etl::timer<>::id::type id2 = timer_controller.register_timer(free_function_callback,  23, etl::timer<>::mode::Repeating);
+      etl::timer<>::id::type id3 = timer_controller.register_timer(free_function_callback2, 11, etl::timer<>::mode::Repeating);
 
       object.tick_list.clear();
       free_tick_list1.clear();
@@ -572,9 +572,9 @@ namespace
     {
       etl::callback_timer_interrupt<3, ScopedGuard> timer_controller;
 
-      etl::timer::id::type id1 = timer_controller.register_timer(member_callback,         37, etl::timer::mode::Repeating);
-      etl::timer::id::type id2 = timer_controller.register_timer(free_function_callback,  23, etl::timer::mode::Repeating);
-      etl::timer::id::type id3 = timer_controller.register_timer(free_function_callback2, 11, etl::timer::mode::Repeating);
+      etl::timer<>::id::type id1 = timer_controller.register_timer(member_callback,         37, etl::timer<>::mode::Repeating);
+      etl::timer<>::id::type id2 = timer_controller.register_timer(free_function_callback,  23, etl::timer<>::mode::Repeating);
+      etl::timer<>::id::type id3 = timer_controller.register_timer(free_function_callback2, 11, etl::timer<>::mode::Repeating);
 
       object.tick_list.clear();
       free_tick_list1.clear();
@@ -585,9 +585,9 @@ namespace
       ticks = 5;
       timer_controller.tick(uint32_t(ticks));
 
-      timer_controller.start(id1, etl::timer::start::Immediate);
-      timer_controller.start(id2, etl::timer::start::Immediate);
-      timer_controller.start(id3, etl::timer::start::Delayed);
+      timer_controller.start(id1, etl::timer<>::start::Immediate);
+      timer_controller.start(id2, etl::timer<>::start::Immediate);
+      timer_controller.start(id3, etl::timer<>::start::Delayed);
 
       const uint32_t step = 1U;
 
@@ -617,8 +617,8 @@ namespace
     {
       etl::callback_timer_interrupt<3, ScopedGuard> timer_controller;
 
-      etl::timer::id::type id1 = timer_controller.register_timer(free_function_callback,  15, etl::timer::mode::Single_Shot);
-      etl::timer::id::type id2 = timer_controller.register_timer(free_function_callback2, 5,  etl::timer::mode::Repeating);
+      etl::timer<>::id::type id1 = timer_controller.register_timer(free_function_callback,  15, etl::timer<>::mode::Single_Shot);
+      etl::timer<>::id::type id2 = timer_controller.register_timer(free_function_callback2, 5,  etl::timer<>::mode::Repeating);
 
       free_tick_list1.clear();
       free_tick_list2.clear();
@@ -655,7 +655,7 @@ namespace
     {
       etl::callback_timer_interrupt<3, ScopedGuard> timer_controller;
 
-      etl::timer::id::type id1 = timer_controller.register_timer(free_function_callback, 5, etl::timer::mode::Single_Shot);
+      etl::timer<>::id::type id1 = timer_controller.register_timer(free_function_callback, 5, etl::timer<>::mode::Single_Shot);
 
       free_tick_list1.clear();
 
@@ -697,9 +697,9 @@ namespace
     {
       etl::callback_timer_interrupt<3, ScopedGuard> timer_controller;
 
-      etl::timer::id::type id1 = timer_controller.register_timer(member_callback,         37, etl::timer::mode::Repeating);
-      etl::timer::id::type id2 = timer_controller.register_timer(free_function_callback,  23, etl::timer::mode::Repeating);
-      etl::timer::id::type id3 = timer_controller.register_timer(free_function_callback2, 11, etl::timer::mode::Repeating);
+      etl::timer<>::id::type id1 = timer_controller.register_timer(member_callback,         37, etl::timer<>::mode::Repeating);
+      etl::timer<>::id::type id2 = timer_controller.register_timer(free_function_callback,  23, etl::timer<>::mode::Repeating);
+      etl::timer<>::id::type id3 = timer_controller.register_timer(free_function_callback2, 11, etl::timer<>::mode::Repeating);
 
       timer_controller.start(id1);
       timer_controller.start(id3);
@@ -745,9 +745,9 @@ namespace
     {
       etl::callback_timer_interrupt<3, ScopedGuard> timer_controller;
 
-      etl::timer::id::type id1 = timer_controller.register_timer(member_callback, 37, etl::timer::mode::Single_Shot);
-      etl::timer::id::type id2 = timer_controller.register_timer(free_function_callback, 23, etl::timer::mode::Single_Shot);
-      etl::timer::id::type id3 = timer_controller.register_timer(free_function_callback2, 11, etl::timer::mode::Single_Shot);
+      etl::timer<>::id::type id1 = timer_controller.register_timer(member_callback, 37, etl::timer<>::mode::Single_Shot);
+      etl::timer<>::id::type id2 = timer_controller.register_timer(free_function_callback, 23, etl::timer<>::mode::Single_Shot);
+      etl::timer<>::id::type id3 = timer_controller.register_timer(free_function_callback2, 11, etl::timer<>::mode::Single_Shot);
 
       timer_controller.start(id1);
       timer_controller.start(id3);
@@ -768,7 +768,7 @@ namespace
       CHECK_TRUE(timer_controller.has_active_timer());
 
       timer_controller.tick(1);
-      CHECK_EQUAL(static_cast<etl::timer::interval::type>(etl::timer::interval::No_Active_Interval), timer_controller.time_to_next());
+      CHECK_EQUAL(static_cast<etl::timer<>::interval::type>(etl::timer<>::interval::No_Active_Interval), timer_controller.time_to_next());
       CHECK_FALSE(timer_controller.has_active_timer());
     }
 
@@ -777,9 +777,9 @@ namespace
     {
       etl::callback_timer_interrupt<3, ScopedGuard> timer_controller;
 
-      etl::timer::id::type id1 = timer_controller.register_timer(member_callback,         37, etl::timer::mode::Single_Shot);
-      etl::timer::id::type id2 = timer_controller.register_timer(free_function_callback,  23, etl::timer::mode::Single_Shot);
-      etl::timer::id::type id3 = timer_controller.register_timer(free_function_callback2, 11, etl::timer::mode::Single_Shot);
+      etl::timer<>::id::type id1 = timer_controller.register_timer(member_callback,         37, etl::timer<>::mode::Single_Shot);
+      etl::timer<>::id::type id2 = timer_controller.register_timer(free_function_callback,  23, etl::timer<>::mode::Single_Shot);
+      etl::timer<>::id::type id3 = timer_controller.register_timer(free_function_callback2, 11, etl::timer<>::mode::Single_Shot);
 
       timer_controller.start(id1);
       timer_controller.start(id3);
@@ -829,7 +829,7 @@ namespace
 
       timer_controller.enable(true);
 
-      etl::timer::id::type id = timer_controller.register_timer(delegate_callback, 5, etl::timer::mode::Single_Shot);
+      etl::timer<>::id::type id = timer_controller.register_timer(delegate_callback, 5, etl::timer<>::mode::Single_Shot);
       timer_controller.start(id);
 
       timer_controller.tick(4);
@@ -887,10 +887,10 @@ namespace
       constexpr uint32_t T3 = 5U;
 
       // Register the timers.
-      etl::timer::id::type id0 = timer_controller.register_timer(delegate_callback0, T0, etl::timer::mode::Repeating);
-      etl::timer::id::type id1 = timer_controller.register_timer(delegate_callback1, T1, etl::timer::mode::Single_Shot);
-      etl::timer::id::type id2 = timer_controller.register_timer(delegate_callback2, T2, etl::timer::mode::Repeating);
-      etl::timer::id::type id3 = timer_controller.register_timer(delegate_callback3, T3, etl::timer::mode::Repeating);
+      etl::timer<>::id::type id0 = timer_controller.register_timer(delegate_callback0, T0, etl::timer<>::mode::Repeating);
+      etl::timer<>::id::type id1 = timer_controller.register_timer(delegate_callback1, T1, etl::timer<>::mode::Single_Shot);
+      etl::timer<>::id::type id2 = timer_controller.register_timer(delegate_callback2, T2, etl::timer<>::mode::Repeating);
+      etl::timer<>::id::type id3 = timer_controller.register_timer(delegate_callback3, T3, etl::timer<>::mode::Repeating);
       
       // Start the repeating timers.
       timer_controller.start(id0);

--- a/test/test_callback_timer_locked.cpp
+++ b/test/test_callback_timer_locked.cpp
@@ -161,17 +161,17 @@ namespace
 
       etl::callback_timer_locked<2> timer_controller(try_lock, lock, unlock);
 
-      etl::timer::id::type id1 = timer_controller.register_timer(member_callback,         37, etl::timer::mode::Single_Shot);
-      etl::timer::id::type id2 = timer_controller.register_timer(free_function_callback,  23, etl::timer::mode::Single_Shot);
-      etl::timer::id::type id3 = timer_controller.register_timer(free_function_callback2, 11, etl::timer::mode::Single_Shot);
+      etl::timer<>::id::type id1 = timer_controller.register_timer(member_callback,         37, etl::timer<>::mode::Single_Shot);
+      etl::timer<>::id::type id2 = timer_controller.register_timer(free_function_callback,  23, etl::timer<>::mode::Single_Shot);
+      etl::timer<>::id::type id3 = timer_controller.register_timer(free_function_callback2, 11, etl::timer<>::mode::Single_Shot);
 
-      CHECK(id1 != etl::timer::id::NO_TIMER);
-      CHECK(id2 != etl::timer::id::NO_TIMER);
-      CHECK(id3 == etl::timer::id::NO_TIMER);
+      CHECK(id1 != etl::timer<>::id::NO_TIMER);
+      CHECK(id2 != etl::timer<>::id::NO_TIMER);
+      CHECK(id3 == etl::timer<>::id::NO_TIMER);
 
       timer_controller.clear();
-      id3 = timer_controller.register_timer(free_function_callback2, 11, etl::timer::mode::Single_Shot);
-      CHECK(id3 != etl::timer::id::NO_TIMER);
+      id3 = timer_controller.register_timer(free_function_callback2, 11, etl::timer<>::mode::Single_Shot);
+      CHECK(id3 != etl::timer<>::id::NO_TIMER);
 
       CHECK_EQUAL(0U, locks.lock_count);
     }
@@ -186,9 +186,9 @@ namespace
 
       etl::callback_timer_locked<4> timer_controller(try_lock, lock, unlock);
 
-      etl::timer::id::type id1 = timer_controller.register_timer(member_callback,         37, etl::timer::mode::Single_Shot);
-      etl::timer::id::type id2 = timer_controller.register_timer(free_function_callback,  23, etl::timer::mode::Single_Shot);
-      etl::timer::id::type id3 = timer_controller.register_timer(free_function_callback2, 11, etl::timer::mode::Single_Shot);
+      etl::timer<>::id::type id1 = timer_controller.register_timer(member_callback,         37, etl::timer<>::mode::Single_Shot);
+      etl::timer<>::id::type id2 = timer_controller.register_timer(free_function_callback,  23, etl::timer<>::mode::Single_Shot);
+      etl::timer<>::id::type id3 = timer_controller.register_timer(free_function_callback2, 11, etl::timer<>::mode::Single_Shot);
 
       object.tick_list.clear();
       free_tick_list1.clear();
@@ -235,7 +235,7 @@ namespace
 
       etl::callback_timer_locked<1> timer_controller(try_lock, lock, unlock);
 
-      etl::timer::id::type id1 = timer_controller.register_timer(member_callback, 37, etl::timer::mode::Single_Shot);
+      etl::timer<>::id::type id1 = timer_controller.register_timer(member_callback, 37, etl::timer<>::mode::Single_Shot);
       object.tick_list.clear();
 
       timer_controller.start(id1);
@@ -288,9 +288,9 @@ namespace
 
       etl::callback_timer_locked<3> timer_controller(try_lock, lock, unlock);
 
-      etl::timer::id::type id1 = timer_controller.register_timer(member_callback,         37, etl::timer::mode::Repeating);
-      etl::timer::id::type id2 = timer_controller.register_timer(free_function_callback,  23, etl::timer::mode::Repeating);
-      etl::timer::id::type id3 = timer_controller.register_timer(free_function_callback2, 11, etl::timer::mode::Repeating);
+      etl::timer<>::id::type id1 = timer_controller.register_timer(member_callback,         37, etl::timer<>::mode::Repeating);
+      etl::timer<>::id::type id2 = timer_controller.register_timer(free_function_callback,  23, etl::timer<>::mode::Repeating);
+      etl::timer<>::id::type id3 = timer_controller.register_timer(free_function_callback2, 11, etl::timer<>::mode::Repeating);
 
       object.tick_list.clear();
       free_tick_list1.clear();
@@ -337,9 +337,9 @@ namespace
 
       etl::callback_timer_locked<3> timer_controller(try_lock, lock, unlock);
 
-      etl::timer::id::type id1 = timer_controller.register_timer(member_callback,         37, etl::timer::mode::Repeating);
-      etl::timer::id::type id2 = timer_controller.register_timer(free_function_callback,  23, etl::timer::mode::Repeating);
-      etl::timer::id::type id3 = timer_controller.register_timer(free_function_callback2, 11, etl::timer::mode::Repeating);
+      etl::timer<>::id::type id1 = timer_controller.register_timer(member_callback,         37, etl::timer<>::mode::Repeating);
+      etl::timer<>::id::type id2 = timer_controller.register_timer(free_function_callback,  23, etl::timer<>::mode::Repeating);
+      etl::timer<>::id::type id3 = timer_controller.register_timer(free_function_callback2, 11, etl::timer<>::mode::Repeating);
 
       object.tick_list.clear();
       free_tick_list1.clear();
@@ -390,9 +390,9 @@ namespace
 
       etl::callback_timer_locked<3> timer_controller(try_lock, lock, unlock);
 
-      etl::timer::id::type id1 = timer_controller.register_timer(member_callback,         37, etl::timer::mode::Repeating);
-      etl::timer::id::type id2 = timer_controller.register_timer(free_function_callback,  23, etl::timer::mode::Repeating);
-      etl::timer::id::type id3 = timer_controller.register_timer(free_function_callback2, 11, etl::timer::mode::Repeating);
+      etl::timer<>::id::type id1 = timer_controller.register_timer(member_callback,         37, etl::timer<>::mode::Repeating);
+      etl::timer<>::id::type id2 = timer_controller.register_timer(free_function_callback,  23, etl::timer<>::mode::Repeating);
+      etl::timer<>::id::type id3 = timer_controller.register_timer(free_function_callback2, 11, etl::timer<>::mode::Repeating);
 
       object.tick_list.clear();
       free_tick_list1.clear();
@@ -450,9 +450,9 @@ namespace
 
       etl::callback_timer_locked<3> timer_controller(try_lock, lock, unlock);
 
-      etl::timer::id::type id1 = timer_controller.register_timer(member_callback2, 100, etl::timer::mode::Single_Shot);
-      etl::timer::id::type id2 = timer_controller.register_timer(member_callback, 10, etl::timer::mode::Single_Shot);
-      etl::timer::id::type id3 = timer_controller.register_timer(member_callback, 22, etl::timer::mode::Single_Shot);
+      etl::timer<>::id::type id1 = timer_controller.register_timer(member_callback2, 100, etl::timer<>::mode::Single_Shot);
+      etl::timer<>::id::type id2 = timer_controller.register_timer(member_callback, 10, etl::timer<>::mode::Single_Shot);
+      etl::timer<>::id::type id3 = timer_controller.register_timer(member_callback, 22, etl::timer<>::mode::Single_Shot);
 
       (void)id2;
       (void)id3;
@@ -494,9 +494,9 @@ namespace
 
       etl::callback_timer_locked<3> timer_controller(try_lock, lock, unlock);
 
-      etl::timer::id::type id1 = timer_controller.register_timer(member_callback2, 100, etl::timer::mode::Single_Shot);
-      etl::timer::id::type id2 = timer_controller.register_timer(member_callback,   10, etl::timer::mode::Single_Shot);
-      etl::timer::id::type id3 = timer_controller.register_timer(member_callback,   22, etl::timer::mode::Single_Shot);
+      etl::timer<>::id::type id1 = timer_controller.register_timer(member_callback2, 100, etl::timer<>::mode::Single_Shot);
+      etl::timer<>::id::type id2 = timer_controller.register_timer(member_callback,   10, etl::timer<>::mode::Single_Shot);
+      etl::timer<>::id::type id3 = timer_controller.register_timer(member_callback,   22, etl::timer<>::mode::Single_Shot);
 
       (void)id2;
       (void)id3;
@@ -538,9 +538,9 @@ namespace
 
       etl::callback_timer_locked<3> timer_controller(try_lock, lock, unlock);
 
-      etl::timer::id::type id1;
-      etl::timer::id::type id2 = timer_controller.register_timer(free_function_callback,  23, etl::timer::mode::Repeating);
-      etl::timer::id::type id3 = timer_controller.register_timer(free_function_callback2, 11, etl::timer::mode::Repeating);
+      etl::timer<>::id::type id1;
+      etl::timer<>::id::type id2 = timer_controller.register_timer(free_function_callback,  23, etl::timer<>::mode::Repeating);
+      etl::timer<>::id::type id3 = timer_controller.register_timer(free_function_callback2, 11, etl::timer<>::mode::Repeating);
 
       object.tick_list.clear();
       free_tick_list1.clear();
@@ -561,7 +561,7 @@ namespace
         {
           timer_controller.unregister_timer(id2);
 
-          id1 = timer_controller.register_timer(member_callback, 37, etl::timer::mode::Repeating);
+          id1 = timer_controller.register_timer(member_callback, 37, etl::timer<>::mode::Repeating);
           timer_controller.start(id1);
         }
 
@@ -594,9 +594,9 @@ namespace
 
       etl::callback_timer_locked<3> timer_controller(try_lock, lock, unlock);
 
-      etl::timer::id::type id1 = timer_controller.register_timer(member_callback,         37, etl::timer::mode::Repeating);
-      etl::timer::id::type id2 = timer_controller.register_timer(free_function_callback,  23, etl::timer::mode::Repeating);
-      etl::timer::id::type id3 = timer_controller.register_timer(free_function_callback2, 11, etl::timer::mode::Repeating);
+      etl::timer<>::id::type id1 = timer_controller.register_timer(member_callback,         37, etl::timer<>::mode::Repeating);
+      etl::timer<>::id::type id2 = timer_controller.register_timer(free_function_callback,  23, etl::timer<>::mode::Repeating);
+      etl::timer<>::id::type id3 = timer_controller.register_timer(free_function_callback2, 11, etl::timer<>::mode::Repeating);
 
       object.tick_list.clear();
       free_tick_list1.clear();
@@ -649,9 +649,9 @@ namespace
 
       etl::callback_timer_locked<3> timer_controller(try_lock, lock, unlock);
 
-      etl::timer::id::type id1 = timer_controller.register_timer(member_callback,         37, etl::timer::mode::Repeating);
-      etl::timer::id::type id2 = timer_controller.register_timer(free_function_callback,  23, etl::timer::mode::Repeating);
-      etl::timer::id::type id3 = timer_controller.register_timer(free_function_callback2, 11, etl::timer::mode::Repeating);
+      etl::timer<>::id::type id1 = timer_controller.register_timer(member_callback,         37, etl::timer<>::mode::Repeating);
+      etl::timer<>::id::type id2 = timer_controller.register_timer(free_function_callback,  23, etl::timer<>::mode::Repeating);
+      etl::timer<>::id::type id3 = timer_controller.register_timer(free_function_callback2, 11, etl::timer<>::mode::Repeating);
 
       object.tick_list.clear();
       free_tick_list1.clear();
@@ -662,9 +662,9 @@ namespace
       ticks = 5;
       timer_controller.tick(uint32_t(ticks));
 
-      timer_controller.start(id1, etl::timer::start::Immediate);
-      timer_controller.start(id2, etl::timer::start::Immediate);
-      timer_controller.start(id3, etl::timer::start::Delayed);
+      timer_controller.start(id1, etl::timer<>::start::Immediate);
+      timer_controller.start(id2, etl::timer<>::start::Immediate);
+      timer_controller.start(id3, etl::timer<>::start::Delayed);
 
       const uint32_t step = 1U;
 
@@ -699,8 +699,8 @@ namespace
 
       etl::callback_timer_locked<3> timer_controller(try_lock, lock, unlock);
 
-      etl::timer::id::type id1 = timer_controller.register_timer(free_function_callback,  15, etl::timer::mode::Single_Shot);
-      etl::timer::id::type id2 = timer_controller.register_timer(free_function_callback2, 5,  etl::timer::mode::Repeating);
+      etl::timer<>::id::type id1 = timer_controller.register_timer(free_function_callback,  15, etl::timer<>::mode::Single_Shot);
+      etl::timer<>::id::type id2 = timer_controller.register_timer(free_function_callback2, 5,  etl::timer<>::mode::Repeating);
 
       free_tick_list1.clear();
       free_tick_list2.clear();
@@ -742,7 +742,7 @@ namespace
 
       etl::callback_timer_locked<3> timer_controller(try_lock, lock, unlock);
 
-      etl::timer::id::type id1 = timer_controller.register_timer(free_function_callback, 5, etl::timer::mode::Single_Shot);
+      etl::timer<>::id::type id1 = timer_controller.register_timer(free_function_callback, 5, etl::timer<>::mode::Single_Shot);
 
       free_tick_list1.clear();
 
@@ -806,7 +806,7 @@ namespace
 
         timer_controller.enable(true);
 
-        etl::timer::id::type id = timer_controller.register_timer(delegate_callback, 5, etl::timer::mode::Single_Shot);
+        etl::timer<>::id::type id = timer_controller.register_timer(delegate_callback, 5, etl::timer<>::mode::Single_Shot);
         timer_controller.start(id);
 
         timer_controller.tick(4);
@@ -828,9 +828,9 @@ namespace
 
       etl::callback_timer_locked<3> timer_controller(try_lock, lock, unlock);
 
-      etl::timer::id::type id1 = timer_controller.register_timer(member_callback,         37, etl::timer::mode::Repeating);
-      etl::timer::id::type id2 = timer_controller.register_timer(free_function_callback,  23, etl::timer::mode::Repeating);
-      etl::timer::id::type id3 = timer_controller.register_timer(free_function_callback2, 11, etl::timer::mode::Repeating);
+      etl::timer<>::id::type id1 = timer_controller.register_timer(member_callback,         37, etl::timer<>::mode::Repeating);
+      etl::timer<>::id::type id2 = timer_controller.register_timer(free_function_callback,  23, etl::timer<>::mode::Repeating);
+      etl::timer<>::id::type id3 = timer_controller.register_timer(free_function_callback2, 11, etl::timer<>::mode::Repeating);
 
       timer_controller.start(id1);
       timer_controller.start(id3);
@@ -881,9 +881,9 @@ namespace
 
       etl::callback_timer_locked<3> timer_controller(try_lock, lock, unlock);
 
-      etl::timer::id::type id1 = timer_controller.register_timer(member_callback,         37, etl::timer::mode::Single_Shot);
-      etl::timer::id::type id2 = timer_controller.register_timer(free_function_callback,  23, etl::timer::mode::Single_Shot);
-      etl::timer::id::type id3 = timer_controller.register_timer(free_function_callback2, 11, etl::timer::mode::Single_Shot);
+      etl::timer<>::id::type id1 = timer_controller.register_timer(member_callback,         37, etl::timer<>::mode::Single_Shot);
+      etl::timer<>::id::type id2 = timer_controller.register_timer(free_function_callback,  23, etl::timer<>::mode::Single_Shot);
+      etl::timer<>::id::type id3 = timer_controller.register_timer(free_function_callback2, 11, etl::timer<>::mode::Single_Shot);
 
       timer_controller.start(id1);
       timer_controller.start(id3);
@@ -921,9 +921,9 @@ namespace
 
       etl::callback_timer_locked<3> timer_controller(try_lock, lock, unlock);
 
-      etl::timer::id::type id1 = timer_controller.register_timer(member_callback, 37, etl::timer::mode::Single_Shot);
-      etl::timer::id::type id2 = timer_controller.register_timer(free_function_callback, 23, etl::timer::mode::Single_Shot);
-      etl::timer::id::type id3 = timer_controller.register_timer(free_function_callback2, 11, etl::timer::mode::Single_Shot);
+      etl::timer<>::id::type id1 = timer_controller.register_timer(member_callback, 37, etl::timer<>::mode::Single_Shot);
+      etl::timer<>::id::type id2 = timer_controller.register_timer(free_function_callback, 23, etl::timer<>::mode::Single_Shot);
+      etl::timer<>::id::type id3 = timer_controller.register_timer(free_function_callback2, 11, etl::timer<>::mode::Single_Shot);
 
       timer_controller.start(id1);
       timer_controller.start(id3);
@@ -944,7 +944,7 @@ namespace
       CHECK_TRUE(timer_controller.has_active_timer());
 
       timer_controller.tick(1);
-      CHECK_EQUAL(static_cast<etl::timer::interval::type>(etl::timer::interval::No_Active_Interval), timer_controller.time_to_next());
+      CHECK_EQUAL(static_cast<etl::timer<>::interval::type>(etl::timer<>::interval::No_Active_Interval), timer_controller.time_to_next());
       CHECK_FALSE(timer_controller.has_active_timer());
     }
 
@@ -1030,9 +1030,9 @@ namespace
     {
       FIX_PROCESSOR_AFFINITY;
 
-      etl::timer::id::type id1 = controller.register_timer(member_callback,         400, etl::timer::mode::Single_Shot);
-      etl::timer::id::type id2 = controller.register_timer(free_function_callback,  100, etl::timer::mode::Repeating);
-      etl::timer::id::type id3 = controller.register_timer(free_function_callback2,  10, etl::timer::mode::Repeating);
+      etl::timer<>::id::type id1 = controller.register_timer(member_callback,         400, etl::timer<>::mode::Single_Shot);
+      etl::timer<>::id::type id2 = controller.register_timer(free_function_callback,  100, etl::timer<>::mode::Repeating);
+      etl::timer<>::id::type id3 = controller.register_timer(free_function_callback2,  10, etl::timer<>::mode::Repeating);
 
       object.tick_list.clear();
       free_tick_list1.clear();

--- a/test/test_message_timer.cpp
+++ b/test/test_message_timer.cpp
@@ -141,17 +141,17 @@ namespace
     {
       etl::message_timer<2> timer_controller;
 
-      etl::timer::id::type id1 = timer_controller.register_timer(message1, router1, 37, etl::timer::mode::Single_Shot);
-      etl::timer::id::type id2 = timer_controller.register_timer(message2, router1, 23, etl::timer::mode::Single_Shot);
-      etl::timer::id::type id3 = timer_controller.register_timer(message3, router1, 11, etl::timer::mode::Single_Shot);
+      etl::timer<>::id::type id1 = timer_controller.register_timer(message1, router1, 37, etl::timer<>::mode::Single_Shot);
+      etl::timer<>::id::type id2 = timer_controller.register_timer(message2, router1, 23, etl::timer<>::mode::Single_Shot);
+      etl::timer<>::id::type id3 = timer_controller.register_timer(message3, router1, 11, etl::timer<>::mode::Single_Shot);
 
-      CHECK(id1 != etl::timer::id::NO_TIMER);
-      CHECK(id2 != etl::timer::id::NO_TIMER);
-      CHECK(id3 == etl::timer::id::NO_TIMER);
+      CHECK(id1 != etl::timer<>::id::NO_TIMER);
+      CHECK(id2 != etl::timer<>::id::NO_TIMER);
+      CHECK(id3 == etl::timer<>::id::NO_TIMER);
 
       timer_controller.clear();
-      id3 = timer_controller.register_timer(message3, router1, 11, etl::timer::mode::Single_Shot);
-      CHECK(id3 != etl::timer::id::NO_TIMER);
+      id3 = timer_controller.register_timer(message3, router1, 11, etl::timer<>::mode::Single_Shot);
+      CHECK(id3 != etl::timer<>::id::NO_TIMER);
     }
 
     //*************************************************************************
@@ -159,9 +159,9 @@ namespace
     {
       etl::message_timer<3> timer_controller;
 
-      etl::timer::id::type id1 = timer_controller.register_timer(message1, router1, 37, etl::timer::mode::Single_Shot);
-      etl::timer::id::type id2 = timer_controller.register_timer(message2, router1, 23, etl::timer::mode::Single_Shot);
-      etl::timer::id::type id3 = timer_controller.register_timer(message3, router1, 11, etl::timer::mode::Single_Shot);
+      etl::timer<>::id::type id1 = timer_controller.register_timer(message1, router1, 37, etl::timer<>::mode::Single_Shot);
+      etl::timer<>::id::type id2 = timer_controller.register_timer(message2, router1, 23, etl::timer<>::mode::Single_Shot);
+      etl::timer<>::id::type id3 = timer_controller.register_timer(message3, router1, 11, etl::timer<>::mode::Single_Shot);
 
       router1.clear();
 
@@ -195,7 +195,7 @@ namespace
     {
       etl::message_timer<1> timer_controller;
 
-      etl::timer::id::type id1 = timer_controller.register_timer(message1, router1, 37, etl::timer::mode::Single_Shot);
+      etl::timer<>::id::type id1 = timer_controller.register_timer(message1, router1, 37, etl::timer<>::mode::Single_Shot);
       router1.clear();
 
       timer_controller.start(id1);
@@ -241,9 +241,9 @@ namespace
     {
       etl::message_timer<3> timer_controller;
 
-      etl::timer::id::type id1 = timer_controller.register_timer(message1, router1, 37, etl::timer::mode::Repeating);
-      etl::timer::id::type id2 = timer_controller.register_timer(message2, router1, 23, etl::timer::mode::Repeating);
-      etl::timer::id::type id3 = timer_controller.register_timer(message3, router1, 11, etl::timer::mode::Repeating);
+      etl::timer<>::id::type id1 = timer_controller.register_timer(message1, router1, 37, etl::timer<>::mode::Repeating);
+      etl::timer<>::id::type id2 = timer_controller.register_timer(message2, router1, 23, etl::timer<>::mode::Repeating);
+      etl::timer<>::id::type id3 = timer_controller.register_timer(message3, router1, 11, etl::timer<>::mode::Repeating);
 
       router1.clear();
 
@@ -277,9 +277,9 @@ namespace
     {
       etl::message_timer<3> timer_controller;
 
-      etl::timer::id::type id1 = timer_controller.register_timer(message1, router1, 37, etl::timer::mode::Repeating);
-      etl::timer::id::type id2 = timer_controller.register_timer(message2, router1, 23, etl::timer::mode::Repeating);
-      etl::timer::id::type id3 = timer_controller.register_timer(message3, router1, 11, etl::timer::mode::Repeating);
+      etl::timer<>::id::type id1 = timer_controller.register_timer(message1, router1, 37, etl::timer<>::mode::Repeating);
+      etl::timer<>::id::type id2 = timer_controller.register_timer(message2, router1, 23, etl::timer<>::mode::Repeating);
+      etl::timer<>::id::type id3 = timer_controller.register_timer(message3, router1, 11, etl::timer<>::mode::Repeating);
 
       router1.clear();
 
@@ -317,9 +317,9 @@ namespace
     {
       etl::message_timer<3> timer_controller;
 
-      etl::timer::id::type id1 = timer_controller.register_timer(message1, router1, 37, etl::timer::mode::Repeating);
-      etl::timer::id::type id2 = timer_controller.register_timer(message2, router1, 23, etl::timer::mode::Repeating);
-      etl::timer::id::type id3 = timer_controller.register_timer(message3, router1, 11, etl::timer::mode::Repeating);
+      etl::timer<>::id::type id1 = timer_controller.register_timer(message1, router1, 37, etl::timer<>::mode::Repeating);
+      etl::timer<>::id::type id2 = timer_controller.register_timer(message2, router1, 23, etl::timer<>::mode::Repeating);
+      etl::timer<>::id::type id3 = timer_controller.register_timer(message3, router1, 11, etl::timer<>::mode::Repeating);
 
       router1.clear();
 
@@ -364,9 +364,9 @@ namespace
     {
       etl::message_timer<3> timer_controller;
 
-      etl::timer::id::type id1;
-      etl::timer::id::type id2 = timer_controller.register_timer(message2, router1, 23, etl::timer::mode::Repeating);
-      etl::timer::id::type id3 = timer_controller.register_timer(message3, router1, 11, etl::timer::mode::Repeating);
+      etl::timer<>::id::type id1;
+      etl::timer<>::id::type id2 = timer_controller.register_timer(message2, router1, 23, etl::timer<>::mode::Repeating);
+      etl::timer<>::id::type id3 = timer_controller.register_timer(message3, router1, 11, etl::timer<>::mode::Repeating);
 
       router1.clear();
 
@@ -385,7 +385,7 @@ namespace
         {
           timer_controller.unregister_timer(id2);
 
-          id1 = timer_controller.register_timer(message1, router1, 37, etl::timer::mode::Repeating);
+          id1 = timer_controller.register_timer(message1, router1, 37, etl::timer<>::mode::Repeating);
           timer_controller.start(id1);
         }
 
@@ -407,9 +407,9 @@ namespace
     {
       etl::message_timer<3> timer_controller;
 
-      etl::timer::id::type id1 = timer_controller.register_timer(message1, router1, 37, etl::timer::mode::Repeating);
-      etl::timer::id::type id2 = timer_controller.register_timer(message2, router1, 23, etl::timer::mode::Repeating);
-      etl::timer::id::type id3 = timer_controller.register_timer(message3, router1, 11, etl::timer::mode::Repeating);
+      etl::timer<>::id::type id1 = timer_controller.register_timer(message1, router1, 37, etl::timer<>::mode::Repeating);
+      etl::timer<>::id::type id2 = timer_controller.register_timer(message2, router1, 23, etl::timer<>::mode::Repeating);
+      etl::timer<>::id::type id3 = timer_controller.register_timer(message3, router1, 11, etl::timer<>::mode::Repeating);
 
       router1.clear();
 
@@ -449,9 +449,9 @@ namespace
     {
       etl::message_timer<3> timer_controller;
 
-      etl::timer::id::type id1 = timer_controller.register_timer(message1, bus1, 37, etl::timer::mode::Single_Shot, ROUTER1);
-      etl::timer::id::type id2 = timer_controller.register_timer(message2, bus1, 23, etl::timer::mode::Single_Shot, ROUTER1);
-      etl::timer::id::type id3 = timer_controller.register_timer(message3, bus1, 11, etl::timer::mode::Single_Shot, etl::imessage_router::ALL_MESSAGE_ROUTERS);
+      etl::timer<>::id::type id1 = timer_controller.register_timer(message1, bus1, 37, etl::timer<>::mode::Single_Shot, ROUTER1);
+      etl::timer<>::id::type id2 = timer_controller.register_timer(message2, bus1, 23, etl::timer<>::mode::Single_Shot, ROUTER1);
+      etl::timer<>::id::type id3 = timer_controller.register_timer(message3, bus1, 11, etl::timer<>::mode::Single_Shot, etl::imessage_router::ALL_MESSAGE_ROUTERS);
 
       bus1.subscribe(router1);
 
@@ -487,9 +487,9 @@ namespace
     {
       etl::message_timer<3> timer_controller;
 
-      etl::timer::id::type id1 = timer_controller.register_timer(message1, router1, 37, etl::timer::mode::Repeating);
-      etl::timer::id::type id2 = timer_controller.register_timer(message2, router1, 23, etl::timer::mode::Repeating);
-      etl::timer::id::type id3 = timer_controller.register_timer(message3, router1, 11, etl::timer::mode::Repeating);
+      etl::timer<>::id::type id1 = timer_controller.register_timer(message1, router1, 37, etl::timer<>::mode::Repeating);
+      etl::timer<>::id::type id2 = timer_controller.register_timer(message2, router1, 23, etl::timer<>::mode::Repeating);
+      etl::timer<>::id::type id3 = timer_controller.register_timer(message3, router1, 11, etl::timer<>::mode::Repeating);
 
       router1.clear();
 
@@ -502,9 +502,9 @@ namespace
       ticks = 5;
       timer_controller.tick(uint32_t(ticks));
 
-      timer_controller.start(id1, etl::timer::start::Immediate);
-      timer_controller.start(id2, etl::timer::start::Immediate);
-      timer_controller.start(id3, etl::timer::start::Delayed);
+      timer_controller.start(id1, etl::timer<>::start::Immediate);
+      timer_controller.start(id2, etl::timer<>::start::Immediate);
+      timer_controller.start(id3, etl::timer<>::start::Delayed);
 
       const uint32_t step = 1UL;
 
@@ -528,8 +528,8 @@ namespace
     {
       etl::message_timer<3> timer_controller;
 
-      etl::timer::id::type id1 = timer_controller.register_timer(message1, router1, 15, etl::timer::mode::Single_Shot);
-      etl::timer::id::type id2 = timer_controller.register_timer(message2, router1,  5, etl::timer::mode::Repeating);
+      etl::timer<>::id::type id1 = timer_controller.register_timer(message1, router1, 15, etl::timer<>::mode::Single_Shot);
+      etl::timer<>::id::type id2 = timer_controller.register_timer(message2, router1,  5, etl::timer<>::mode::Repeating);
 
       router1.clear();
 
@@ -560,7 +560,7 @@ namespace
     {
       etl::message_timer<3> timer_controller;
 
-      etl::timer::id::type id1 = timer_controller.register_timer(message1, router1, 5, etl::timer::mode::Single_Shot);
+      etl::timer<>::id::type id1 = timer_controller.register_timer(message1, router1, 5, etl::timer<>::mode::Single_Shot);
 
       router1.clear();
 
@@ -598,9 +598,9 @@ namespace
     {
       etl::message_timer<3> timer_controller;
 
-      etl::timer::id::type id1 = timer_controller.register_timer(message1, router1, 37, etl::timer::mode::Repeating);
-      etl::timer::id::type id2 = timer_controller.register_timer(message2, router1, 23, etl::timer::mode::Repeating);
-      etl::timer::id::type id3 = timer_controller.register_timer(message3, router1, 11, etl::timer::mode::Repeating);
+      etl::timer<>::id::type id1 = timer_controller.register_timer(message1, router1, 37, etl::timer<>::mode::Repeating);
+      etl::timer<>::id::type id2 = timer_controller.register_timer(message2, router1, 23, etl::timer<>::mode::Repeating);
+      etl::timer<>::id::type id3 = timer_controller.register_timer(message3, router1, 11, etl::timer<>::mode::Repeating);
 
       router1.clear();
 
@@ -644,13 +644,40 @@ namespace
     }
 
     //*************************************************************************
+    TEST(message_timer_time_to_next_huge_timer)
+    {
+      etl::message_timer<2, etl::timer_model::TIMER_MODEL_HUGE> timer_controller;
+
+      const uint8_t id1_interval = 0xFFU;
+      const uint64_t id2_interval = 0xFFFFFFFFFFFFFFF1U;
+
+      etl::timer<etl::timer_model::TIMER_MODEL_HUGE>::id::type id1 =
+        timer_controller.register_timer(message1, router1, id1_interval, etl::timer<etl::timer_model::TIMER_MODEL_HUGE>::mode::Single_Shot);
+
+      etl::timer<etl::timer_model::TIMER_MODEL_HUGE>::id::type id2 =
+        timer_controller.register_timer(message2, router1, id2_interval, etl::timer<>::mode::Repeating);
+
+      router1.clear();
+
+      timer_controller.start(id1);
+      timer_controller.start(id2);
+
+      timer_controller.enable(true);
+
+      CHECK_EQUAL(id1_interval, timer_controller.time_to_next());
+
+      timer_controller.tick(id1_interval);
+      CHECK_EQUAL(id2_interval - id1_interval, timer_controller.time_to_next());
+    }
+
+    //*************************************************************************
     TEST(message_timer_time_to_next_with_has_active_timer)
     {
       etl::message_timer<3> timer_controller;
 
-      etl::timer::id::type id1 = timer_controller.register_timer(message1, router1, 37, etl::timer::mode::Single_Shot);
-      etl::timer::id::type id2 = timer_controller.register_timer(message2, router1, 23, etl::timer::mode::Single_Shot);
-      etl::timer::id::type id3 = timer_controller.register_timer(message3, router1, 11, etl::timer::mode::Single_Shot);
+      etl::timer<>::id::type id1 = timer_controller.register_timer(message1, router1, 37, etl::timer<>::mode::Single_Shot);
+      etl::timer<>::id::type id2 = timer_controller.register_timer(message2, router1, 23, etl::timer<>::mode::Single_Shot);
+      etl::timer<>::id::type id3 = timer_controller.register_timer(message3, router1, 11, etl::timer<>::mode::Single_Shot);
 
       router1.clear();
 
@@ -673,7 +700,7 @@ namespace
       CHECK_TRUE(timer_controller.has_active_timer());
 
       timer_controller.tick(1);
-      CHECK_EQUAL(static_cast<etl::timer::interval::type>(etl::timer::interval::No_Active_Interval), timer_controller.time_to_next());
+      CHECK_EQUAL(static_cast<etl::timer<>::interval::type>(etl::timer<>::interval::No_Active_Interval), timer_controller.time_to_next());
       CHECK_FALSE(timer_controller.has_active_timer());
     }
 
@@ -720,9 +747,9 @@ namespace
     {
       FIX_PROCESSOR_AFFINITY;
 
-      etl::timer::id::type id1 = controller.register_timer(message1, router1, 400,  etl::timer::mode::Single_Shot);
-      etl::timer::id::type id2 = controller.register_timer(message2, router1, 100,  etl::timer::mode::Repeating);
-      etl::timer::id::type id3 = controller.register_timer(message3, router1, 10,   etl::timer::mode::Repeating);
+      etl::timer<>::id::type id1 = controller.register_timer(message1, router1, 400,  etl::timer<>::mode::Single_Shot);
+      etl::timer<>::id::type id2 = controller.register_timer(message2, router1, 100,  etl::timer<>::mode::Repeating);
+      etl::timer<>::id::type id3 = controller.register_timer(message3, router1, 10,   etl::timer<>::mode::Repeating);
 
       router1.clear();
 

--- a/test/test_message_timer_atomic.cpp
+++ b/test/test_message_timer_atomic.cpp
@@ -141,17 +141,17 @@ namespace
     {
       etl::message_timer_atomic<2, std::atomic_uint32_t> timer_controller;
 
-      etl::timer::id::type id1 = timer_controller.register_timer(message1, router1, 37, etl::timer::mode::Single_Shot);
-      etl::timer::id::type id2 = timer_controller.register_timer(message2, router1, 23, etl::timer::mode::Single_Shot);
-      etl::timer::id::type id3 = timer_controller.register_timer(message3, router1, 11, etl::timer::mode::Single_Shot);
+      etl::timer<>::id::type id1 = timer_controller.register_timer(message1, router1, 37, etl::timer<>::mode::Single_Shot);
+      etl::timer<>::id::type id2 = timer_controller.register_timer(message2, router1, 23, etl::timer<>::mode::Single_Shot);
+      etl::timer<>::id::type id3 = timer_controller.register_timer(message3, router1, 11, etl::timer<>::mode::Single_Shot);
 
-      CHECK(id1 != etl::timer::id::NO_TIMER);
-      CHECK(id2 != etl::timer::id::NO_TIMER);
-      CHECK(id3 == etl::timer::id::NO_TIMER);
+      CHECK(id1 != etl::timer<>::id::NO_TIMER);
+      CHECK(id2 != etl::timer<>::id::NO_TIMER);
+      CHECK(id3 == etl::timer<>::id::NO_TIMER);
 
       timer_controller.clear();
-      id3 = timer_controller.register_timer(message3, router1, 11, etl::timer::mode::Single_Shot);
-      CHECK(id3 != etl::timer::id::NO_TIMER);
+      id3 = timer_controller.register_timer(message3, router1, 11, etl::timer<>::mode::Single_Shot);
+      CHECK(id3 != etl::timer<>::id::NO_TIMER);
     }
 
     //*************************************************************************
@@ -159,9 +159,9 @@ namespace
     {
       etl::message_timer_atomic<3, std::atomic_uint32_t> timer_controller;
 
-      etl::timer::id::type id1 = timer_controller.register_timer(message1, router1, 37, etl::timer::mode::Single_Shot);
-      etl::timer::id::type id2 = timer_controller.register_timer(message2, router1, 23, etl::timer::mode::Single_Shot);
-      etl::timer::id::type id3 = timer_controller.register_timer(message3, router1, 11, etl::timer::mode::Single_Shot);
+      etl::timer<>::id::type id1 = timer_controller.register_timer(message1, router1, 37, etl::timer<>::mode::Single_Shot);
+      etl::timer<>::id::type id2 = timer_controller.register_timer(message2, router1, 23, etl::timer<>::mode::Single_Shot);
+      etl::timer<>::id::type id3 = timer_controller.register_timer(message3, router1, 11, etl::timer<>::mode::Single_Shot);
 
       router1.clear();
 
@@ -195,7 +195,7 @@ namespace
     {
       etl::message_timer_atomic<1, std::atomic_uint32_t> timer_controller;
 
-      etl::timer::id::type id1 = timer_controller.register_timer(message1, router1, 37, etl::timer::mode::Single_Shot);
+      etl::timer<>::id::type id1 = timer_controller.register_timer(message1, router1, 37, etl::timer<>::mode::Single_Shot);
       router1.clear();
 
       timer_controller.start(id1);
@@ -241,9 +241,9 @@ namespace
     {
       etl::message_timer_atomic<3, std::atomic_uint32_t> timer_controller;
 
-      etl::timer::id::type id1 = timer_controller.register_timer(message1, router1, 37, etl::timer::mode::Repeating);
-      etl::timer::id::type id2 = timer_controller.register_timer(message2, router1, 23, etl::timer::mode::Repeating);
-      etl::timer::id::type id3 = timer_controller.register_timer(message3, router1, 11, etl::timer::mode::Repeating);
+      etl::timer<>::id::type id1 = timer_controller.register_timer(message1, router1, 37, etl::timer<>::mode::Repeating);
+      etl::timer<>::id::type id2 = timer_controller.register_timer(message2, router1, 23, etl::timer<>::mode::Repeating);
+      etl::timer<>::id::type id3 = timer_controller.register_timer(message3, router1, 11, etl::timer<>::mode::Repeating);
 
       router1.clear();
 
@@ -277,9 +277,9 @@ namespace
     {
       etl::message_timer_atomic<3, std::atomic_uint32_t> timer_controller;
 
-      etl::timer::id::type id1 = timer_controller.register_timer(message1, router1, 37, etl::timer::mode::Repeating);
-      etl::timer::id::type id2 = timer_controller.register_timer(message2, router1, 23, etl::timer::mode::Repeating);
-      etl::timer::id::type id3 = timer_controller.register_timer(message3, router1, 11, etl::timer::mode::Repeating);
+      etl::timer<>::id::type id1 = timer_controller.register_timer(message1, router1, 37, etl::timer<>::mode::Repeating);
+      etl::timer<>::id::type id2 = timer_controller.register_timer(message2, router1, 23, etl::timer<>::mode::Repeating);
+      etl::timer<>::id::type id3 = timer_controller.register_timer(message3, router1, 11, etl::timer<>::mode::Repeating);
 
       router1.clear();
 
@@ -317,9 +317,9 @@ namespace
     {
       etl::message_timer_atomic<3, std::atomic_uint32_t> timer_controller;
 
-      etl::timer::id::type id1 = timer_controller.register_timer(message1, router1, 37, etl::timer::mode::Repeating);
-      etl::timer::id::type id2 = timer_controller.register_timer(message2, router1, 23, etl::timer::mode::Repeating);
-      etl::timer::id::type id3 = timer_controller.register_timer(message3, router1, 11, etl::timer::mode::Repeating);
+      etl::timer<>::id::type id1 = timer_controller.register_timer(message1, router1, 37, etl::timer<>::mode::Repeating);
+      etl::timer<>::id::type id2 = timer_controller.register_timer(message2, router1, 23, etl::timer<>::mode::Repeating);
+      etl::timer<>::id::type id3 = timer_controller.register_timer(message3, router1, 11, etl::timer<>::mode::Repeating);
 
       router1.clear();
 
@@ -364,9 +364,9 @@ namespace
     {
       etl::message_timer_atomic<3, std::atomic_uint32_t> timer_controller;
 
-      etl::timer::id::type id1;
-      etl::timer::id::type id2 = timer_controller.register_timer(message2, router1, 23, etl::timer::mode::Repeating);
-      etl::timer::id::type id3 = timer_controller.register_timer(message3, router1, 11, etl::timer::mode::Repeating);
+      etl::timer<>::id::type id1;
+      etl::timer<>::id::type id2 = timer_controller.register_timer(message2, router1, 23, etl::timer<>::mode::Repeating);
+      etl::timer<>::id::type id3 = timer_controller.register_timer(message3, router1, 11, etl::timer<>::mode::Repeating);
 
       router1.clear();
 
@@ -385,7 +385,7 @@ namespace
         {
           timer_controller.unregister_timer(id2);
 
-          id1 = timer_controller.register_timer(message1, router1, 37, etl::timer::mode::Repeating);
+          id1 = timer_controller.register_timer(message1, router1, 37, etl::timer<>::mode::Repeating);
           timer_controller.start(id1);
         }
 
@@ -407,9 +407,9 @@ namespace
     {
       etl::message_timer_atomic<3, std::atomic_uint32_t> timer_controller;
 
-      etl::timer::id::type id1 = timer_controller.register_timer(message1, router1, 37, etl::timer::mode::Repeating);
-      etl::timer::id::type id2 = timer_controller.register_timer(message2, router1, 23, etl::timer::mode::Repeating);
-      etl::timer::id::type id3 = timer_controller.register_timer(message3, router1, 11, etl::timer::mode::Repeating);
+      etl::timer<>::id::type id1 = timer_controller.register_timer(message1, router1, 37, etl::timer<>::mode::Repeating);
+      etl::timer<>::id::type id2 = timer_controller.register_timer(message2, router1, 23, etl::timer<>::mode::Repeating);
+      etl::timer<>::id::type id3 = timer_controller.register_timer(message3, router1, 11, etl::timer<>::mode::Repeating);
 
       router1.clear();
 
@@ -449,9 +449,9 @@ namespace
     {
       etl::message_timer_atomic<3, std::atomic_uint32_t> timer_controller;
 
-      etl::timer::id::type id1 = timer_controller.register_timer(message1, bus1, 37, etl::timer::mode::Single_Shot, ROUTER1);
-      etl::timer::id::type id2 = timer_controller.register_timer(message2, bus1, 23, etl::timer::mode::Single_Shot, ROUTER1);
-      etl::timer::id::type id3 = timer_controller.register_timer(message3, bus1, 11, etl::timer::mode::Single_Shot, etl::imessage_router::ALL_MESSAGE_ROUTERS);
+      etl::timer<>::id::type id1 = timer_controller.register_timer(message1, bus1, 37, etl::timer<>::mode::Single_Shot, ROUTER1);
+      etl::timer<>::id::type id2 = timer_controller.register_timer(message2, bus1, 23, etl::timer<>::mode::Single_Shot, ROUTER1);
+      etl::timer<>::id::type id3 = timer_controller.register_timer(message3, bus1, 11, etl::timer<>::mode::Single_Shot, etl::imessage_router::ALL_MESSAGE_ROUTERS);
 
       bus1.subscribe(router1);
 
@@ -487,9 +487,9 @@ namespace
     {
       etl::message_timer_atomic<3, std::atomic_uint32_t> timer_controller;
 
-      etl::timer::id::type id1 = timer_controller.register_timer(message1, router1, 37, etl::timer::mode::Repeating);
-      etl::timer::id::type id2 = timer_controller.register_timer(message2, router1, 23, etl::timer::mode::Repeating);
-      etl::timer::id::type id3 = timer_controller.register_timer(message3, router1, 11, etl::timer::mode::Repeating);
+      etl::timer<>::id::type id1 = timer_controller.register_timer(message1, router1, 37, etl::timer<>::mode::Repeating);
+      etl::timer<>::id::type id2 = timer_controller.register_timer(message2, router1, 23, etl::timer<>::mode::Repeating);
+      etl::timer<>::id::type id3 = timer_controller.register_timer(message3, router1, 11, etl::timer<>::mode::Repeating);
 
       router1.clear();
 
@@ -502,9 +502,9 @@ namespace
       ticks = 5;
       timer_controller.tick(uint32_t(ticks));
 
-      timer_controller.start(id1, etl::timer::start::Immediate);
-      timer_controller.start(id2, etl::timer::start::Immediate);
-      timer_controller.start(id3, etl::timer::start::Delayed);
+      timer_controller.start(id1, etl::timer<>::start::Immediate);
+      timer_controller.start(id2, etl::timer<>::start::Immediate);
+      timer_controller.start(id3, etl::timer<>::start::Delayed);
 
       const uint32_t step = 1UL;
 
@@ -528,8 +528,8 @@ namespace
     {
       etl::message_timer_atomic<3, std::atomic_uint32_t> timer_controller;
 
-      etl::timer::id::type id1 = timer_controller.register_timer(message1, router1, 15, etl::timer::mode::Single_Shot);
-      etl::timer::id::type id2 = timer_controller.register_timer(message2, router1,  5, etl::timer::mode::Repeating);
+      etl::timer<>::id::type id1 = timer_controller.register_timer(message1, router1, 15, etl::timer<>::mode::Single_Shot);
+      etl::timer<>::id::type id2 = timer_controller.register_timer(message2, router1,  5, etl::timer<>::mode::Repeating);
 
       router1.clear();
 
@@ -560,7 +560,7 @@ namespace
     {
       etl::message_timer_atomic<3, std::atomic_uint32_t> timer_controller;
 
-      etl::timer::id::type id1 = timer_controller.register_timer(message1, router1, 5, etl::timer::mode::Single_Shot);
+      etl::timer<>::id::type id1 = timer_controller.register_timer(message1, router1, 5, etl::timer<>::mode::Single_Shot);
 
       router1.clear();
 
@@ -598,9 +598,9 @@ namespace
     {
       etl::message_timer_atomic<3, std::atomic_uint32_t> timer_controller;
 
-      etl::timer::id::type id1 = timer_controller.register_timer(message1, router1, 37, etl::timer::mode::Repeating);
-      etl::timer::id::type id2 = timer_controller.register_timer(message2, router1, 23, etl::timer::mode::Repeating);
-      etl::timer::id::type id3 = timer_controller.register_timer(message3, router1, 11, etl::timer::mode::Repeating);
+      etl::timer<>::id::type id1 = timer_controller.register_timer(message1, router1, 37, etl::timer<>::mode::Repeating);
+      etl::timer<>::id::type id2 = timer_controller.register_timer(message2, router1, 23, etl::timer<>::mode::Repeating);
+      etl::timer<>::id::type id3 = timer_controller.register_timer(message3, router1, 11, etl::timer<>::mode::Repeating);
 
       router1.clear();
 
@@ -648,9 +648,9 @@ namespace
     {
       etl::message_timer_atomic<3, std::atomic_uint32_t> timer_controller;
 
-      etl::timer::id::type id1 = timer_controller.register_timer(message1, router1, 37, etl::timer::mode::Single_Shot);
-      etl::timer::id::type id2 = timer_controller.register_timer(message2, router1, 23, etl::timer::mode::Single_Shot);
-      etl::timer::id::type id3 = timer_controller.register_timer(message3, router1, 11, etl::timer::mode::Single_Shot);
+      etl::timer<>::id::type id1 = timer_controller.register_timer(message1, router1, 37, etl::timer<>::mode::Single_Shot);
+      etl::timer<>::id::type id2 = timer_controller.register_timer(message2, router1, 23, etl::timer<>::mode::Single_Shot);
+      etl::timer<>::id::type id3 = timer_controller.register_timer(message3, router1, 11, etl::timer<>::mode::Single_Shot);
 
       router1.clear();
 
@@ -673,7 +673,7 @@ namespace
       CHECK_TRUE(timer_controller.has_active_timer());
 
       timer_controller.tick(1);
-      CHECK_EQUAL(static_cast<etl::timer::interval::type>(etl::timer::interval::No_Active_Interval), timer_controller.time_to_next());
+      CHECK_EQUAL(static_cast<etl::timer<>::interval::type>(etl::timer<>::interval::No_Active_Interval), timer_controller.time_to_next());
       CHECK_FALSE(timer_controller.has_active_timer());
     }
 
@@ -720,9 +720,9 @@ namespace
     {
       FIX_PROCESSOR_AFFINITY;
 
-      etl::timer::id::type id1 = controller.register_timer(message1, router1, 400,  etl::timer::mode::Single_Shot);
-      etl::timer::id::type id2 = controller.register_timer(message2, router1, 100,  etl::timer::mode::Repeating);
-      etl::timer::id::type id3 = controller.register_timer(message3, router1, 10,   etl::timer::mode::Repeating);
+      etl::timer<>::id::type id1 = controller.register_timer(message1, router1, 400,  etl::timer<>::mode::Single_Shot);
+      etl::timer<>::id::type id2 = controller.register_timer(message2, router1, 100,  etl::timer<>::mode::Repeating);
+      etl::timer<>::id::type id3 = controller.register_timer(message3, router1, 10,   etl::timer<>::mode::Repeating);
 
       router1.clear();
 

--- a/test/test_message_timer_interrupt.cpp
+++ b/test/test_message_timer_interrupt.cpp
@@ -63,7 +63,7 @@ namespace
   //***************************************************************************
   struct TimerLogEntry
   {
-    etl::timer::id::type id;
+    etl::timer<>::id::type id;
     uint64_t time_called;
   };
 
@@ -164,17 +164,17 @@ namespace
     {
       etl::message_timer_interrupt<2, ScopedGuard> timer_controller;
 
-      etl::timer::id::type id1 = timer_controller.register_timer(message1, router1, 37, etl::timer::mode::Single_Shot);
-      etl::timer::id::type id2 = timer_controller.register_timer(message2, router1, 23, etl::timer::mode::Single_Shot);
-      etl::timer::id::type id3 = timer_controller.register_timer(message3, router1, 11, etl::timer::mode::Single_Shot);
+      etl::timer<>::id::type id1 = timer_controller.register_timer(message1, router1, 37, etl::timer<>::mode::Single_Shot);
+      etl::timer<>::id::type id2 = timer_controller.register_timer(message2, router1, 23, etl::timer<>::mode::Single_Shot);
+      etl::timer<>::id::type id3 = timer_controller.register_timer(message3, router1, 11, etl::timer<>::mode::Single_Shot);
 
-      CHECK(id1 != etl::timer::id::NO_TIMER);
-      CHECK(id2 != etl::timer::id::NO_TIMER);
-      CHECK(id3 == etl::timer::id::NO_TIMER);
+      CHECK(id1 != etl::timer<>::id::NO_TIMER);
+      CHECK(id2 != etl::timer<>::id::NO_TIMER);
+      CHECK(id3 == etl::timer<>::id::NO_TIMER);
 
       timer_controller.clear();
-      id3 = timer_controller.register_timer(message3, router1, 11, etl::timer::mode::Single_Shot);
-      CHECK(id3 != etl::timer::id::NO_TIMER);
+      id3 = timer_controller.register_timer(message3, router1, 11, etl::timer<>::mode::Single_Shot);
+      CHECK(id3 != etl::timer<>::id::NO_TIMER);
 
       CHECK_EQUAL(0U, ScopedGuard::guard_count);
     }
@@ -184,9 +184,9 @@ namespace
     {
       etl::message_timer_interrupt<3, ScopedGuard> timer_controller;
 
-      etl::timer::id::type id1 = timer_controller.register_timer(message1, router1, 37, etl::timer::mode::Single_Shot);
-      etl::timer::id::type id2 = timer_controller.register_timer(message2, router1, 23, etl::timer::mode::Single_Shot);
-      etl::timer::id::type id3 = timer_controller.register_timer(message3, router1, 11, etl::timer::mode::Single_Shot);
+      etl::timer<>::id::type id1 = timer_controller.register_timer(message1, router1, 37, etl::timer<>::mode::Single_Shot);
+      etl::timer<>::id::type id2 = timer_controller.register_timer(message2, router1, 23, etl::timer<>::mode::Single_Shot);
+      etl::timer<>::id::type id3 = timer_controller.register_timer(message3, router1, 11, etl::timer<>::mode::Single_Shot);
 
       router1.clear();
 
@@ -222,7 +222,7 @@ namespace
     {
       etl::message_timer_interrupt<1, ScopedGuard> timer_controller;
 
-      etl::timer::id::type id1 = timer_controller.register_timer(message1, router1, 37, etl::timer::mode::Single_Shot);
+      etl::timer<>::id::type id1 = timer_controller.register_timer(message1, router1, 37, etl::timer<>::mode::Single_Shot);
       router1.clear();
 
       timer_controller.start(id1);
@@ -270,9 +270,9 @@ namespace
     {
       etl::message_timer_interrupt<3, ScopedGuard> timer_controller;
 
-      etl::timer::id::type id1 = timer_controller.register_timer(message1, router1, 37, etl::timer::mode::Repeating);
-      etl::timer::id::type id2 = timer_controller.register_timer(message2, router1, 23, etl::timer::mode::Repeating);
-      etl::timer::id::type id3 = timer_controller.register_timer(message3, router1, 11, etl::timer::mode::Repeating);
+      etl::timer<>::id::type id1 = timer_controller.register_timer(message1, router1, 37, etl::timer<>::mode::Repeating);
+      etl::timer<>::id::type id2 = timer_controller.register_timer(message2, router1, 23, etl::timer<>::mode::Repeating);
+      etl::timer<>::id::type id3 = timer_controller.register_timer(message3, router1, 11, etl::timer<>::mode::Repeating);
 
       router1.clear();
 
@@ -308,9 +308,9 @@ namespace
     {
       etl::message_timer_interrupt<3, ScopedGuard> timer_controller;
 
-      etl::timer::id::type id1 = timer_controller.register_timer(message1, router1, 37, etl::timer::mode::Repeating);
-      etl::timer::id::type id2 = timer_controller.register_timer(message2, router1, 23, etl::timer::mode::Repeating);
-      etl::timer::id::type id3 = timer_controller.register_timer(message3, router1, 11, etl::timer::mode::Repeating);
+      etl::timer<>::id::type id1 = timer_controller.register_timer(message1, router1, 37, etl::timer<>::mode::Repeating);
+      etl::timer<>::id::type id2 = timer_controller.register_timer(message2, router1, 23, etl::timer<>::mode::Repeating);
+      etl::timer<>::id::type id3 = timer_controller.register_timer(message3, router1, 11, etl::timer<>::mode::Repeating);
 
       router1.clear();
 
@@ -350,9 +350,9 @@ namespace
     {
       etl::message_timer_interrupt<3, ScopedGuard> timer_controller;
 
-      etl::timer::id::type id1 = timer_controller.register_timer(message1, router1, 37, etl::timer::mode::Repeating);
-      etl::timer::id::type id2 = timer_controller.register_timer(message2, router1, 23, etl::timer::mode::Repeating);
-      etl::timer::id::type id3 = timer_controller.register_timer(message3, router1, 11, etl::timer::mode::Repeating);
+      etl::timer<>::id::type id1 = timer_controller.register_timer(message1, router1, 37, etl::timer<>::mode::Repeating);
+      etl::timer<>::id::type id2 = timer_controller.register_timer(message2, router1, 23, etl::timer<>::mode::Repeating);
+      etl::timer<>::id::type id3 = timer_controller.register_timer(message3, router1, 11, etl::timer<>::mode::Repeating);
 
       router1.clear();
 
@@ -399,9 +399,9 @@ namespace
     {
       etl::message_timer_interrupt<3, ScopedGuard> timer_controller;
 
-      etl::timer::id::type id1;
-      etl::timer::id::type id2 = timer_controller.register_timer(message2, router1, 23, etl::timer::mode::Repeating);
-      etl::timer::id::type id3 = timer_controller.register_timer(message3, router1, 11, etl::timer::mode::Repeating);
+      etl::timer<>::id::type id1;
+      etl::timer<>::id::type id2 = timer_controller.register_timer(message2, router1, 23, etl::timer<>::mode::Repeating);
+      etl::timer<>::id::type id3 = timer_controller.register_timer(message3, router1, 11, etl::timer<>::mode::Repeating);
 
       router1.clear();
 
@@ -420,7 +420,7 @@ namespace
         {
           timer_controller.unregister_timer(id2);
 
-          id1 = timer_controller.register_timer(message1, router1, 37, etl::timer::mode::Repeating);
+          id1 = timer_controller.register_timer(message1, router1, 37, etl::timer<>::mode::Repeating);
           timer_controller.start(id1);
         }
 
@@ -444,9 +444,9 @@ namespace
     {
       etl::message_timer_interrupt<3, ScopedGuard> timer_controller;
 
-      etl::timer::id::type id1 = timer_controller.register_timer(message1, router1, 37, etl::timer::mode::Repeating);
-      etl::timer::id::type id2 = timer_controller.register_timer(message2, router1, 23, etl::timer::mode::Repeating);
-      etl::timer::id::type id3 = timer_controller.register_timer(message3, router1, 11, etl::timer::mode::Repeating);
+      etl::timer<>::id::type id1 = timer_controller.register_timer(message1, router1, 37, etl::timer<>::mode::Repeating);
+      etl::timer<>::id::type id2 = timer_controller.register_timer(message2, router1, 23, etl::timer<>::mode::Repeating);
+      etl::timer<>::id::type id3 = timer_controller.register_timer(message3, router1, 11, etl::timer<>::mode::Repeating);
 
       router1.clear();
 
@@ -488,9 +488,9 @@ namespace
     {
       etl::message_timer_interrupt<3, ScopedGuard> timer_controller;
 
-      etl::timer::id::type id1 = timer_controller.register_timer(message1, bus1, 37, etl::timer::mode::Single_Shot, ROUTER1);
-      etl::timer::id::type id2 = timer_controller.register_timer(message2, bus1, 23, etl::timer::mode::Single_Shot, ROUTER1);
-      etl::timer::id::type id3 = timer_controller.register_timer(message3, bus1, 11, etl::timer::mode::Single_Shot, etl::imessage_router::ALL_MESSAGE_ROUTERS);
+      etl::timer<>::id::type id1 = timer_controller.register_timer(message1, bus1, 37, etl::timer<>::mode::Single_Shot, ROUTER1);
+      etl::timer<>::id::type id2 = timer_controller.register_timer(message2, bus1, 23, etl::timer<>::mode::Single_Shot, ROUTER1);
+      etl::timer<>::id::type id3 = timer_controller.register_timer(message3, bus1, 11, etl::timer<>::mode::Single_Shot, etl::imessage_router::ALL_MESSAGE_ROUTERS);
 
       bus1.subscribe(router1);
 
@@ -528,9 +528,9 @@ namespace
     {
       etl::message_timer_interrupt<3, ScopedGuard> timer_controller;
 
-      etl::timer::id::type id1 = timer_controller.register_timer(message1, router1, 37, etl::timer::mode::Repeating);
-      etl::timer::id::type id2 = timer_controller.register_timer(message2, router1, 23, etl::timer::mode::Repeating);
-      etl::timer::id::type id3 = timer_controller.register_timer(message3, router1, 11, etl::timer::mode::Repeating);
+      etl::timer<>::id::type id1 = timer_controller.register_timer(message1, router1, 37, etl::timer<>::mode::Repeating);
+      etl::timer<>::id::type id2 = timer_controller.register_timer(message2, router1, 23, etl::timer<>::mode::Repeating);
+      etl::timer<>::id::type id3 = timer_controller.register_timer(message3, router1, 11, etl::timer<>::mode::Repeating);
 
       router1.clear();
 
@@ -543,9 +543,9 @@ namespace
       ticks = 5;
       timer_controller.tick(uint32_t(ticks));
 
-      timer_controller.start(id1, etl::timer::start::Immediate);
-      timer_controller.start(id2, etl::timer::start::Immediate);
-      timer_controller.start(id3, etl::timer::start::Delayed);
+      timer_controller.start(id1, etl::timer<>::start::Immediate);
+      timer_controller.start(id2, etl::timer<>::start::Immediate);
+      timer_controller.start(id3, etl::timer<>::start::Delayed);
 
       const uint32_t step = 1UL;
 
@@ -571,8 +571,8 @@ namespace
     {
       etl::message_timer_interrupt<3, ScopedGuard> timer_controller;
 
-      etl::timer::id::type id1 = timer_controller.register_timer(message1, router1, 15, etl::timer::mode::Single_Shot);
-      etl::timer::id::type id2 = timer_controller.register_timer(message2, router1,  5, etl::timer::mode::Repeating);
+      etl::timer<>::id::type id1 = timer_controller.register_timer(message1, router1, 15, etl::timer<>::mode::Single_Shot);
+      etl::timer<>::id::type id2 = timer_controller.register_timer(message2, router1,  5, etl::timer<>::mode::Repeating);
 
       router1.clear();
 
@@ -605,7 +605,7 @@ namespace
     {
       etl::message_timer_interrupt<3, ScopedGuard> timer_controller;
 
-      etl::timer::id::type id1 = timer_controller.register_timer(message1, router1, 5, etl::timer::mode::Single_Shot);
+      etl::timer<>::id::type id1 = timer_controller.register_timer(message1, router1, 5, etl::timer<>::mode::Single_Shot);
 
       router1.clear();
 
@@ -645,9 +645,9 @@ namespace
     {
       etl::message_timer_interrupt<3, ScopedGuard> timer_controller;
 
-      etl::timer::id::type id1 = timer_controller.register_timer(message1, router1, 37, etl::timer::mode::Repeating);
-      etl::timer::id::type id2 = timer_controller.register_timer(message2, router1, 23, etl::timer::mode::Repeating);
-      etl::timer::id::type id3 = timer_controller.register_timer(message3, router1, 11, etl::timer::mode::Repeating);
+      etl::timer<>::id::type id1 = timer_controller.register_timer(message1, router1, 37, etl::timer<>::mode::Repeating);
+      etl::timer<>::id::type id2 = timer_controller.register_timer(message2, router1, 23, etl::timer<>::mode::Repeating);
+      etl::timer<>::id::type id3 = timer_controller.register_timer(message3, router1, 11, etl::timer<>::mode::Repeating);
 
       router1.clear();
 
@@ -695,9 +695,9 @@ namespace
     {
       etl::message_timer_interrupt<3, ScopedGuard> timer_controller;
 
-      etl::timer::id::type id1 = timer_controller.register_timer(message1, router1, 37, etl::timer::mode::Single_Shot);
-      etl::timer::id::type id2 = timer_controller.register_timer(message2, router1, 23, etl::timer::mode::Single_Shot);
-      etl::timer::id::type id3 = timer_controller.register_timer(message3, router1, 11, etl::timer::mode::Single_Shot);
+      etl::timer<>::id::type id1 = timer_controller.register_timer(message1, router1, 37, etl::timer<>::mode::Single_Shot);
+      etl::timer<>::id::type id2 = timer_controller.register_timer(message2, router1, 23, etl::timer<>::mode::Single_Shot);
+      etl::timer<>::id::type id3 = timer_controller.register_timer(message3, router1, 11, etl::timer<>::mode::Single_Shot);
 
       router1.clear();
 
@@ -720,7 +720,7 @@ namespace
       CHECK_TRUE(timer_controller.has_active_timer());
 
       timer_controller.tick(1);
-      CHECK_EQUAL(static_cast<etl::timer::interval::type>(etl::timer::interval::No_Active_Interval), timer_controller.time_to_next());
+      CHECK_EQUAL(static_cast<etl::timer<>::interval::type>(etl::timer<>::interval::No_Active_Interval), timer_controller.time_to_next());
       CHECK_FALSE(timer_controller.has_active_timer());
     }
 
@@ -790,10 +790,10 @@ namespace
       constexpr uint32_t T4 = 5U;
 
       // Register the timers.
-      etl::timer::id::type id1 = timer_controller.register_timer(message1, router, T1, etl::timer::mode::Repeating);
-      etl::timer::id::type id2 = timer_controller.register_timer(message2, router, T2, etl::timer::mode::Single_Shot);
-      etl::timer::id::type id3 = timer_controller.register_timer(message3, router, T3, etl::timer::mode::Repeating);
-      etl::timer::id::type id4 = timer_controller.register_timer(message4, router, T4, etl::timer::mode::Repeating);
+      etl::timer<>::id::type id1 = timer_controller.register_timer(message1, router, T1, etl::timer<>::mode::Repeating);
+      etl::timer<>::id::type id2 = timer_controller.register_timer(message2, router, T2, etl::timer<>::mode::Single_Shot);
+      etl::timer<>::id::type id3 = timer_controller.register_timer(message3, router, T3, etl::timer<>::mode::Repeating);
+      etl::timer<>::id::type id4 = timer_controller.register_timer(message4, router, T4, etl::timer<>::mode::Repeating);
 
       // Start the repeating timers.
       timer_controller.start(id1);

--- a/test/test_message_timer_locked.cpp
+++ b/test/test_message_timer_locked.cpp
@@ -184,17 +184,17 @@ namespace
 
       etl::message_timer_locked<2> timer_controller(try_lock, lock, unlock);
 
-      etl::timer::id::type id1 = timer_controller.register_timer(message1, router1, 37, etl::timer::mode::Single_Shot);
-      etl::timer::id::type id2 = timer_controller.register_timer(message2, router1, 23, etl::timer::mode::Single_Shot);
-      etl::timer::id::type id3 = timer_controller.register_timer(message3, router1, 11, etl::timer::mode::Single_Shot);
+      etl::timer<>::id::type id1 = timer_controller.register_timer(message1, router1, 37, etl::timer<>::mode::Single_Shot);
+      etl::timer<>::id::type id2 = timer_controller.register_timer(message2, router1, 23, etl::timer<>::mode::Single_Shot);
+      etl::timer<>::id::type id3 = timer_controller.register_timer(message3, router1, 11, etl::timer<>::mode::Single_Shot);
 
-      CHECK(id1 != etl::timer::id::NO_TIMER);
-      CHECK(id2 != etl::timer::id::NO_TIMER);
-      CHECK(id3 == etl::timer::id::NO_TIMER);
+      CHECK(id1 != etl::timer<>::id::NO_TIMER);
+      CHECK(id2 != etl::timer<>::id::NO_TIMER);
+      CHECK(id3 == etl::timer<>::id::NO_TIMER);
 
       timer_controller.clear();
-      id3 = timer_controller.register_timer(message3, router1, 11, etl::timer::mode::Single_Shot);
-      CHECK(id3 != etl::timer::id::NO_TIMER);
+      id3 = timer_controller.register_timer(message3, router1, 11, etl::timer<>::mode::Single_Shot);
+      CHECK(id3 != etl::timer<>::id::NO_TIMER);
 
       CHECK_EQUAL(0U, locks.lock_count);
     }
@@ -209,9 +209,9 @@ namespace
 
       etl::message_timer_locked<3> timer_controller(try_lock, lock, unlock);
 
-      etl::timer::id::type id1 = timer_controller.register_timer(message1, router1, 37, etl::timer::mode::Single_Shot);
-      etl::timer::id::type id2 = timer_controller.register_timer(message2, router1, 23, etl::timer::mode::Single_Shot);
-      etl::timer::id::type id3 = timer_controller.register_timer(message3, router1, 11, etl::timer::mode::Single_Shot);
+      etl::timer<>::id::type id1 = timer_controller.register_timer(message1, router1, 37, etl::timer<>::mode::Single_Shot);
+      etl::timer<>::id::type id2 = timer_controller.register_timer(message2, router1, 23, etl::timer<>::mode::Single_Shot);
+      etl::timer<>::id::type id3 = timer_controller.register_timer(message3, router1, 11, etl::timer<>::mode::Single_Shot);
 
       router1.clear();
 
@@ -252,7 +252,7 @@ namespace
 
       etl::message_timer_locked<1> timer_controller(try_lock, lock, unlock);
 
-      etl::timer::id::type id1 = timer_controller.register_timer(message1, router1, 37, etl::timer::mode::Single_Shot);
+      etl::timer<>::id::type id1 = timer_controller.register_timer(message1, router1, 37, etl::timer<>::mode::Single_Shot);
       router1.clear();
 
       timer_controller.start(id1);
@@ -305,9 +305,9 @@ namespace
 
       etl::message_timer_locked<3> timer_controller(try_lock, lock, unlock);
 
-      etl::timer::id::type id1 = timer_controller.register_timer(message1, router1, 37, etl::timer::mode::Repeating);
-      etl::timer::id::type id2 = timer_controller.register_timer(message2, router1, 23, etl::timer::mode::Repeating);
-      etl::timer::id::type id3 = timer_controller.register_timer(message3, router1, 11, etl::timer::mode::Repeating);
+      etl::timer<>::id::type id1 = timer_controller.register_timer(message1, router1, 37, etl::timer<>::mode::Repeating);
+      etl::timer<>::id::type id2 = timer_controller.register_timer(message2, router1, 23, etl::timer<>::mode::Repeating);
+      etl::timer<>::id::type id3 = timer_controller.register_timer(message3, router1, 11, etl::timer<>::mode::Repeating);
 
       router1.clear();
 
@@ -348,9 +348,9 @@ namespace
 
       etl::message_timer_locked<3> timer_controller(try_lock, lock, unlock);
 
-      etl::timer::id::type id1 = timer_controller.register_timer(message1, router1, 37, etl::timer::mode::Repeating);
-      etl::timer::id::type id2 = timer_controller.register_timer(message2, router1, 23, etl::timer::mode::Repeating);
-      etl::timer::id::type id3 = timer_controller.register_timer(message3, router1, 11, etl::timer::mode::Repeating);
+      etl::timer<>::id::type id1 = timer_controller.register_timer(message1, router1, 37, etl::timer<>::mode::Repeating);
+      etl::timer<>::id::type id2 = timer_controller.register_timer(message2, router1, 23, etl::timer<>::mode::Repeating);
+      etl::timer<>::id::type id3 = timer_controller.register_timer(message3, router1, 11, etl::timer<>::mode::Repeating);
 
       router1.clear();
 
@@ -395,9 +395,9 @@ namespace
 
       etl::message_timer_locked<3> timer_controller(try_lock, lock, unlock);
 
-      etl::timer::id::type id1 = timer_controller.register_timer(message1, router1, 37, etl::timer::mode::Repeating);
-      etl::timer::id::type id2 = timer_controller.register_timer(message2, router1, 23, etl::timer::mode::Repeating);
-      etl::timer::id::type id3 = timer_controller.register_timer(message3, router1, 11, etl::timer::mode::Repeating);
+      etl::timer<>::id::type id1 = timer_controller.register_timer(message1, router1, 37, etl::timer<>::mode::Repeating);
+      etl::timer<>::id::type id2 = timer_controller.register_timer(message2, router1, 23, etl::timer<>::mode::Repeating);
+      etl::timer<>::id::type id3 = timer_controller.register_timer(message3, router1, 11, etl::timer<>::mode::Repeating);
 
       router1.clear();
 
@@ -449,9 +449,9 @@ namespace
 
       etl::message_timer_locked<3> timer_controller(try_lock, lock, unlock);
 
-      etl::timer::id::type id1;
-      etl::timer::id::type id2 = timer_controller.register_timer(message2, router1, 23, etl::timer::mode::Repeating);
-      etl::timer::id::type id3 = timer_controller.register_timer(message3, router1, 11, etl::timer::mode::Repeating);
+      etl::timer<>::id::type id1;
+      etl::timer<>::id::type id2 = timer_controller.register_timer(message2, router1, 23, etl::timer<>::mode::Repeating);
+      etl::timer<>::id::type id3 = timer_controller.register_timer(message3, router1, 11, etl::timer<>::mode::Repeating);
 
       router1.clear();
 
@@ -470,7 +470,7 @@ namespace
         {
           timer_controller.unregister_timer(id2);
 
-          id1 = timer_controller.register_timer(message1, router1, 37, etl::timer::mode::Repeating);
+          id1 = timer_controller.register_timer(message1, router1, 37, etl::timer<>::mode::Repeating);
           timer_controller.start(id1);
         }
 
@@ -499,9 +499,9 @@ namespace
 
       etl::message_timer_locked<3> timer_controller(try_lock, lock, unlock);
 
-      etl::timer::id::type id1 = timer_controller.register_timer(message1, router1, 37, etl::timer::mode::Repeating);
-      etl::timer::id::type id2 = timer_controller.register_timer(message2, router1, 23, etl::timer::mode::Repeating);
-      etl::timer::id::type id3 = timer_controller.register_timer(message3, router1, 11, etl::timer::mode::Repeating);
+      etl::timer<>::id::type id1 = timer_controller.register_timer(message1, router1, 37, etl::timer<>::mode::Repeating);
+      etl::timer<>::id::type id2 = timer_controller.register_timer(message2, router1, 23, etl::timer<>::mode::Repeating);
+      etl::timer<>::id::type id3 = timer_controller.register_timer(message3, router1, 11, etl::timer<>::mode::Repeating);
 
       router1.clear();
 
@@ -548,9 +548,9 @@ namespace
 
       etl::message_timer_locked<3> timer_controller(try_lock, lock, unlock);
 
-      etl::timer::id::type id1 = timer_controller.register_timer(message1, bus1, 37, etl::timer::mode::Single_Shot, ROUTER1);
-      etl::timer::id::type id2 = timer_controller.register_timer(message2, bus1, 23, etl::timer::mode::Single_Shot, ROUTER1);
-      etl::timer::id::type id3 = timer_controller.register_timer(message3, bus1, 11, etl::timer::mode::Single_Shot, etl::imessage_router::ALL_MESSAGE_ROUTERS);
+      etl::timer<>::id::type id1 = timer_controller.register_timer(message1, bus1, 37, etl::timer<>::mode::Single_Shot, ROUTER1);
+      etl::timer<>::id::type id2 = timer_controller.register_timer(message2, bus1, 23, etl::timer<>::mode::Single_Shot, ROUTER1);
+      etl::timer<>::id::type id3 = timer_controller.register_timer(message3, bus1, 11, etl::timer<>::mode::Single_Shot, etl::imessage_router::ALL_MESSAGE_ROUTERS);
 
       bus1.subscribe(router1);
 
@@ -593,9 +593,9 @@ namespace
 
       etl::message_timer_locked<3> timer_controller(try_lock, lock, unlock);
 
-      etl::timer::id::type id1 = timer_controller.register_timer(message1, router1, 37, etl::timer::mode::Repeating);
-      etl::timer::id::type id2 = timer_controller.register_timer(message2, router1, 23, etl::timer::mode::Repeating);
-      etl::timer::id::type id3 = timer_controller.register_timer(message3, router1, 11, etl::timer::mode::Repeating);
+      etl::timer<>::id::type id1 = timer_controller.register_timer(message1, router1, 37, etl::timer<>::mode::Repeating);
+      etl::timer<>::id::type id2 = timer_controller.register_timer(message2, router1, 23, etl::timer<>::mode::Repeating);
+      etl::timer<>::id::type id3 = timer_controller.register_timer(message3, router1, 11, etl::timer<>::mode::Repeating);
 
       router1.clear();
 
@@ -608,9 +608,9 @@ namespace
       ticks = 5;
       timer_controller.tick(uint32_t(ticks));
 
-      timer_controller.start(id1, etl::timer::start::Immediate);
-      timer_controller.start(id2, etl::timer::start::Immediate);
-      timer_controller.start(id3, etl::timer::start::Delayed);
+      timer_controller.start(id1, etl::timer<>::start::Immediate);
+      timer_controller.start(id2, etl::timer<>::start::Immediate);
+      timer_controller.start(id3, etl::timer<>::start::Delayed);
 
       const uint32_t step = 1UL;
 
@@ -641,8 +641,8 @@ namespace
 
       etl::message_timer_locked<3> timer_controller(try_lock, lock, unlock);
 
-      etl::timer::id::type id1 = timer_controller.register_timer(message1, router1, 15, etl::timer::mode::Single_Shot);
-      etl::timer::id::type id2 = timer_controller.register_timer(message2, router1,  5, etl::timer::mode::Repeating);
+      etl::timer<>::id::type id1 = timer_controller.register_timer(message1, router1, 15, etl::timer<>::mode::Single_Shot);
+      etl::timer<>::id::type id2 = timer_controller.register_timer(message2, router1,  5, etl::timer<>::mode::Repeating);
 
       router1.clear();
 
@@ -680,7 +680,7 @@ namespace
 
       etl::message_timer_locked<3> timer_controller(try_lock, lock, unlock);
 
-      etl::timer::id::type id1 = timer_controller.register_timer(message1, router1, 5, etl::timer::mode::Single_Shot);
+      etl::timer<>::id::type id1 = timer_controller.register_timer(message1, router1, 5, etl::timer<>::mode::Single_Shot);
 
       router1.clear();
 
@@ -725,9 +725,9 @@ namespace
 
       etl::message_timer_locked<3> timer_controller(try_lock, lock, unlock);
 
-      etl::timer::id::type id1 = timer_controller.register_timer(message1, router1, 37, etl::timer::mode::Repeating);
-      etl::timer::id::type id2 = timer_controller.register_timer(message2, router1, 23, etl::timer::mode::Repeating);
-      etl::timer::id::type id3 = timer_controller.register_timer(message3, router1, 11, etl::timer::mode::Repeating);
+      etl::timer<>::id::type id1 = timer_controller.register_timer(message1, router1, 37, etl::timer<>::mode::Repeating);
+      etl::timer<>::id::type id2 = timer_controller.register_timer(message2, router1, 23, etl::timer<>::mode::Repeating);
+      etl::timer<>::id::type id3 = timer_controller.register_timer(message3, router1, 11, etl::timer<>::mode::Repeating);
 
       router1.clear();
 
@@ -780,9 +780,9 @@ namespace
 
       etl::message_timer_locked<3> timer_controller(try_lock, lock, unlock);
 
-      etl::timer::id::type id1 = timer_controller.register_timer(message1, router1, 37, etl::timer::mode::Single_Shot);
-      etl::timer::id::type id2 = timer_controller.register_timer(message2, router1, 23, etl::timer::mode::Single_Shot);
-      etl::timer::id::type id3 = timer_controller.register_timer(message3, router1, 11, etl::timer::mode::Single_Shot);
+      etl::timer<>::id::type id1 = timer_controller.register_timer(message1, router1, 37, etl::timer<>::mode::Single_Shot);
+      etl::timer<>::id::type id2 = timer_controller.register_timer(message2, router1, 23, etl::timer<>::mode::Single_Shot);
+      etl::timer<>::id::type id3 = timer_controller.register_timer(message3, router1, 11, etl::timer<>::mode::Single_Shot);
 
       router1.clear();
 
@@ -805,7 +805,7 @@ namespace
       CHECK_TRUE(timer_controller.has_active_timer());
 
       timer_controller.tick(1);
-      CHECK_EQUAL(static_cast<etl::timer::interval::type>(etl::timer::interval::No_Active_Interval), timer_controller.time_to_next());
+      CHECK_EQUAL(static_cast<etl::timer<>::interval::type>(etl::timer<>::interval::No_Active_Interval), timer_controller.time_to_next());
       CHECK_FALSE(timer_controller.has_active_timer());
     }
 
@@ -857,9 +857,9 @@ namespace
     {
       FIX_PROCESSOR_AFFINITY;
 
-      etl::timer::id::type id1 = timer_controller.register_timer(message1, router1, 400,  etl::timer::mode::Single_Shot);
-      etl::timer::id::type id2 = timer_controller.register_timer(message2, router1, 100,  etl::timer::mode::Repeating);
-      etl::timer::id::type id3 = timer_controller.register_timer(message3, router1, 10,   etl::timer::mode::Repeating);
+      etl::timer<>::id::type id1 = timer_controller.register_timer(message1, router1, 400,  etl::timer<>::mode::Single_Shot);
+      etl::timer<>::id::type id2 = timer_controller.register_timer(message2, router1, 100,  etl::timer<>::mode::Repeating);
+      etl::timer<>::id::type id3 = timer_controller.register_timer(message3, router1, 10,   etl::timer<>::mode::Repeating);
 
       router1.clear();
 


### PR DESCRIPTION
Addresses #941 

Opening this now before continuing with the other timer services because I feel the approach is perhaps breaking too many things.

This adds `timer_model.h` (name up to change, just wanted to keep it aligned with memory model) that is then used to determine the appropriate type for the ticker, to not limit the resolution to 32bits. I implemented this only for `message_timer.h` as a proof of concept but the concept can be applied to the rest of the services 

The main issue I have with this approach, is that it requires templating `timer` since `interval` and `state` depend on `TIMER_MODEL`. I couldn't find a way to abstract this without some major refactoring and without not templating `timer`. If this is a breaking change and there are no proposed alternative and more elegant solutions I'm missing, feel free to reject and close this PR

Otherwise, I can work on cleaning this up and working on the rest of the timers