### PR TITLE
Fix fixed extent span empty()

### DIFF
--- a/include/etl/span.h
+++ b/include/etl/span.h
@@ -238,7 +238,7 @@ namespace etl
     //*************************************************************************
     ETL_NODISCARD ETL_CONSTEXPR bool empty() const ETL_NOEXCEPT
     {
-      return false;
+      return Extent == 0;
     }
 
     //*************************************************************************

--- a/test/test_span_fixed_extent.cpp
+++ b/test/test_span_fixed_extent.cpp
@@ -52,6 +52,7 @@ namespace
     typedef etl::span<int, 10U> View;
     typedef etl::span<int, 9U> SView;
     typedef etl::span<const int, 10U> CView;
+    typedef etl::span<int, 0U> EView;
 
 #if ETL_USING_CPP20
     using StdView = std::span<int, 10U>;
@@ -464,6 +465,9 @@ namespace
     {
       View view1(etldata.begin(), etldata.begin());
       CHECK(!view1.empty());
+
+      EView view2(etldata.begin(), etldata.begin());
+      CHECK(view2.empty());
     }
 
     //*************************************************************************


### PR DESCRIPTION
Since 0-sized spans are allowed, they should report their empty() property as true.

This makes it consistent with the dynamic extent span and the size() property.