### PR TITLE
Add etl::make_span()

### DIFF
--- a/include/etl/span.h
+++ b/include/etl/span.h
@@ -377,6 +377,16 @@ namespace etl
     pointer pbegin;
   };
 
+  //*************************************************************************
+  /// Pseudo constructor for constructing from C array without explicitly
+  /// specifying type and size
+  //*************************************************************************
+  template <typename T, size_t Extent>
+  ETL_CONSTEXPR span<T, Extent> make_span(T (&data)[Extent])
+  {
+    return span<T, Extent>(data);
+  }
+
   //***************************************************************************
   /// Span - Dynamic Extent
   //***************************************************************************
@@ -699,6 +709,26 @@ namespace etl
     pointer pbegin;
     pointer pend;
   };
+
+  //*************************************************************************
+  /// Pseudo constructor for constructing from container without explicitly
+  /// specifying type and size
+  //*************************************************************************
+  template <typename T>
+  ETL_CONSTEXPR span<typename T::value_type, etl::dynamic_extent> make_span(T& data)
+  {
+    return span<typename T::value_type, etl::dynamic_extent>(data);
+  }
+
+  //*************************************************************************
+  /// Pseudo constructor for constructing from const container without
+  /// explicitly specifying type and size
+  //*************************************************************************
+  template <typename T>
+  ETL_CONSTEXPR span<typename T::value_type const, etl::dynamic_extent> make_span(const T& data)
+  {
+    return span<typename T::value_type const, etl::dynamic_extent>(data);
+  }
 
   template <typename T, size_t Extent>
   ETL_CONSTANT size_t span<T, Extent>::extent;

--- a/test/test_span_dynamic_extent.cpp
+++ b/test/test_span_dynamic_extent.cpp
@@ -1205,6 +1205,25 @@ namespace
       }
     }
 
+    //*************************************************************************
+    TEST(test_make_span_container)
+    {
+      {
+        auto s = etl::make_span(etldata);
+
+        CHECK_EQUAL(s.size(), 10);
+        View view(etldata);
+        CHECK_TRUE(etl::equal(s, view));
+      }
+      {
+        auto s = etl::make_span(cetldata);
+
+        CHECK_EQUAL(s.size(), 10);
+        View view(etldata);
+        CHECK_TRUE(etl::equal(s, view));
+      }
+    }
+
 #include "etl/private/diagnostic_pop.h"
   };
 }

--- a/test/test_span_fixed_extent.cpp
+++ b/test/test_span_fixed_extent.cpp
@@ -1123,6 +1123,25 @@ namespace
       }
     }
 
+    //*************************************************************************
+    TEST(test_make_span_c_array)
+    {
+      {
+        auto s = etl::make_span(cdata);
+
+        CHECK_EQUAL(s.size(), 10);
+        View view(etldata);
+        CHECK_TRUE(etl::equal(s, view));
+      }
+      {
+        auto s = etl::make_span(ccdata);
+
+        CHECK_EQUAL(s.size(), 10);
+        View view(etldata);
+        CHECK_TRUE(etl::equal(s, view));
+      }
+    }
+
 #include "etl/private/diagnostic_pop.h"
   };
 }


### PR DESCRIPTION
Especially without deduction guides in C++14, I typically have the use case of creating a span with long template arguments to the constructor, where they better could be deducted. This PR adds etl::make_span() deducing template arguments.

E.g. `etl::make_span(etldata);`