### PR TITLE
Add at method to span

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ The library is intended for any compiler that supports C++98/03/11/14/17/20.
 - Checksums & hash functions
 - Variants (a type that can store many types in a type-safe interface)
 - Choice of asserts, exceptions, error handler or no checks on errors
-- Unit tested (currently over 6480 tests), using VS2019, GCC 8.1.0, , GCC 9.3.0, Clang 9.0.0 & 10.0.0
+- Unit tested (currently over 9400 tests), using VS2022, GCC 12, Clang 14.
 - Many utilities for template support.
 - Easy to read and documented source.
 - Free support via email, GitHub and Slack

--- a/include/etl/span.h
+++ b/include/etl/span.h
@@ -272,6 +272,26 @@ namespace etl
     {
       pbegin = other.pbegin;
       return *this;
+    } 
+
+    //*************************************************************************
+    /// Returns a reference to the value at index 'i'.
+    //*************************************************************************
+    ETL_NODISCARD ETL_CONSTEXPR14 reference at(size_t i)
+    {
+      ETL_ASSERT(i < size(), ETL_ERROR(array_out_of_range));
+
+      return pbegin[i];
+    }
+
+    //*************************************************************************
+    /// Returns a const reference to the value at index 'i'.
+    //*************************************************************************
+    ETL_NODISCARD ETL_CONSTEXPR14 const_reference at(size_t i) const
+    {
+      ETL_ASSERT(i < size(), ETL_ERROR(array_out_of_range));
+
+      return pbegin[i];
     }
 
     //*************************************************************************
@@ -612,6 +632,26 @@ namespace etl
       pbegin = other.pbegin;
       pend = other.pend;
       return *this;
+    }
+
+    //*************************************************************************
+    /// Returns a reference to the value at index 'i'.
+    //*************************************************************************
+    ETL_NODISCARD ETL_CONSTEXPR14 reference at(size_t i)
+    {
+      ETL_ASSERT(i < size(), ETL_ERROR(array_out_of_range));
+
+      return pbegin[i];
+    }
+
+    //*************************************************************************
+    /// Returns a const reference to the value at index 'i'.
+    //*************************************************************************
+    ETL_NODISCARD ETL_CONSTEXPR14 const_reference at(size_t i) const
+    {
+      ETL_ASSERT(i < size(), ETL_ERROR(array_out_of_range));
+
+      return pbegin[i];
     }
 
     //*************************************************************************

--- a/test/test_span_dynamic_extent.cpp
+++ b/test/test_span_dynamic_extent.cpp
@@ -446,6 +446,22 @@ namespace
     }
 
     //*************************************************************************
+    TEST(test_at)
+    {
+      View  view(etldata.begin(), etldata.end());
+      CView cview(etldata.begin(), etldata.end());
+
+      for (size_t i = 0UL; i < etldata.size(); ++i)
+      {
+        CHECK_EQUAL(etldata.at(i), view.at(i));
+        CHECK_EQUAL(etldata.at(i), cview.at(i));
+      }
+
+      CHECK_THROW({ int d = view.at(view.size()); (void)d; }, etl::array_out_of_range);
+      CHECK_THROW({ int d = cview.at(cview.size()); (void)d; }, etl::array_out_of_range);
+    }
+
+    //*************************************************************************
     TEST(test_index_operator)
     {
       View  view(etldata.begin(), etldata.end());

--- a/test/test_span_fixed_extent.cpp
+++ b/test/test_span_fixed_extent.cpp
@@ -434,6 +434,22 @@ namespace
     }
 
     //*************************************************************************
+    TEST(test_at)
+    {
+      View  view(etldata.begin(), etldata.end());
+      CView cview(etldata.begin(), etldata.end());
+
+      for (size_t i = 0UL; i < etldata.size(); ++i)
+      {
+        CHECK_EQUAL(etldata.at(i), view.at(i));
+        CHECK_EQUAL(etldata.at(i), cview.at(i));
+      }
+
+      CHECK_THROW({ int d = view.at(view.size()); (void)d; }, etl::array_out_of_range);
+      CHECK_THROW({ int d = cview.at(cview.size()); (void)d; }, etl::array_out_of_range);
+    }
+
+    //*************************************************************************
     TEST(test_index_operator)
     {
       View  view(etldata.begin(), etldata.end());


### PR DESCRIPTION
std span is getting the `at` method in c++ 26. https://en.cppreference.com/w/cpp/container/span/at

This is adding the equivalent to etl span.