### PR TITLE
For GCC10, check __cplusplus >= 201709 for c++20 support

### DIFF
--- a/include/etl/profiles/determine_compiler_language_support.h
+++ b/include/etl/profiles/determine_compiler_language_support.h
@@ -58,6 +58,12 @@ SOFTWARE.
       #endif
     #elif defined(ETL_COMPILER_ARM5)
       #define ETL_CPP20_SUPPORTED 0
+    #elif defined(ETL_COMPILER_GCC)
+      #if (__GNUC__ == 10)
+        #define ETL_CPP20_SUPPORTED (__cplusplus >= 201709L)
+      #else
+        #define ETL_CPP20_SUPPORTED (__cplusplus >= 202002L)
+      #endif
     #else
       #define ETL_CPP20_SUPPORTED (__cplusplus >= 202002L)
     #endif


### PR DESCRIPTION
From here: https://godbolt.org/z/n967rrMGY you can see that using GCC 10 and compiling with -stdc++=20 that __cplusplus evaluates to 201709. Switching to GCC 11, it evaluates to 202002.
This was problematic in our build as ETL_CPP20_SUPPORTED was not being detected correctly and we were having issues with redefinition of char8_t. Tried to workaround by setting ETL_NO_SMALL_CHAR_SUPPORT=0, however parts of our build use -stdc++=17 which would then fail with this flag due to missing definition of char8_t.