### PR TITLE
Intrusive forward list add remove by pointer

### DIFF
--- a/include/etl/intrusive_forward_list.h
+++ b/include/etl/intrusive_forward_list.h
@@ -992,6 +992,28 @@ namespace etl
     }
 
     //*************************************************************************
+    // Removes the element specified by pointer.
+    //*************************************************************************
+    void remove(const_pointer element)
+    {
+      iterator i_item = begin();
+      iterator i_last_item = before_begin();
+
+      while (i_item != end())
+      {
+        if (&i_item == element)
+        {
+          i_item = erase_after(i_last_item);
+        }
+        else
+        {
+          ++i_item;
+          ++i_last_item;
+        }
+      }
+    }
+
+    //*************************************************************************
     /// Removes according to a predicate.
     //*************************************************************************
     template <typename TPredicate>

--- a/include/etl/intrusive_forward_list.h
+++ b/include/etl/intrusive_forward_list.h
@@ -1004,6 +1004,7 @@ namespace etl
         if (&i_item == element)
         {
           i_item = erase_after(i_last_item);
+          return;
         }
         else
         {

--- a/test/test_intrusive_forward_list.cpp
+++ b/test/test_intrusive_forward_list.cpp
@@ -860,6 +860,35 @@ namespace
     }
 
     //*************************************************************************
+    TEST_FIXTURE(SetupFixture, test_remove_by_pointer)
+    {
+      std::forward_list<ItemNDCNode> compare_data(sorted_data.begin(), sorted_data.end());
+      DataNDC0 data0(sorted_data.begin(), sorted_data.end());
+      DataNDC1 data1(sorted_data.begin(), sorted_data.end());
+
+      auto it = data0.begin();
+      for (int i = 0; i < 7; ++i)
+      {
+        it++;
+      }
+      ItemNDCNode* element = &it;
+
+      compare_data.remove(ItemNDCNode("7"));
+      data0.remove(*element);
+
+      bool are_equal = std::equal(data0.begin(), data0.end(), compare_data.begin());
+
+      CHECK(are_equal);
+      CHECK_EQUAL(size_t(std::distance(compare_data.begin(), compare_data.end())), data0.size());
+      CHECK_EQUAL(std::distance(compare_data.begin(), compare_data.end()), std::distance(data0.begin(), data0.end()));
+
+      are_equal = std::equal(data1.begin(), data1.end(), sorted_data.begin());
+      CHECK(are_equal);
+      CHECK_EQUAL(sorted_data.size(), data1.size());
+      CHECK_EQUAL(sorted_data.size(), size_t(std::distance(data1.begin(), data1.end())));
+    }
+
+    //*************************************************************************
     TEST_FIXTURE(SetupFixture, test_remove_if)
     {
       std::forward_list<ItemNDCNode> compare_data(sorted_data.begin(), sorted_data.end());


### PR DESCRIPTION
Besides remove() by reference, I provide this remove() by pointer (overload).

Scenario is as follows:

Current remove() by reference uses the comparison operator, comparing actually different instances for equality. In my use case, I have objects in the intrusive_forward_list which don't have a comparison operator defined but I have a pointer to them. This way, I can intentionally remove the actual object from the list pointed to by the pointer.