### PR TITLE
Support etl::inplace_function

### DIFF
--- a/include/etl/inplace_function.h
+++ b/include/etl/inplace_function.h
@@ -1,0 +1,40 @@
+///\file
+
+/******************************************************************************
+The MIT License(MIT)
+
+Embedded Template Library.
+https://github.com/ETLCPP/etl
+https://www.etlcpp.com
+
+Copyright(c) 2025 BMW AG
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files(the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions :
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+******************************************************************************/
+
+#ifndef ETL_INPLACE_FUNCTION_INCLUDED
+#define ETL_INPLACE_FUNCTION_INCLUDED
+
+#include "platform.h"
+
+#if ETL_USING_CPP14
+  #include "private/inplace_function_cpp14.h"
+#endif
+
+#endif

--- a/include/etl/private/inplace_function_cpp14.h
+++ b/include/etl/private/inplace_function_cpp14.h
@@ -1,0 +1,234 @@
+///\file
+
+/******************************************************************************
+The MIT License(MIT)
+
+Embedded Template Library.
+https://github.com/ETLCPP/etl
+https://www.etlcpp.com
+
+Copyright(c) 2025 BMW AG
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files(the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions :
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+******************************************************************************/
+
+#ifndef ETL_INPLACE_FUNCTION_CPP14_INCLUDED
+#define ETL_INPLACE_FUNCTION_CPP14_INCLUDED
+
+#include "../platform.h"
+#include "../type_traits.h"
+#include "../utility.h"
+
+#ifndef ETL_INPLACE_FUNCTION_DEFAULT_CAPACITY
+  #define ETL_INPLACE_FUNCTION_DEFAULT_CAPACITY 32
+#endif
+namespace etl
+{
+  namespace private_inplace_function
+  {
+    template <typename T>
+    struct wrapper
+    {
+      using type = T;
+    };
+    template <typename R, typename... Args>
+    struct vtable_t ETL_FINAL
+    {
+      using storage_ptr_t = void*;
+      using invoke_func_t = R (*)(storage_ptr_t, Args&&...);
+      using copy_or_move_func_t = void (*)(storage_ptr_t, storage_ptr_t);
+      using dtor_func_t = void (*)(storage_ptr_t);
+
+      const invoke_func_t       invoke_func{[](storage_ptr_t, Args&&...) -> R
+                                      { return R(); }};
+      const copy_or_move_func_t copy_func{[](storage_ptr_t, storage_ptr_t) -> void {}};
+      const copy_or_move_func_t move_func{[](storage_ptr_t, storage_ptr_t) -> void {}};
+      const dtor_func_t         dtor_func{[](storage_ptr_t) -> void {}};
+
+      ~vtable_t() = default;
+
+      ETL_CONSTEXPR vtable_t() ETL_NOEXCEPT = default;
+
+      template <typename T>
+      explicit ETL_CONSTEXPR vtable_t(wrapper<T>) ETL_NOEXCEPT
+        : invoke_func{[](storage_ptr_t storage_ptr, Args&&... args) -> R
+                      { return (*static_cast<T*>(storage_ptr))(
+                          etl::forward<Args&&>(args)...); }},
+          copy_func{[](storage_ptr_t dst_ptr, storage_ptr_t src_ptr) -> void
+                    { ::new (dst_ptr) T{*static_cast<T*>(src_ptr)}; }},
+          move_func{[](storage_ptr_t dst_ptr, storage_ptr_t src_ptr) -> void
+                    {
+                      ::new (dst_ptr) T{etl::move(*static_cast<T*>(src_ptr))};
+                      static_cast<T*>(src_ptr)->~T();
+                    }},
+          dtor_func{[](storage_ptr_t src_ptr) -> void
+                    { static_cast<T*>(src_ptr)->~T(); }}
+      {
+      }
+
+    private:
+      vtable_t(const vtable_t&) ETL_DELETE;
+      vtable_t(vtable_t&&) ETL_DELETE;
+
+      vtable_t& operator=(const vtable_t&) ETL_DELETE;
+      vtable_t& operator=(vtable_t&&) ETL_DELETE;
+    };
+
+    template <class R, class... Args>
+    ETL_INLINE_VAR ETL_CONSTEXPR17
+        vtable_t<R, Args...>
+        default_vtable{};
+  }  // namespace private_inplace_function
+
+  template <
+    typename Signature,
+    size_t Capacity = ETL_INPLACE_FUNCTION_DEFAULT_CAPACITY>
+  class inplace_function;
+
+  namespace private_inplace_function
+  {
+    template <typename>
+    struct is_inplace_function : etl::false_type
+    {
+    };
+    template <typename Sig, size_t Cap>
+    struct is_inplace_function<inplace_function<Sig, Cap>> : etl::true_type
+    {
+    };
+  }  // namespace private_inplace_function
+
+  template <
+    typename R,
+    typename... Args,
+    size_t Capacity>
+  class inplace_function<R(Args...), Capacity> ETL_FINAL
+  {
+    using vtable_t = private_inplace_function::vtable_t<R, Args...>;
+    using vtable_ptr_t = const vtable_t*;
+
+    template <typename, size_t>
+    friend class inplace_function;
+
+  public:
+    using capacity = etl::integral_constant<size_t, Capacity>;
+
+    inplace_function() ETL_NOEXCEPT = default;
+
+    template <
+      typename T,
+      typename C = etl::decay_t<T>,
+      typename = etl::enable_if_t<
+        !private_inplace_function::is_inplace_function<C>::value && etl::is_invocable_r<R, C&, Args...>::value>>
+    inplace_function(T&& closure)
+    {
+      ETL_STATIC_ASSERT(etl::is_copy_constructible<C>::value,
+                        "cannot be constructed from non-copyable types");
+
+      ETL_STATIC_ASSERT(sizeof(C) <= Capacity,
+                        "internal storage too small");
+
+      static const vtable_t vt{private_inplace_function::wrapper<C>{}};
+
+      vtable_ptr = &vt;
+      ::new (storage) C{etl::forward<T>(closure)};
+    }
+
+    template <size_t Cap>
+    inplace_function(const inplace_function<R(Args...), Cap>& other)
+      : inplace_function(other.vtable_ptr, other.vtable_ptr->copy_func, other.storage)
+    {
+      ETL_STATIC_ASSERT(Capacity >= Cap,
+                        "internal storage too small");
+    }
+
+    template <size_t Cap>
+    inplace_function(inplace_function<R(Args...), Cap>&& other) ETL_NOEXCEPT
+      : inplace_function(other.vtable_ptr, other.vtable_ptr->move_func, other.storage)
+    {
+      ETL_STATIC_ASSERT(Capacity >= Cap,
+                        "internal storage too small");
+    }
+
+    inplace_function(const inplace_function& other)
+      : vtable_ptr{other.vtable_ptr}
+    {
+      vtable_ptr->copy_func(
+        storage,
+        other.storage);
+    }
+
+    inplace_function(inplace_function&& other) ETL_NOEXCEPT
+      : vtable_ptr{other.vtable_ptr}
+    {
+      vtable_ptr->move_func(
+        storage,
+        other.storage);
+    }
+
+    inplace_function& operator=(etl::nullptr_t) ETL_NOEXCEPT
+    {
+      vtable_ptr->dtor_func(&storage);
+      vtable_ptr = ETL_NULLPTR;
+      return *this;
+    }
+
+    inplace_function& operator=(inplace_function other) ETL_NOEXCEPT
+    {
+      vtable_ptr->dtor_func(storage);
+      vtable_ptr = other.vtable_ptr;
+      vtable_ptr->move_func(
+        storage,
+        other.storage);
+      return *this;
+    }
+
+    ~inplace_function()
+    {
+      vtable_ptr->dtor_func(storage);
+    }
+
+    R operator()(Args... args) const
+    {
+      return vtable_ptr->invoke_func(
+        storage,
+        etl::forward<Args>(args)...);
+    }
+
+    explicit ETL_CONSTEXPR operator bool() const ETL_NOEXCEPT
+    {
+      return vtable_ptr != &private_inplace_function::default_vtable<R, Args...>;
+    }
+
+  private:
+    vtable_ptr_t vtable_ptr{&private_inplace_function::default_vtable<R, Args...>};
+    mutable char storage[Capacity];
+
+    inplace_function(
+      vtable_ptr_t                           vtable,
+      typename vtable_t::copy_or_move_func_t copy_or_move_func,
+      typename vtable_t::storage_ptr_t       storage_ptr)
+      : vtable_ptr{vtable}
+    {
+      copy_or_move_func(storage, storage_ptr);
+    }
+  };
+
+}  // namespace etl
+
+#endif

--- a/include/etl/type_traits.h
+++ b/include/etl/type_traits.h
@@ -2349,6 +2349,57 @@ typedef integral_constant<bool, true>  true_type;
   template <typename T, typename... TTypes>
   inline constexpr bool has_duplicates_of_v = etl::has_duplicates_of<T, TTypes...>::value;
 #endif
+
+#if ETL_USING_STL && ETL_USING_CPP17
+  template <typename... Types>
+  using is_invocable_r = std::is_invocable_r<Types...>;
+  template <typename R, typename F, typename... Args>
+  inline constexpr bool is_invocable_r_v = std::is_invocable_r_v<R, F, Args...>;
+#elif ETL_USING_CPP11
+  namespace private_type_traits
+  {
+    template <typename R>
+    void accept(R);
+
+    template <typename, typename R, typename F, typename... Args>
+    struct is_invocable_r_impl : etl::false_type
+    {
+    };
+
+    template <typename F, typename... Args>
+    struct is_invocable_r_impl<
+      decltype(etl::declval<F>()(etl::declval<Args>()...), void()),
+      void,
+      F,
+      Args...> : etl::true_type
+    {
+    };
+
+    template <typename F, typename... Args>
+    struct is_invocable_r_impl<
+      decltype(etl::declval<F>()(etl::declval<Args>()...), void()),
+      const void,
+      F,
+      Args...> : etl::true_type
+    {
+    };
+
+    template <typename R, typename F, typename... Args>
+    struct is_invocable_r_impl<
+      decltype(accept<R>(etl::declval<F>()(etl::declval<Args>()...))),
+      R,
+      F,
+      Args...> : etl::true_type
+    {
+    };
+  }  // namespace private_type_traits
+  template <typename R, typename F, typename... Args>
+  using is_invocable_r = private_type_traits::is_invocable_r_impl<void, R, F, Args...>;
+#if ETL_USING_CPP17
+  template <typename R, typename F, typename... Args>
+  inline constexpr bool is_invocable_r_v = is_invocable_r<R, F, Args...>::value;
+#endif
+#endif
 }
 
 // Helper macros

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -151,6 +151,7 @@ add_executable(etl_tests
 	test_histogram.cpp
 	test_indirect_vector.cpp
 	test_indirect_vector_external_buffer.cpp
+	test_inplace_function.cpp
 	test_instance_count.cpp
 	test_integral_limits.cpp
 	test_intrusive_forward_list.cpp

--- a/test/test_inplace_function.cpp
+++ b/test/test_inplace_function.cpp
@@ -1,0 +1,652 @@
+/******************************************************************************
+The MIT License(MIT)
+
+Embedded Template Library.
+https://github.com/ETLCPP/etl
+https://www.etlcpp.com
+
+Copyright(c) 2025 BMW AG
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files(the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions :
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+******************************************************************************/
+
+#include "unit_test_framework.h"
+
+#include "etl/inplace_function.h"
+
+#include <functional>
+
+#if ETL_USING_CPP14
+namespace
+{
+  void fooRef(int32_t& result)
+  {
+    result = 2;
+  }
+
+  int32_t foo0()
+  {
+    return 2;
+  }
+
+  int32_t foo1(float f)
+  {
+    return f;
+  }
+
+  int32_t foo2(float, int32_t g)
+  {
+    return g;
+  }
+
+  int32_t foo3(float, int32_t, int32_t h)
+  {
+    return h;
+  }
+
+  int32_t foo4(float, int32_t, int32_t, int32_t i)
+  {
+    return i;
+  }
+
+  int32_t foo5(float, int32_t, int32_t, int32_t, int32_t j)
+  {
+    return j;
+  }
+
+  struct Foo
+  {
+    int32_t foo0()
+    {
+      return 3;
+    }
+
+    int32_t foo1(float f)
+    {
+      return f;
+    }
+
+    int32_t foo2(float, int32_t g)
+    {
+      return g;
+    }
+
+    int32_t foo3(float, int32_t, int32_t h)
+    {
+      return h;
+    }
+
+    int32_t foo4(float, int32_t, int32_t, int32_t i)
+    {
+      return i;
+    }
+
+    int32_t foo5(float, int32_t, int32_t, int32_t, int32_t j)
+    {
+      return j;
+    }
+
+    static int32_t bar0()
+    {
+      return 5;
+    }
+
+    static int32_t bar1(float f)
+    {
+      return f;
+    }
+
+    static int32_t bar2(float, int32_t g)
+    {
+      return g;
+    }
+
+    static int32_t bar3(float, int32_t, int32_t h)
+    {
+      return h;
+    }
+
+    static int32_t bar4(float, int32_t, int32_t, int32_t i)
+    {
+      return i;
+    }
+
+    static int32_t bar5(float, int32_t, int32_t, int32_t, int32_t j)
+    {
+      return j;
+    }
+  };
+
+  struct Bar0
+  {
+    int32_t operator()() const
+    {
+      return 7;
+    }
+  };
+
+  struct Bar1
+  {
+    int32_t operator()(float f) const
+    {
+      return f;
+    }
+  };
+
+  struct Bar2
+  {
+    int32_t operator()(float, int32_t g) const
+    {
+      return g;
+    }
+  };
+
+  struct Bar3
+  {
+    int32_t operator()(float, int32_t, int32_t h) const
+    {
+      return h;
+    }
+  };
+
+  struct Bar4
+  {
+    int32_t operator()(float, int32_t, int32_t, int32_t i) const
+    {
+      return i;
+    }
+  };
+
+  struct Bar5
+  {
+    int32_t operator()(float, int32_t, int32_t, int32_t, int32_t j) const
+    {
+      return j;
+    }
+  };
+
+  struct BarV
+  {
+    int32_t _m;
+
+    int32_t operator()()
+    {
+      _m++;
+      return _m + 7;
+    }
+
+    int32_t operator()(int32_t f) const
+    {
+      return _m + f;
+    }
+
+    int32_t operator()(int32_t, int32_t g) const
+    {
+      return _m + g;
+    }
+
+    int32_t operator()(int32_t, int32_t, int32_t h) const
+    {
+      return _m + h;
+    }
+
+    int32_t operator()(int32_t, int32_t, int32_t, int32_t i) const
+    {
+      return _m + i;
+    }
+
+    int32_t operator()(int32_t, int32_t, int32_t, int32_t, int32_t j) const
+    {
+      return _m + j;
+    }
+  };
+
+  struct IntClass
+  {
+    IntClass()
+      : i(10)
+    {
+    }
+
+    int32_t i;
+  };
+}  // namespace
+
+namespace
+{
+  SUITE(test_inplace_function)
+  {
+    TEST(DefaultConstructed)
+    {
+      etl::inplace_function<IntClass()> f;
+      CHECK_EQUAL(10, f().i);
+
+      etl::inplace_function<IntClass(IntClass)> f1;
+      IntClass                                  a1;
+      CHECK_EQUAL(10, f1(a1).i);
+
+      etl::inplace_function<IntClass(IntClass, IntClass)> f2;
+      IntClass                                            a2;
+      CHECK_EQUAL(10, f2(a1, a2).i);
+
+      etl::inplace_function<IntClass(IntClass, IntClass)> f2_copy;
+
+      f2_copy = f2;
+      CHECK_EQUAL(10, f2_copy(a1, a2).i);
+
+      etl::inplace_function<IntClass(IntClass, IntClass, IntClass)> f3;
+      IntClass                                                      a3;
+      CHECK_EQUAL(10, f3(a1, a2, a3).i);
+
+      etl::inplace_function<IntClass(IntClass, IntClass, IntClass, IntClass)> f4;
+      IntClass                                                                a4;
+      CHECK_EQUAL(10, f4(a1, a2, a3, a4).i);
+
+      etl::inplace_function<IntClass(IntClass, IntClass, IntClass, IntClass, IntClass)> f5;
+      IntClass                                                                          a5;
+      CHECK_EQUAL(10, f5(a1, a2, a3, a4, a5).i);
+    }
+
+    TEST(OperatorBool)
+    {
+      etl::inplace_function<int32_t()>                                          f0;
+      etl::inplace_function<int32_t(float)>                                     f1;
+      etl::inplace_function<int32_t(float, int32_t)>                            f2;
+      etl::inplace_function<int32_t(float, int32_t, int32_t)>                   f3;
+      etl::inplace_function<int32_t(float, int32_t, int32_t, int32_t)>          f4;
+      etl::inplace_function<int32_t(float, int32_t, int32_t, int32_t, int32_t)> f5;
+
+      CHECK_FALSE(f0);
+      CHECK_FALSE(f1);
+      CHECK_FALSE(f2);
+      CHECK_FALSE(f3);
+      CHECK_FALSE(f4);
+      CHECK_FALSE(f5);
+
+      f0 = etl::inplace_function<int32_t()>(&Foo::bar0);
+      f1 = etl::inplace_function<int32_t(float)>(&Foo::bar1);
+      f2 = etl::inplace_function<int32_t(float, int32_t)>(&Foo::bar2);
+      f3 = etl::inplace_function<int32_t(float, int32_t, int32_t)>(&Foo::bar3);
+      f4 = etl::inplace_function<int32_t(float, int32_t, int32_t, int32_t)>(&Foo::bar4);
+      f5 = etl::inplace_function<int32_t(float, int32_t, int32_t, int32_t, int32_t)>(&Foo::bar5);
+
+      CHECK(f0);
+      CHECK(f1);
+      CHECK(f2);
+      CHECK(f3);
+      CHECK(f4);
+      CHECK(f5);
+    }
+
+    TEST(HasValue)
+    {
+      etl::inplace_function<int32_t()>                                          f0;
+      etl::inplace_function<int32_t(float)>                                     f1;
+      etl::inplace_function<int32_t(float, int32_t)>                            f2;
+      etl::inplace_function<int32_t(float, int32_t, int32_t)>                   f3;
+      etl::inplace_function<int32_t(float, int32_t, int32_t, int32_t)>          f4;
+      etl::inplace_function<int32_t(float, int32_t, int32_t, int32_t, int32_t)> f5;
+
+      CHECK_FALSE(f0);
+      CHECK_FALSE(f1);
+      CHECK_FALSE(f2);
+      CHECK_FALSE(f3);
+      CHECK_FALSE(f4);
+      CHECK_FALSE(f5);
+
+      f0 = etl::inplace_function<int32_t()>(&Foo::bar0);
+      f1 = etl::inplace_function<int32_t(float)>(&Foo::bar1);
+      f2 = etl::inplace_function<int32_t(float, int32_t)>(&Foo::bar2);
+      f3 = etl::inplace_function<int32_t(float, int32_t, int32_t)>(&Foo::bar3);
+      f4 = etl::inplace_function<int32_t(float, int32_t, int32_t, int32_t)>(&Foo::bar4);
+      f5 = etl::inplace_function<int32_t(float, int32_t, int32_t, int32_t, int32_t)>(&Foo::bar5);
+
+      CHECK(f0);
+      CHECK(f1);
+      CHECK(f2);
+      CHECK(f3);
+      CHECK(f4);
+      CHECK(f5);
+    }
+
+    TEST(TestFreeFunctionZeroParams)
+    {
+      etl::inplace_function<int32_t()> f = etl::inplace_function<int32_t()>(&foo0);
+      CHECK_EQUAL(2, f());
+    }
+
+    TEST(TestMemberFunctionZeroParams)
+    {
+      Foo                              foo;
+      etl::inplace_function<int32_t()> f = std::bind(&Foo::foo0, &foo);
+      CHECK_EQUAL(3, f());
+    }
+
+    TEST(TestStaticMemberFunctionZeroParams)
+    {
+      etl::inplace_function<int32_t()> f = etl::inplace_function<int32_t()>(&Foo::bar0);
+      CHECK_EQUAL(5, f());
+    }
+
+    TEST(TestFunctorZeroParams)
+    {
+      Bar0                             bar;
+      etl::inplace_function<int32_t()> f(bar);
+      CHECK_EQUAL(7, f());
+    }
+
+    TEST(TestLambdaParameter)
+    {
+      auto callme = [](etl::inplace_function<int32_t()> f)
+      { return f(); };
+      auto f = []()
+      { return 112358; };
+      CHECK_EQUAL(112358, callme(f));
+    }
+
+    TEST(TestFreeFunctionOneParam)
+    {
+      etl::inplace_function<int32_t(float)> f = &foo1;
+      CHECK_EQUAL(2, f(2.14));
+    }
+
+    TEST(TestFreeFunctionOneParamVoid)
+    {
+      etl::inplace_function<void(int32_t&)> f = &fooRef;
+      int32_t                               result = 0;
+      f(result);
+      CHECK_EQUAL(2, result);
+    }
+
+    TEST(TestMemberFunctionOneParam)
+    {
+      Foo                                   foo;
+      etl::inplace_function<int32_t(float)> f =
+        std::bind(&Foo::foo1, &foo, std::placeholders::_1);
+      CHECK_EQUAL(3, f(3.14));
+    }
+
+    TEST(TestStaticMemberFunctionOneParam)
+    {
+      etl::inplace_function<int32_t(float)> f = &Foo::bar1;
+      CHECK_EQUAL(5, f(5.75));
+    }
+
+    TEST(TestFunctorOneParam)
+    {
+      Bar1                                  bar;
+      etl::inplace_function<int32_t(float)> f = bar;
+      CHECK_EQUAL(7, f(7.65));
+    }
+
+    TEST(TestFreeFunctionTwoParams)
+    {
+      etl::inplace_function<int32_t(float, int32_t)> f = &foo2;
+      CHECK_EQUAL(2, f(2.14, 2));
+    }
+
+    TEST(TestMemberFunctionTwoParams)
+    {
+      Foo                                            foo;
+      etl::inplace_function<int32_t(float, int32_t)> f =
+        std::bind(&Foo::foo2, &foo, std::placeholders::_1, std::placeholders::_2);
+      CHECK_EQUAL(3, f(3.14, 3));
+    }
+
+    TEST(TestStaticMemberFunctionTwoParams)
+    {
+      etl::inplace_function<int32_t(float, int32_t)> f = &Foo::bar2;
+      CHECK_EQUAL(5, f(5.75, 5));
+    }
+
+    TEST(TestFunctorTwoParams)
+    {
+      Bar2                                           bar;
+      etl::inplace_function<int32_t(float, int32_t)> f = bar;
+      CHECK_EQUAL(7, f(7.65, 7));
+    }
+
+    TEST(TestFreeFunctionThreeParams)
+    {
+      etl::inplace_function<int32_t(float, int32_t, int32_t)> f = &foo3;
+      CHECK_EQUAL(4, f(2.14, 2, 4));
+    }
+
+    TEST(TestMemberFunctionThreeParams)
+    {
+      Foo                                                     foo;
+      etl::inplace_function<int32_t(float, int32_t, int32_t)> f =
+        [e = &foo](float p0, int32_t p1, int32_t p2)
+      { return e->foo3(p0, p1, p2); };
+      CHECK_EQUAL(120, f(3.14, 3, 120));
+    }
+
+    TEST(TestStaticMemberFunctionThreeParams)
+    {
+      etl::inplace_function<int32_t(float, int32_t, int32_t)> f = &Foo::bar3;
+      CHECK_EQUAL(4, f(5.75, 5, 4));
+    }
+
+    TEST(TestFunctorThreeParams)
+    {
+      Bar3                                                    bar;
+      etl::inplace_function<int32_t(float, int32_t, int32_t)> f = bar;
+      CHECK_EQUAL(4, f(7.65, 7, 4));
+    }
+
+    TEST(TestFreeFunctionFourParams)
+    {
+      etl::inplace_function<int32_t(float, int32_t, int32_t, int32_t)> f = &foo4;
+      CHECK_EQUAL(5, f(2.14, 2, 4, 5));
+    }
+
+    TEST(TestStaticMemberFunctionFourParams)
+    {
+      etl::inplace_function<int32_t(float, int32_t, int32_t, int32_t)> f = &Foo::bar4;
+      CHECK_EQUAL(5, f(5.75, 5, 4, 5));
+    }
+
+    TEST(TestFunctorFourParams)
+    {
+      Bar4                                                             bar;
+      etl::inplace_function<int32_t(float, int32_t, int32_t, int32_t)> f = bar;
+      CHECK_EQUAL(5, f(7.65, 7, 4, 5));
+    }
+
+    TEST(TestFreeFunctionFiveParams)
+    {
+      etl::inplace_function<int32_t(float, int32_t, int32_t, int32_t, int32_t)> f = &foo5;
+      CHECK_EQUAL(7, f(2.14, 2, 4, 5, 7));
+    }
+
+    TEST(TestStaticMemberFunctionFiveParams)
+    {
+      etl::inplace_function<int32_t(float, int32_t, int32_t, int32_t, int32_t)> f = &Foo::bar5;
+      CHECK_EQUAL(8, f(5.75, 5, 4, 5, 8));
+    }
+
+    TEST(TestFunctorFiveParams)
+    {
+      Bar5                                                                      bar;
+      etl::inplace_function<int32_t(float, int32_t, int32_t, int32_t, int32_t)> f =
+        bar;
+      CHECK_EQUAL(8, f(7.65, 7, 4, 5, 8));
+    }
+
+    TEST(CopyConstructorZeroParams)
+    {
+      {
+        etl::inplace_function<int32_t()> f = &foo0;
+        etl::inplace_function<int32_t()> g(f);
+        CHECK_EQUAL(2, f());
+        CHECK_EQUAL(2, g());
+      }
+      {
+        Foo                              foo;
+        etl::inplace_function<int32_t()> f = [e = &foo]
+        { return e->foo0(); };
+        etl::inplace_function<int32_t()> g(f);
+        CHECK_EQUAL(3, f());
+        CHECK_EQUAL(3, g());
+      }
+      {
+        etl::inplace_function<int32_t()> f = &Foo::bar0;
+        etl::inplace_function<int32_t()> g = f;
+        CHECK_EQUAL(5, f());
+        CHECK_EQUAL(5, g());
+      }
+      {
+        Bar0                             bar;
+        etl::inplace_function<int32_t()> f = bar;
+        etl::inplace_function<int32_t()> g = f;
+        CHECK_EQUAL(7, f());
+        CHECK_EQUAL(7, g());
+      }
+    }
+
+    TEST(AssignmentOperatorZeroParams)
+    {
+      {
+        etl::inplace_function<int32_t()> f = &foo0, g;
+        g = f;
+        CHECK_EQUAL(2, f());
+        CHECK_EQUAL(2, g());
+      }
+      {
+        Foo                              foo;
+        etl::inplace_function<int32_t()> f = [e = &foo]
+        { return e->foo0(); },
+                                         g;
+        g = f;
+        CHECK_EQUAL(3, f());
+        CHECK_EQUAL(3, g());
+      }
+      {
+        etl::inplace_function<int32_t()> f = &Foo::bar0, g;
+        g = f;
+        CHECK_EQUAL(5, f());
+        CHECK_EQUAL(5, g());
+      }
+      {
+        Bar0                             bar;
+        etl::inplace_function<int32_t()> f = bar, g;
+        g = f;
+        CHECK_EQUAL(7, f());
+        CHECK_EQUAL(7, g());
+      }
+    }
+
+    class Const
+    {
+      int32_t _i;
+
+    public:
+      Const(int32_t i)
+        : _i(i)
+      {
+      }
+
+      int32_t get0() const
+      {
+        return _i;
+      }
+
+      int32_t get0_b() const
+      {
+        return _i * 2;
+      }
+
+      int32_t get1(Const&) const
+      {
+        return _i;
+      }
+
+      int32_t get1NotConst(Const const&) const
+      {
+        return _i;
+      }
+
+      int32_t get2(Const const&, Const const&) const
+      {
+        return _i;
+      }
+
+      int32_t get3(Const const&, Const const&, Const const&) const
+      {
+        return _i;
+      }
+
+      int32_t get4(Const const&, Const const&, Const const&, Const const&) const
+      {
+        return _i;
+      }
+
+      int32_t get5(Const const&, Const const&, Const const&, Const const&, Const const&) const
+      {
+        return _i;
+      }
+    };
+    TEST(ConstMemberFunction)
+    {
+      Const                            i(17);
+      etl::inplace_function<int32_t()> f = [e = &i]
+      { return e->get0(); };
+      CHECK_EQUAL(17, f());
+
+      Const const&                     c = i;
+      etl::inplace_function<int32_t()> f2 = [e = &c]
+      { return e->get0(); };
+      CHECK_EQUAL(17, f2());
+
+      etl::inplace_function<int32_t(Const&)> f3 = [e = &c](Const& p0)
+      { return e->get1(p0); };
+      CHECK_EQUAL(17, f3(i));
+
+      etl::inplace_function<int32_t(Const const&)> f3NotConst =
+        [e = &i](Const const& p0)
+      { return e->get1NotConst(p0); };
+      CHECK_EQUAL(17, f3NotConst(i));
+
+      etl::inplace_function<int32_t(Const const&, Const const&)> f4 =
+        [e = &c](Const const& p0, Const const& p1)
+      { return e->get2(p0, p1); };
+      CHECK_EQUAL(17, f4(i, i));
+      CHECK_EQUAL(17, f4(c, c));
+
+      etl::inplace_function<int32_t(Const const&, Const const&, Const const&)> f5 =
+        [e = &c](Const const& p0, Const const& p1, Const const& p2)
+      { return e->get3(p0, p1, p2); };
+      CHECK_EQUAL(17, f5(i, i, i));
+      CHECK_EQUAL(17, f5(c, c, c));
+
+      etl::inplace_function<int32_t(Const const&, Const const&, Const const&, Const const&)> f6 = etl::inplace_function<int32_t(Const const&, Const const&, Const const&, Const const&)>([e = &c](Const const& p0, Const const& p1, Const const& p2, Const const& p3)
+                                                                                                                                                                                         { return e->get4(p0, p1, p2, p3); });
+      CHECK_EQUAL(17, f6(i, i, i, i));
+      CHECK_EQUAL(17, f6(c, c, c, c));
+
+      etl::inplace_function<int32_t(Const const&, Const const&, Const const&, Const const&, Const const&)>
+        f7 = [e = &c](Const const& p0, Const const& p1, Const const& p2, Const const& p3, Const const& p4)
+      { return e->get5(p0, p1, p2, p3, p4); };
+      CHECK_EQUAL(17, f7(i, i, i, i, i));
+      CHECK_EQUAL(17, f7(c, c, c, c, c));
+    }
+  }
+}  // namespace
+
+#endif

--- a/test/test_type_traits.cpp
+++ b/test/test_type_traits.cpp
@@ -1379,4 +1379,27 @@ namespace
     CHECK_EQUAL(2, (etl::count_of<char, int, char, double, char>::value));
 #endif
   }
+#if ETL_USING_CPP11
+  TEST(test_is_invocable_r)
+  {
+    auto func2 = [](char) -> int (*)()
+    {
+      return nullptr;
+    };
+#if ETL_USING_CPP17
+    CHECK_TRUE((etl::is_invocable_r_v<int, int()>));
+    CHECK_TRUE((etl::is_invocable_r_v<void, void(int), int>));
+    CHECK_TRUE((etl::is_invocable_r_v<int(*)(), decltype(func2), char>));
+    CHECK_FALSE((etl::is_invocable_r_v<int*, int()>));
+    CHECK_FALSE((etl::is_invocable_r_v<void, void(int), void>));
+    CHECK_FALSE((etl::is_invocable_r_v<int(*)(), decltype(func2), void>));
+#endif
+    CHECK_TRUE((etl::is_invocable_r<int, int()>::value));
+    CHECK_TRUE((etl::is_invocable_r<void, void(int), int>::value));
+    CHECK_TRUE((etl::is_invocable_r<int(*)(), decltype(func2), char>::value));
+    CHECK_FALSE((etl::is_invocable_r<int*, int()>::value));
+    CHECK_FALSE((etl::is_invocable_r<void, void(int), void>::value));
+    CHECK_FALSE((etl::is_invocable_r<int(*)(), decltype(func2), void>::value));
+  }
+#endif
 }


### PR DESCRIPTION
Provide similar api to std::function.

Current use case is mainly to hold a r-value lambda object, which etl::delegate is unsuitable since etl::delegate does not extend the lifetime of r-value lambda object.

Store a callable inside the inplace_function object's member field in a type-erasure way.
The member field, i.e. storage or buffer, has a compile-time fixed size.
The size is specified either by the macro ETL_INPLACE_FUNCTION_DEFAULT_CAPACITY or a non-type template parameter.

The implementation is inspired by:
1. SG14 inplace_function
2. folly::Function
3. function2