### PR TITLE
Fixed memory.h: mem_copy, mem_move, mem_compare for pointers to const

### DIFF
--- a/include/etl/memory.h
+++ b/include/etl/memory.h
@@ -2264,13 +2264,13 @@ namespace etl
   /// \param destination begin
   /// \return A pointer to the destination.
   //***************************************************************************
-  template <typename TPointer>
-  typename etl::enable_if<etl::is_trivially_copyable<typename etl::iterator_traits<TPointer>::value_type>::value, TPointer>::type
-    mem_copy(const TPointer sb, const TPointer se, TPointer db) ETL_NOEXCEPT
+  template <typename T>
+  typename etl::enable_if<etl::is_trivially_copyable<typename etl::iterator_traits<T*>::value_type>::value, T*>::type
+    mem_copy(const T* sb, const T* se, T* db) ETL_NOEXCEPT
   {
-    return reinterpret_cast<TPointer>(memcpy(reinterpret_cast<void*>(db), 
-                                             reinterpret_cast<void*>(sb), 
-                                             sizeof(typename etl::iterator_traits<TPointer>::value_type) * static_cast<size_t>(se - sb)));
+    return reinterpret_cast<T*>(memcpy(reinterpret_cast<void*>(db),
+                                       reinterpret_cast<const void*>(sb),
+                                       sizeof(typename etl::iterator_traits<T*>::value_type) * static_cast<size_t>(se - sb)));
   }
 
   //***************************************************************************
@@ -2280,13 +2280,13 @@ namespace etl
   /// \param source length
   /// \param destination begin
   //***************************************************************************
-  template <typename TPointer>
-  typename etl::enable_if<etl::is_trivially_copyable<typename etl::iterator_traits<TPointer>::value_type>::value, TPointer>::type
-    mem_copy(const TPointer sb, size_t n, TPointer db) ETL_NOEXCEPT
+  template <typename T>
+  typename etl::enable_if<etl::is_trivially_copyable<typename etl::iterator_traits<T*>::value_type>::value, T*>::type
+    mem_copy(const T* sb, size_t n, T* db) ETL_NOEXCEPT
   {
-    return reinterpret_cast<TPointer>(memcpy(reinterpret_cast<void*>(db), 
-                                             reinterpret_cast<void*>(sb), 
-                                             sizeof(typename etl::iterator_traits<TPointer>::value_type) * n));
+    return reinterpret_cast<T*>(memcpy(reinterpret_cast<void*>(db),
+                                       reinterpret_cast<const void*>(sb),
+                                       sizeof(typename etl::iterator_traits<T*>::value_type) * n));
   }
 
   //***************************************************************************
@@ -2296,13 +2296,13 @@ namespace etl
   /// \param source end
   /// \param destination begin
   //***************************************************************************
-  template <typename TPointer>
-  typename etl::enable_if<etl::is_trivially_copyable<typename etl::iterator_traits<TPointer>::value_type>::value, TPointer>::type
-    mem_move(const TPointer sb, const TPointer se, TPointer db) ETL_NOEXCEPT
+  template <typename T>
+  typename etl::enable_if<etl::is_trivially_copyable<typename etl::iterator_traits<T*>::value_type>::value, T*>::type
+    mem_move(const T* sb, const T* se, T* db) ETL_NOEXCEPT
   {
-    return reinterpret_cast<TPointer>(memmove(reinterpret_cast<void*>(db), 
-                                              reinterpret_cast<void*>(sb), 
-                                              sizeof(typename etl::iterator_traits<TPointer>::value_type) * static_cast<size_t>(se - sb)));
+    return reinterpret_cast<T*>(memmove(reinterpret_cast<void*>(db),
+                                        reinterpret_cast<const void*>(sb),
+                                        sizeof(typename etl::iterator_traits<T*>::value_type) * static_cast<size_t>(se - sb)));
   }
 
   //***************************************************************************
@@ -2312,13 +2312,13 @@ namespace etl
   /// \param source length
   /// \param destination begin
   //***************************************************************************
-  template <typename TPointer>
-  typename etl::enable_if<etl::is_trivially_copyable<typename etl::iterator_traits<TPointer>::value_type>::value, TPointer>::type
-    mem_move(const TPointer sb, size_t n, TPointer db) ETL_NOEXCEPT
+  template <typename T>
+  typename etl::enable_if<etl::is_trivially_copyable<typename etl::iterator_traits<T*>::value_type>::value, T*>::type
+    mem_move(const T* sb, size_t n, T* db) ETL_NOEXCEPT
   {
-    return reinterpret_cast<TPointer>(memmove(reinterpret_cast<void*>(db), 
-                                              reinterpret_cast<void*>(sb), 
-                                              sizeof(typename etl::iterator_traits<TPointer>::value_type) * n));
+    return reinterpret_cast<T*>(memmove(reinterpret_cast<void*>(db),
+                                        reinterpret_cast<const void*>(sb),
+                                        sizeof(typename etl::iterator_traits<T*>::value_type) * n));
   }
 
   //***************************************************************************
@@ -2330,14 +2330,14 @@ namespace etl
   ///   0 The contents of both memory blocks are equal
   /// > 0	The first byte that does not match in both memory blocks has a greater value in 'sb' than in 'db' when evaluated as unsigned char values.
   //***************************************************************************
-  template <typename TPointer>
+  template <typename T>
   ETL_NODISCARD
-    typename etl::enable_if<etl::is_trivially_copyable<typename etl::iterator_traits<TPointer>::value_type>::value, int>::type
-    mem_compare(const TPointer sb, const TPointer se, TPointer db) ETL_NOEXCEPT
+    typename etl::enable_if<etl::is_trivially_copyable<typename etl::iterator_traits<T*>::value_type>::value, int>::type
+    mem_compare(const T* sb, const T* se, const T* db) ETL_NOEXCEPT
   {
-    return memcmp(reinterpret_cast<void*>(db), 
-                  reinterpret_cast<void*>(sb), 
-                  sizeof(typename etl::iterator_traits<TPointer>::value_type) * static_cast<size_t>(se - sb));
+    return memcmp(reinterpret_cast<const void*>(db),
+                  reinterpret_cast<const void*>(sb),
+                  sizeof(typename etl::iterator_traits<T*>::value_type) * static_cast<size_t>(se - sb));
   }
 
   //***************************************************************************
@@ -2349,14 +2349,14 @@ namespace etl
   ///   0 The contents of both memory blocks are equal
   /// > 0	The first byte that does not match in both memory blocks has a greater value in 'sb' than in 'db' when evaluated as unsigned char values.
   //***************************************************************************
-  template <typename TPointer>
+  template <typename T>
   ETL_NODISCARD
-    typename etl::enable_if<etl::is_trivially_copyable<typename etl::iterator_traits<TPointer>::value_type>::value, int>::type
-    mem_compare(const TPointer sb, size_t n, TPointer db) ETL_NOEXCEPT
+    typename etl::enable_if<etl::is_trivially_copyable<typename etl::iterator_traits<T*>::value_type>::value, int>::type
+    mem_compare(const T* sb, size_t n, const T* db) ETL_NOEXCEPT
   {
-    return memcmp(reinterpret_cast<void*>(db), 
-                  reinterpret_cast<void*>(sb), 
-                  sizeof(typename etl::iterator_traits<TPointer>::value_type) * n);
+    return memcmp(reinterpret_cast<const void*>(db),
+                  reinterpret_cast<const void*>(sb),
+                  sizeof(typename etl::iterator_traits<T*>::value_type) * n);
   }
 
   //***************************************************************************
@@ -2384,7 +2384,7 @@ namespace etl
   //***************************************************************************
   template <typename TPointer, typename T>
   typename etl::enable_if<etl::is_trivially_copyable<typename etl::iterator_traits<TPointer>::value_type>::value, TPointer>::type
-    mem_set(const TPointer db, size_t n, T value) ETL_NOEXCEPT
+    mem_set(TPointer db, size_t n, T value) ETL_NOEXCEPT
   {
     return reinterpret_cast<TPointer>(memset(reinterpret_cast<void*>(db),
                                              static_cast<char>(value),

--- a/test/test_memory.cpp
+++ b/test/test_memory.cpp
@@ -1181,13 +1181,33 @@ namespace
     }
 
     //*************************************************************************
+    TEST(test_mem_copy_const_pointer_const_pointer_pointer)
+    {
+      const uint32_t src[8] = { 0x12345678, 0x76543210, 0x01452367, 0x23670145, 0x67234501, 0x45016723, 0x01324576, 0x76453201 };
+      uint32_t dst[8] = { 0, 0, 0, 0, 0, 0, 0, 0 };
+
+      etl::mem_copy(src, src + 8, dst);
+
+      CHECK(std::equal(src, src + 8, dst));
+    }
+
+    //*************************************************************************
     TEST(test_mem_copy_pointer_length_pointer)
     {
       uint32_t src[8] = { 0x12345678, 0x76543210, 0x01452367, 0x23670145, 0x67234501, 0x45016723, 0x01324576, 0x76453201 };
       uint32_t dst[8] = { 0, 0, 0, 0, 0, 0, 0, 0 };
 
       etl::mem_copy(src, 8, dst);
+      CHECK(std::equal(src, src + 8, dst));
+    }
 
+    //*************************************************************************
+    TEST(test_mem_copy_const_pointer_length_pointer)
+    {
+      const uint32_t src[8] = { 0x12345678, 0x76543210, 0x01452367, 0x23670145, 0x67234501, 0x45016723, 0x01324576, 0x76453201 };
+      uint32_t dst[8] = { 0, 0, 0, 0, 0, 0, 0, 0 };
+
+      etl::mem_copy(src, 8, dst);
       CHECK(std::equal(src, src + 8, dst));
     }
 
@@ -1203,12 +1223,36 @@ namespace
     }
 
     //*************************************************************************
+    TEST(test_mem_move_const_pointer_const_pointer_pointer)
+    {
+      uint32_t expected[8] = { 0x12345678, 0x76543210, 0x01452367, 0x23670145, 0x67234501, 0x45016723, 0x01324576, 0x76453201 };
+      uint32_t data[12]    = { 0x12345678, 0x76543210, 0x01452367, 0x23670145, 0x67234501, 0x45016723, 0x01324576, 0x76453201, 0, 0, 0, 0 };
+      const uint32_t* data_begin = &data[0];
+      const uint32_t* data_end = &data[8];
+
+      etl::mem_move(data_begin, data_end, data + 4);
+
+      CHECK(std::equal(expected, expected + 8, data + 4));
+    }
+
+    //*************************************************************************
     TEST(test_mem_move_pointer_length_pointer)
     {
       uint32_t expected[8] = { 0x12345678, 0x76543210, 0x01452367, 0x23670145, 0x67234501, 0x45016723, 0x01324576, 0x76453201 };
       uint32_t data[12]    = { 0x12345678, 0x76543210, 0x01452367, 0x23670145, 0x67234501, 0x45016723, 0x01324576, 0x76453201, 0, 0, 0, 0 };
 
       etl::mem_move(data, 8, data + 4);
+
+      CHECK(std::equal(expected, expected + 8, data + 4));
+    }
+
+    //*************************************************************************
+    TEST(test_mem_move_const_pointer_length_pointer)
+    {
+      uint32_t expected[8] = { 0x12345678, 0x76543210, 0x01452367, 0x23670145, 0x67234501, 0x45016723, 0x01324576, 0x76453201 };
+      uint32_t data[12]    = { 0x12345678, 0x76543210, 0x01452367, 0x23670145, 0x67234501, 0x45016723, 0x01324576, 0x76453201, 0, 0, 0, 0 };
+      const uint32_t* data_begin = &data[0];
+      etl::mem_move(data_begin, 8, data + 4);
 
       CHECK(std::equal(expected, expected + 8, data + 4));
     }
@@ -1227,12 +1271,64 @@ namespace
     }
 
     //*************************************************************************
+    TEST(test_mem_compare_const_pointer_const_pointer_pointer)
+    {
+      const uint32_t data[8] = { 0x12345678, 0x76543210, 0x01452367, 0x23670145, 0x67234501, 0x45016723, 0x01324576, 0x76453201 };
+      uint32_t same[8] = { 0x12345678, 0x76543210, 0x01452367, 0x23670145, 0x67234501, 0x45016723, 0x01324576, 0x76453201 };
+      uint32_t grtr[8] = { 0x12345678, 0x76543210, 0x01452367, 0x23670145, 0x67235501, 0x45016723, 0x01324576, 0x76453201 };
+      uint32_t less[8] = { 0x12345678, 0x76543210, 0x01452367, 0x23670145, 0x67134501, 0x45016723, 0x01324576, 0x76453201 };
+
+      CHECK(etl::mem_compare(data, data + 8, same) == 0);
+      CHECK(etl::mem_compare(data, data + 8, grtr) > 0);
+      CHECK(etl::mem_compare(data, data + 8, less) < 0);
+    }
+
+    //*************************************************************************
+    TEST(test_mem_compare_const_pointer_const_pointer_const_pointer)
+    {
+      const uint32_t data[8] = { 0x12345678, 0x76543210, 0x01452367, 0x23670145, 0x67234501, 0x45016723, 0x01324576, 0x76453201 };
+      const uint32_t same[8] = { 0x12345678, 0x76543210, 0x01452367, 0x23670145, 0x67234501, 0x45016723, 0x01324576, 0x76453201 };
+      uint32_t grtr[8] = { 0x12345678, 0x76543210, 0x01452367, 0x23670145, 0x67235501, 0x45016723, 0x01324576, 0x76453201 };
+      uint32_t less[8] = { 0x12345678, 0x76543210, 0x01452367, 0x23670145, 0x67134501, 0x45016723, 0x01324576, 0x76453201 };
+
+      CHECK(etl::mem_compare(data, data + 8, same) == 0);
+      CHECK(etl::mem_compare(data, data + 8, grtr) > 0);
+      CHECK(etl::mem_compare(data, data + 8, less) < 0);
+    }
+
+    //*************************************************************************
     TEST(test_mem_compare_pointer_length_pointer)
     {
       uint32_t data[8] = { 0x12345678, 0x76543210, 0x01452367, 0x23670145, 0x67234501, 0x45016723, 0x01324576, 0x76453201 };
       uint32_t same[8] = { 0x12345678, 0x76543210, 0x01452367, 0x23670145, 0x67234501, 0x45016723, 0x01324576, 0x76453201 };
       uint32_t grtr[8] = { 0x12345678, 0x76543210, 0x01452367, 0x23670145, 0x67235501, 0x45016723, 0x01324576, 0x76453201 };
       uint32_t less[8] = { 0x12345678, 0x76543210, 0x01452367, 0x23670145, 0x67134501, 0x45016723, 0x01324576, 0x76453201 };
+
+      CHECK(etl::mem_compare(data, 8, same) == 0);
+      CHECK(etl::mem_compare(data, 8, grtr) > 0);
+      CHECK(etl::mem_compare(data, 8, less) < 0);
+    }
+
+    //*************************************************************************
+    TEST(test_mem_compare_const_pointer_length_pointer)
+    {
+      const uint32_t data[8] = { 0x12345678, 0x76543210, 0x01452367, 0x23670145, 0x67234501, 0x45016723, 0x01324576, 0x76453201 };
+      uint32_t same[8] = { 0x12345678, 0x76543210, 0x01452367, 0x23670145, 0x67234501, 0x45016723, 0x01324576, 0x76453201 };
+      uint32_t grtr[8] = { 0x12345678, 0x76543210, 0x01452367, 0x23670145, 0x67235501, 0x45016723, 0x01324576, 0x76453201 };
+      uint32_t less[8] = { 0x12345678, 0x76543210, 0x01452367, 0x23670145, 0x67134501, 0x45016723, 0x01324576, 0x76453201 };
+
+      CHECK(etl::mem_compare(data, 8, same) == 0);
+      CHECK(etl::mem_compare(data, 8, grtr) > 0);
+      CHECK(etl::mem_compare(data, 8, less) < 0);
+    }
+
+    //*************************************************************************
+    TEST(test_mem_compare_const_pointer_length_const_pointer)
+    {
+      const uint32_t data[8] = { 0x12345678, 0x76543210, 0x01452367, 0x23670145, 0x67234501, 0x45016723, 0x01324576, 0x76453201 };
+      const uint32_t same[8] = { 0x12345678, 0x76543210, 0x01452367, 0x23670145, 0x67234501, 0x45016723, 0x01324576, 0x76453201 };
+      const uint32_t grtr[8] = { 0x12345678, 0x76543210, 0x01452367, 0x23670145, 0x67235501, 0x45016723, 0x01324576, 0x76453201 };
+      const uint32_t less[8] = { 0x12345678, 0x76543210, 0x01452367, 0x23670145, 0x67134501, 0x45016723, 0x01324576, 0x76453201 };
 
       CHECK(etl::mem_compare(data, 8, same) == 0);
       CHECK(etl::mem_compare(data, 8, grtr) > 0);


### PR DESCRIPTION
Currently, mem_copy() etc. get the constness wrong: "const TPointer" is not a pointer to const data, as intended.

The additional tests illustrate the problem by failing to compile in current ETL.

The change to memory.h fixes it.