### PR TITLE
Make Copy Construction and Assignment Defaulted For Strong Types

### DIFF
--- a/include/etl/type_def.h
+++ b/include/etl/type_def.h
@@ -70,12 +70,6 @@ namespace etl
     }
 
     //*********************************************************************
-    ETL_CONSTEXPR type_def(const type_def& other)
-      : value(other.value)
-    {
-    }
-
-    //*********************************************************************
     ETL_CONSTEXPR operator TValue() const
     {
       return value;
@@ -241,13 +235,6 @@ namespace etl
     ETL_CONSTEXPR14 type_def& operator =(TValue rhs)
     {
       value = rhs;
-      return *this;
-    }
-
-    //*********************************************************************
-    ETL_CONSTEXPR14 type_def& operator =(const type_def& rhs)
-    {
-      value = rhs.value;
       return *this;
     }
 


### PR DESCRIPTION
This implements the feature requested here: https://github.com/ETLCPP/etl/issues/1000
