### PR TITLE
Alignment typed storage

### DIFF
--- a/include/etl/alignment.h
+++ b/include/etl/alignment.h
@@ -405,7 +405,7 @@ namespace etl
     /// \returns the instance of T which has been constructed in the internal byte array.
     //***************************************************************************
     template<typename... Args>
-    reference emplace(Args&&... args)
+    reference create(Args&&... args)
     {
       ETL_ASSERT(!has_value(), ETL_ERROR(etl::typed_storage_error));
       valid = true;

--- a/test/test_alignment.cpp
+++ b/test/test_alignment.cpp
@@ -48,6 +48,23 @@ void f(int)
 {
 }
 
+struct A_t
+{
+  A_t(uint32_t v_x, uint8_t v_y)
+   : x(v_x)
+   , y(v_y)
+  {
+  }
+
+  bool operator==(A_t& other)
+  {
+    return other.x == x && other.y == y;
+  }
+
+  uint32_t x;
+  uint8_t y;
+};
+
 namespace
 {
   SUITE(test_alignment)
@@ -155,5 +172,31 @@ namespace
       CHECK_EQUAL(32, alignof(etl::type_with_alignment_t<32>));
       CHECK_EQUAL(64, alignof(etl::type_with_alignment_t<64>));
     }
+
+    //*************************************************************************
+#if ETL_USING_CPP11
+    TEST(test_typed_storage)
+    {
+      etl::typed_storage<A_t> a;
+
+      CHECK_EQUAL(false, a.has_value());
+
+      auto& b = a.emplace(123, 4);
+
+      CHECK_EQUAL(true, a.has_value());
+
+      CHECK_EQUAL(a->x, 123);
+      CHECK_EQUAL(a->y, 4);
+
+      CHECK_EQUAL(b.x, 123);
+      CHECK_EQUAL(b.y, 4);
+
+      CHECK_TRUE(*a == b);
+
+      CHECK_EQUAL(true, a.has_value());
+      a.destroy();
+      CHECK_EQUAL(false, a.has_value());
+    }
+#endif
   };
 }

--- a/test/test_alignment.cpp
+++ b/test/test_alignment.cpp
@@ -181,7 +181,7 @@ namespace
 
       CHECK_EQUAL(false, a.has_value());
 
-      auto& b = a.emplace(123, 4);
+      auto& b = a.create(123, 4);
 
       CHECK_EQUAL(true, a.has_value());
 


### PR DESCRIPTION
I have a recurring use case of globally allocated class instances that I need to explicitly construct in a more defined order than implicit construction of global C++ objects can offer.

Therefore, I have a convenience wrapper etl::typed_storage for aligned_storage_as for instantiating an object explicitly at a defined time.

Previously, I tried with etl::optional<T>, which basically supports the same interface I need, but I can't use this one because it always references ~T. But I want the compiler to optimize away the unneeded dtors because the global objects won't get destroyed anyway until power-off in many embedded scenarios.

(You can still explicitly destroy() if needed.)
