### PR TITLE
Make include paths to private files relative

### DIFF
--- a/include/etl/base64.h
+++ b/include/etl/base64.h
@@ -26,13 +26,13 @@ SOFTWARE.
 #ifndef ETL_BASE64_INCLUDED
 #define ETL_BASE64_INCLUDED
 
-#include "etl/platform.h"
-#include "etl/static_assert.h"
-#include "etl/exception.h"
-#include "etl/error_handler.h"
-#include "etl/type_traits.h"
-#include "etl/enum_type.h"
-#include "etl/integral_limits.h"
+#include "platform.h"
+#include "static_assert.h"
+#include "exception.h"
+#include "error_handler.h"
+#include "type_traits.h"
+#include "enum_type.h"
+#include "integral_limits.h"
 
 #include <stdint.h>
 

--- a/include/etl/base64_decoder.h
+++ b/include/etl/base64_decoder.h
@@ -28,19 +28,19 @@ SOFTWARE.
 #ifndef ETL_BASE64_DECODER_INCLUDED
 #define ETL_BASE64_DECODER_INCLUDED
 
-#include "etl/platform.h"
-#include "etl/static_assert.h"
-#include "etl/error_handler.h"
-#include "etl/type_traits.h"
-#include "etl/binary.h"
-#include "etl/algorithm.h"
-#include "etl/integral_limits.h"
-#include "etl/iterator.h"
-#include "etl/enum_type.h"
-#include "etl/delegate.h"
-#include "etl/span.h"
+#include "platform.h"
+#include "static_assert.h"
+#include "error_handler.h"
+#include "type_traits.h"
+#include "binary.h"
+#include "algorithm.h"
+#include "integral_limits.h"
+#include "iterator.h"
+#include "enum_type.h"
+#include "delegate.h"
+#include "span.h"
 
-#include "etl/base64.h"
+#include "base64.h"
 
 #include <stdint.h>
 

--- a/include/etl/base64_encoder.h
+++ b/include/etl/base64_encoder.h
@@ -28,19 +28,19 @@ SOFTWARE.
 #ifndef ETL_BASE64_ENCODER_INCLUDED
 #define ETL_BASE64_ENCODER_INCLUDED
 
-#include "etl/platform.h"
-#include "etl/static_assert.h"
-#include "etl/error_handler.h"
-#include "etl/type_traits.h"
-#include "etl/binary.h"
-#include "etl/algorithm.h"
-#include "etl/integral_limits.h"
-#include "etl/iterator.h"
-#include "etl/enum_type.h"
-#include "etl/delegate.h"
-#include "etl/span.h"
+#include "platform.h"
+#include "static_assert.h"
+#include "error_handler.h"
+#include "type_traits.h"
+#include "binary.h"
+#include "algorithm.h"
+#include "integral_limits.h"
+#include "iterator.h"
+#include "enum_type.h"
+#include "delegate.h"
+#include "span.h"
 
-#include "etl/base64.h"
+#include "base64.h"
 
 #include <stdint.h>
 

--- a/include/etl/intrusive_forward_list.h
+++ b/include/etl/intrusive_forward_list.h
@@ -489,9 +489,9 @@ namespace etl
 
       reference operator *() const
       {
-#include "etl/private/diagnostic_null_dereference_push.h"
+#include "private/diagnostic_null_dereference_push.h"
         return *static_cast<pointer>(p_value);
-#include "etl/private/diagnostic_pop.h"
+#include "private/diagnostic_pop.h"
       }
 
       pointer operator &() const

--- a/include/etl/intrusive_list.h
+++ b/include/etl/intrusive_list.h
@@ -528,9 +528,9 @@ namespace etl
 
       reference operator *() const
       {
-#include "etl/private/diagnostic_null_dereference_push.h"
+#include "private/diagnostic_null_dereference_push.h"
         return *static_cast<pointer>(p_value);
-#include "etl/private/diagnostic_pop.h"
+#include "private/diagnostic_pop.h"
       }
 
       pointer operator &() const


### PR DESCRIPTION
Analog to #879 

By removing `etl/` from include paths (in `#include` statements), the path to the directory `include/` doesn't need to be provided to the preprocessor as an include path if the files in `include/etl/` are included by other means. This has no disadvantages.
Actually the form `#include "..."` is intended to be used for relative paths in the first place.

This is relevant if one wants to include the source files from `include/etl` only indirectly.

For example we use special generated header files which wrap the include statement of the vanilla header files with diagnostic commands. Those commands disable some compiler diagnostics for ETL's files and re-enable them after the file inclusion. Wrapper files are generated for every non-private header file. We provide the directory with the wrapper files as include path to the preprocessor instead of the normal `include/` directory. Thus include statements like `#include "etl/private/..."` are invalid in that case.

This may be beneficial only in special cases like ours. But it should have no disadvantages. In contrary, it uses the `#include "..."` form as intended.