### PR TITLE
Added basic guidelines for contributing code

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,5 +5,6 @@ If your are considering creating a pull request, please observe the following:
 - If you are adding or modifying a feature, add *new* unit tests that test that feature.
 - If you are fixing a bug, add a unit test that *fails* before the bug fix is implemented.
 - Do not initiate a pull request until all of the units tests pass.
+- Branches should be based on the branch `master`.
 
 There is a project file for VS2022 for C++14, 17, 20, and bash scripts that run the tests for C++11, 14, 17, 20 under Linux with GCC and Clang.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,9 @@
+# How to contribute
+
+If your are considering creating a pull request, please observe the following:
+
+- If you are adding or modifying a feature, add *new* unit tests that test that feature.
+- If you are fixing a bug, add a unit test that *fails* before the bug fix is implemented.
+- Do not initiate a pull request until all of the units tests pass.
+
+There is a project file for VS2022 for C++14, 17, 20, and bash scripts that run the tests for C++11, 14, 17, 20 under Linux with GCC and Clang.

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ The library is intended for any compiler that supports C++98/03/11/14/17/20.
 - Checksums & hash functions
 - Variants (a type that can store many types in a type-safe interface)
 - Choice of asserts, exceptions, error handler or no checks on errors
-- Unit tested (currently over 6480 tests), using VS2019, GCC 8.1.0, , GCC 9.3.0, Clang 9.0.0 & 10.0.0
+- Unit tested (currently over 9400 tests), using VS2022, GCC 12, Clang 14.
 - Many utilities for template support.
 - Easy to read and documented source.
 - Free support via email, GitHub and Slack


### PR DESCRIPTION
- Apply instructions for pull requests from Slack to new CONTRIBUTING guideline file.  
  I copied the [message in Slack](https://etlcpp.slack.com/archives/C7SJ45VFB/p1729596737002559) from @jwellbelove into a new file for [contributing guidelines](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/setting-guidelines-for-repository-contributors). This way a starting point for potential contributors is delivered next to the source code.
- Added hint for the starting point for contributing commits.  
  I derived this rule from https://github.com/ETLCPP/etl/issues/802#issuecomment-2323530862