### PR TITLE
fix build and test failures on arm64 linux platform

### DIFF
--- a/test/test_bit_stream.cpp
+++ b/test/test_bit_stream.cpp
@@ -930,8 +930,8 @@ namespace
     //*************************************************************************
     TEST(put_get_multiple_variable_size)
     {
-      char c1 = 26;             // 6 bits
-      char c2 = -10;            // 7 bits
+      int8_t c1 = 26;             // 6 bits
+      int8_t c2 = -10;            // 7 bits
       unsigned short s1 = 6742; // 13 bits
       unsigned short s2 = 1878; // 11 bits
       int32_t i1 = 2448037L;     // 23 bits
@@ -983,8 +983,8 @@ namespace
 
       bit_stream.restart();
 
-      char rc1 = 0;
-      char rc2 = 0;
+      int8_t rc1 = 0;
+      int8_t rc2 = 0;
       unsigned short rs1 = 0;
       unsigned short rs2 = 0;
       int32_t ri1 = 0;

--- a/test/test_bit_stream_reader_big_endian.cpp
+++ b/test/test_bit_stream_reader_big_endian.cpp
@@ -210,7 +210,7 @@ namespace
     TEST(test_read_int8_t)
     {
       std::array<char, 4U> storage = { char(0x01), char(0x5A), char(0xA5), char(0xFF) };
-      std::array<char, 4U> expected = { int8_t(0x01), int8_t(0x5A), int8_t(0xA5), int8_t(0xFF) };
+      std::array<int8_t, 4U> expected = { int8_t(0x01), int8_t(0x5A), int8_t(0xA5), int8_t(0xFF) };
 
       etl::bit_stream_reader bit_stream(storage.data(), storage.size(), etl::endian::big);
 
@@ -246,7 +246,7 @@ namespace
     TEST(test_read_checked_int8_t_using_non_member_function)
     {
       std::array<char, 4U> storage = { char(0x01), char(0x5A), char(0xA5), char(0xFF) };
-      std::array<char, 4U> expected = { int8_t(0x01), int8_t(0x5A), int8_t(0xA5), int8_t(0xFF) };
+      std::array<int8_t, 4U> expected = { int8_t(0x01), int8_t(0x5A), int8_t(0xA5), int8_t(0xFF) };
 
       etl::bit_stream_reader bit_stream(storage.data(), storage.size(), etl::endian::big);
 
@@ -282,7 +282,7 @@ namespace
     TEST(test_read_unchecked_int8_t_using_non_member_function)
     {
       std::array<char, 4U> storage = { char(0x01), char(0x5A), char(0xA5), char(0xFF) };
-      std::array<char, 4U> expected = { int8_t(0x01), int8_t(0x5A), int8_t(0xA5), int8_t(0xFF) };
+      std::array<int8_t, 4U> expected = { int8_t(0x01), int8_t(0x5A), int8_t(0xA5), int8_t(0xFF) };
 
       etl::bit_stream_reader bit_stream(storage.data(), storage.size(), etl::endian::big);
 
@@ -307,7 +307,7 @@ namespace
     TEST(test_read_int8_t_5bits)
     {
       std::array<char, 3U> storage = { char(0x0E), char(0x8B), char(0xF0) };
-      std::array<char, 4U> expected = { int8_t(0x01), int8_t(0xFA), int8_t(0x05), int8_t(0xFF) };
+      std::array<int8_t, 4U> expected = { int8_t(0x01), int8_t(0xFA), int8_t(0x05), int8_t(0xFF) };
 
       etl::bit_stream_reader bit_stream(storage.data(), storage.size(), etl::endian::big);
 

--- a/test/test_bresenham_line.cpp
+++ b/test/test_bresenham_line.cpp
@@ -44,7 +44,7 @@ namespace etl
 
 namespace
 {
-  using Value = char;
+  using Value = int8_t;
 
   using Point = etl::coordinate_2d<Value>;
 

--- a/test/test_correlation.cpp
+++ b/test/test_correlation.cpp
@@ -34,17 +34,17 @@ SOFTWARE.
 
 namespace
 {
-  std::array<char, 10> input_c
+  std::array<int8_t, 10> input_c
   {
     0, 1, 2, 3, 4, 5, 6, 7, 8, 9
   };
 
-  std::array<char, 10> input_c_flat
+  std::array<int8_t, 10> input_c_flat
   {
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0
   };
 
-  std::array<char, 10> input_c_inv
+  std::array<int8_t, 10> input_c_inv
   {
     0, -1, -2, -3, -4, -5, -6, -7, -8, -9
   };
@@ -120,21 +120,21 @@ namespace
       double covariance_result;
 
       // Negative correlation.
-      etl::correlation<etl::correlation_type::Population, char, int32_t> correlation1(input_c.begin(), input_c.end(), input_c_inv.begin());
+      etl::correlation<etl::correlation_type::Population, int8_t, int32_t> correlation1(input_c.begin(), input_c.end(), input_c_inv.begin());
       correlation_result = correlation1;
       CHECK_CLOSE(-1.0, correlation_result, 0.1);
       covariance_result = correlation1.get_covariance();
       CHECK_CLOSE(-8.25, covariance_result, 0.1);
 
       // Zero correlation
-      etl::correlation<etl::correlation_type::Population, char, int32_t> correlation2(input_c.begin(), input_c.end(), input_c_flat.begin());
+      etl::correlation<etl::correlation_type::Population, int8_t, int32_t> correlation2(input_c.begin(), input_c.end(), input_c_flat.begin());
       correlation_result = correlation2;
       CHECK_CLOSE(0.0, correlation_result, 0.1);
       covariance_result = correlation2.get_covariance();
       CHECK_CLOSE(0.0, covariance_result, 0.1);
 
       // Positive correlation.
-      etl::correlation<etl::correlation_type::Population, char, int32_t> correlation3(input_c.begin(), input_c.end(), input_c.begin());
+      etl::correlation<etl::correlation_type::Population, int8_t, int32_t> correlation3(input_c.begin(), input_c.end(), input_c.begin());
       correlation_result = correlation3;
       CHECK_CLOSE(1.0, correlation_result, 0.1);
       covariance_result = correlation3.get_covariance();
@@ -148,21 +148,21 @@ namespace
       double covariance_result;
 
       // Negative correlation.
-      etl::correlation<etl::correlation_type::Sample, char, int32_t> correlation1(input_c.begin(), input_c.end(), input_c_inv.begin());
+      etl::correlation<etl::correlation_type::Sample, int8_t, int32_t> correlation1(input_c.begin(), input_c.end(), input_c_inv.begin());
       correlation_result = correlation1;
       CHECK_CLOSE(-1.0, correlation_result, 0.1);
       covariance_result = correlation1.get_covariance();
       CHECK_CLOSE(-9.17, covariance_result, 0.1);
 
       // Zero correlation
-      etl::correlation<etl::correlation_type::Sample, char, int32_t> correlation2(input_c.begin(), input_c.end(), input_c_flat.begin());
+      etl::correlation<etl::correlation_type::Sample, int8_t, int32_t> correlation2(input_c.begin(), input_c.end(), input_c_flat.begin());
       correlation_result = correlation2;
       CHECK_CLOSE(0.0, correlation_result, 0.1);
       covariance_result = correlation2.get_covariance();
       CHECK_CLOSE(0.0, covariance_result, 0.1);
 
       // Positive correlation.
-      etl::correlation<etl::correlation_type::Sample, char, int32_t> correlation3(input_c.begin(), input_c.end(), input_c.begin());
+      etl::correlation<etl::correlation_type::Sample, int8_t, int32_t> correlation3(input_c.begin(), input_c.end(), input_c.begin());
       correlation_result = correlation3;
       CHECK_CLOSE(1.0, correlation_result, 0.1);
       covariance_result = correlation3.get_covariance();

--- a/test/test_covariance.cpp
+++ b/test/test_covariance.cpp
@@ -34,17 +34,17 @@ SOFTWARE.
 
 namespace
 {
-  std::array<char, 10> input_c
+  std::array<int8_t, 10> input_c
   {
     0, 1, 2, 3, 4, 5, 6, 7, 8, 9
   };
 
-  std::array<char, 10> input_c_flat
+  std::array<int8_t, 10> input_c_flat
   {
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0
   };
 
-  std::array<char, 10> input_c_inv
+  std::array<int8_t, 10> input_c_inv
   {
     0, -1, -2, -3, -4, -5, -6, -7, -8, -9
   };
@@ -119,17 +119,17 @@ namespace
       double covariance_result;
 
       // Negative covariance.
-      etl::covariance<etl::covariance_type::Population, char, int32_t> covariance1(input_c.begin(), input_c.end(), input_c_inv.begin());
+      etl::covariance<etl::covariance_type::Population, int8_t, int32_t> covariance1(input_c.begin(), input_c.end(), input_c_inv.begin());
       covariance_result = covariance1.get_covariance();
       CHECK_CLOSE(-8.25, covariance_result, 0.1);
 
       // Zero covariance
-      etl::covariance<etl::covariance_type::Population, char, int32_t> covariance2(input_c.begin(), input_c.end(), input_c_flat.begin());
+      etl::covariance<etl::covariance_type::Population, int8_t, int32_t> covariance2(input_c.begin(), input_c.end(), input_c_flat.begin());
       covariance_result = covariance2.get_covariance();
       CHECK_CLOSE(0.0, covariance_result, 0.1);
 
       // Positive covariance.
-      etl::covariance<etl::covariance_type::Population, char, int32_t> covariance3(input_c.begin(), input_c.end(), input_c.begin());
+      etl::covariance<etl::covariance_type::Population, int8_t, int32_t> covariance3(input_c.begin(), input_c.end(), input_c.begin());
       covariance_result = covariance3.get_covariance();
       CHECK_CLOSE(8.25, covariance_result, 0.1);
     }
@@ -140,17 +140,17 @@ namespace
       double covariance_result;
 
       // Negative covariance.
-      etl::covariance<etl::covariance_type::Sample, char, int32_t> covariance1(input_c.begin(), input_c.end(), input_c_inv.begin());
+      etl::covariance<etl::covariance_type::Sample, int8_t, int32_t> covariance1(input_c.begin(), input_c.end(), input_c_inv.begin());
       covariance_result = covariance1.get_covariance();
       CHECK_CLOSE(-9.17, covariance_result, 0.1);
 
       // Zero covariance
-      etl::covariance<etl::covariance_type::Sample, char, int32_t> covariance2(input_c.begin(), input_c.end(), input_c_flat.begin());
+      etl::covariance<etl::covariance_type::Sample, int8_t, int32_t> covariance2(input_c.begin(), input_c.end(), input_c_flat.begin());
       covariance_result = covariance2.get_covariance();
       CHECK_CLOSE(0.0, covariance_result, 0.1);
 
       // Positive covariance.
-      etl::covariance<etl::covariance_type::Sample, char, int32_t> covariance3(input_c.begin(), input_c.end(), input_c.begin());
+      etl::covariance<etl::covariance_type::Sample, int8_t, int32_t> covariance3(input_c.begin(), input_c.end(), input_c.begin());
       covariance_result = covariance3.get_covariance();
       CHECK_CLOSE(9.17, covariance_result, 0.1);
     }

--- a/test/test_rms.cpp
+++ b/test/test_rms.cpp
@@ -34,7 +34,7 @@ SOFTWARE.
 
 namespace
 {
-  std::array<char, 18> input_c
+  std::array<int8_t, 18> input_c
   {
     // Sawtooth wave
     0, 1, 2, 3, 4, 5, 6, 7, 8, 9, -8, -7, -6, -5, -4, -3, -2, -1
@@ -52,7 +52,7 @@ namespace
     //*************************************************************************
     TEST(test_char_rms)
     {
-      etl::rms<char, int> rms(input_c.begin(), input_c.end());
+      etl::rms<int8_t, int> rms(input_c.begin(), input_c.end());
       double result = rms.get_rms();
 
       CHECK_CLOSE(5.21, result, 0.05);


### PR DESCRIPTION
there are few build and test failures on arm64 platform with "narrowing conversion" due to char implementation differences between differnet platforms and gcc versions. This patch is to replace char with explicit datatype that works across all the platforms.