### PR TITLE
Packed unaligned_type

### DIFF
--- a/include/etl/platform.h
+++ b/include/etl/platform.h
@@ -455,6 +455,14 @@ SOFTWARE.
 #endif
 
 //*************************************
+// Determine if the ETL should use __attribute__((packed).
+#if defined(ETL_COMPILER_CLANG) || defined(ETL_COMPILER_GCC) || defined(ETL_COMPILER_INTEL)
+  #define ETL_PACKED __attribute__((packed))
+#else
+  #define ETL_PACKED
+#endif
+
+//*************************************
 // Check for availability of certain builtins
 #include "profiles/determine_builtin_support.h"
 

--- a/include/etl/unaligned_type.h
+++ b/include/etl/unaligned_type.h
@@ -227,7 +227,7 @@ namespace etl
   ///\tparam Endian The endianness of the arithmetic type.
   //*************************************************************************
   template <typename T, int Endian_>
-  class unaligned_type : public private_unaligned_type::unaligned_type_common<sizeof(T)>
+  class ETL_PACKED unaligned_type : public private_unaligned_type::unaligned_type_common<sizeof(T)>
   {
   public:
 


### PR DESCRIPTION
This way, unaligned_types like etl::be_uint32_t can be used in places where POD types are expected.