### PR TITLE
Support chrono.h

### DIFF
--- a/include/etl/chrono.h
+++ b/include/etl/chrono.h
@@ -1,0 +1,577 @@
+/******************************************************************************
+The MIT License(MIT)
+
+Embedded Template Library.
+https://github.com/ETLCPP/etl
+https://www.etlcpp.com
+
+Copyright(c) 2025 BMW AG
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files(the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions :
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+******************************************************************************/
+
+#ifndef ETL_CHRONO_INCLUDED
+#define ETL_CHRONO_INCLUDED
+
+#include "platform.h"
+#include "limits.h"
+#include "ratio.h"
+#include "stdint.h"
+#include "type_traits.h"
+
+//*****************************************************************************
+///\defgroup chrono chrono
+/// Provides functionalities of std::chrono
+///\ingroup utilities
+//*****************************************************************************
+namespace etl
+{
+  namespace chrono
+  {
+    template <typename Rep, typename Period = ratio<1>>
+    struct duration;
+
+    template <typename Clock, typename Dur = typename Clock::duration>
+    struct time_point;
+
+    namespace private_chrono
+    {
+      template <typename T>
+      struct is_duration_impl : false_type
+      {
+      };
+
+      template <typename Rep, typename Period>
+      struct is_duration_impl<duration<Rep, Period>> : true_type
+      {
+      };
+
+      template <typename T>
+      struct is_duration : is_duration_impl<typename decay<T>::type>
+      {
+      };
+
+      template <typename FromDuration,
+                typename ToDuration,
+                typename Period = ratio_divide<typename FromDuration::period,
+                                               typename ToDuration::period>,
+                bool = (Period::num == 1),
+                bool = (Period::den == 1)>
+      struct duration_cast_impl;
+
+      template <typename FromDuration, typename ToDuration, typename Period>
+      struct duration_cast_impl<FromDuration, ToDuration, Period, true, true>
+      {
+        static ETL_CONSTEXPR ToDuration cast(const FromDuration& dur)
+        {
+          return ToDuration(static_cast<typename ToDuration::rep>(dur.count()));
+        }
+      };
+
+      template <typename FromDuration, typename ToDuration, typename Period>
+      struct duration_cast_impl<FromDuration, ToDuration, Period, true, false>
+      {
+        static ETL_CONSTEXPR ToDuration cast(const FromDuration& dur)
+        {
+          using Ct = typename common_type<typename ToDuration::rep, typename FromDuration::rep, intmax_t>::type;
+          return ToDuration(
+            static_cast<typename ToDuration::rep>(static_cast<Ct>(dur.count()) / static_cast<Ct>(Period::den)));
+        }
+      };
+
+      template <typename FromDuration, typename ToDuration, typename Period>
+      struct duration_cast_impl<FromDuration, ToDuration, Period, false, true>
+      {
+        static ETL_CONSTEXPR ToDuration cast(const FromDuration& dur)
+        {
+          using Ct = typename common_type<typename ToDuration::rep, typename FromDuration::rep, intmax_t>::type;
+          return ToDuration(
+            static_cast<typename ToDuration::rep>(static_cast<Ct>(dur.count()) * static_cast<Ct>(Period::num)));
+        }
+      };
+
+      template <typename FromDuration, typename ToDuration, typename Period>
+      struct duration_cast_impl<FromDuration, ToDuration, Period, false, false>
+      {
+        static ETL_CONSTEXPR ToDuration cast(const FromDuration& dur)
+        {
+          using Ct = typename common_type<typename ToDuration::rep, typename FromDuration::rep, intmax_t>::type;
+          return ToDuration(static_cast<typename ToDuration::rep>(
+            static_cast<Ct>(dur.count()) * static_cast<Ct>(Period::num) / static_cast<Ct>(Period::den)));
+        }
+      };
+    }  // namespace private_chrono
+
+    template <typename ToDuration, typename Rep, typename Period, typename enable_if<private_chrono::is_duration<ToDuration>::value, int>::type = 0>
+    ETL_CONSTEXPR ToDuration duration_cast(const duration<Rep, Period>& dur)
+    {
+      return private_chrono::duration_cast_impl<duration<Rep, Period>, ToDuration>::cast(dur);
+    }
+  }  // namespace chrono
+
+  template <typename Rep1, typename Period1, typename Rep2, typename Period2>
+  struct common_type<chrono::duration<Rep1, Period1>, chrono::duration<Rep2, Period2>>
+  {
+    using type = chrono::duration<typename common_type<Rep1, Rep2>::type,
+                                  ratio<
+                                    private_ratio::ratio_gcd<intmax_t, Period1::num, Period2::num>::value,
+                                    private_ratio::ratio_lcm<intmax_t, Period1::den, Period2::den>::value>>;
+  };
+
+  template <typename Clock, typename Dur1, typename Dur2>
+  struct common_type<chrono::time_point<Clock, Dur1>, chrono::time_point<Clock, Dur2>>
+  {
+    using type = chrono::time_point<Clock, typename common_type<Dur1, Dur2>::type>;
+  };
+
+  namespace chrono
+  {
+    template <typename Rep>
+    struct duration_values
+    {
+      static Rep ETL_CONSTEXPR zero() ETL_NOEXCEPT
+      {
+        return Rep(0);
+      };
+
+      static Rep ETL_CONSTEXPR min() ETL_NOEXCEPT
+      {
+        return numeric_limits<Rep>::lowest();
+      }
+
+      static Rep ETL_CONSTEXPR max() ETL_NOEXCEPT
+      {
+        return numeric_limits<Rep>::max();
+      }
+    };
+
+    template <typename Rep, typename Period>
+    struct duration
+    {
+      using rep = Rep;
+      using period = Period;
+
+      ETL_CONSTEXPR duration()
+        : val(0)
+      {
+      }
+
+      duration(duration const& rhs)
+        : val(rhs.val)
+      {
+      }
+
+      template <typename Rep2, typename enable_if<is_convertible<const Rep2&, rep>::value && (is_floating_point<rep>::value || !is_floating_point<Rep2>::value), int>::type = 0>
+      ETL_CONSTEXPR explicit duration(Rep2 const& rhs)
+        : val(rhs)
+      {
+      }
+
+      template <typename Rep2, typename Period2>
+      ETL_CONSTEXPR duration(duration<Rep2, Period2> const& dur)
+        : val(
+            duration_cast<
+              typename enable_if<(ratio_divide<Period2, Period>::den == 1), duration<Rep, Period>>::type>(
+              dur)
+              .count())
+      {
+      }
+
+      duration& operator=(duration const& rhs)
+      {
+        val = rhs.val;
+        return *this;
+      }
+
+      ETL_CONSTEXPR rep count() const
+      {
+        return val;
+      }
+
+      ETL_CONSTEXPR duration operator+() const
+      {
+        return *this;
+      }
+
+      ETL_CONSTEXPR duration operator-() const
+      {
+        return duration(-val);
+      }
+
+      duration& operator++()
+      {
+        ++val;
+        return *this;
+      }
+
+      duration operator++(int)
+      {
+        duration ret = *this;
+        ++val;
+        return ret;
+      }
+
+      duration& operator--()
+      {
+        --val;
+        return *this;
+      }
+
+      duration operator--(int)
+      {
+        duration ret = *this;
+        --val;
+        return ret;
+      }
+
+      duration& operator+=(duration const& rhs)
+      {
+        val += rhs.count();
+        return *this;
+      }
+
+      duration& operator-=(duration const& rhs)
+      {
+        val -= rhs.count();
+        return *this;
+      }
+
+      duration& operator*=(rep const& r)
+      {
+        val *= r;
+        return *this;
+      }
+
+      duration& operator/=(rep const& rhs)
+      {
+        val /= rhs;
+        return *this;
+      }
+
+      duration& operator%=(rep const& rhs)
+      {
+        val %= rhs;
+        return *this;
+      }
+
+      duration& operator%=(duration const& rhs)
+      {
+        val %= rhs.count();
+        return *this;
+      }
+
+      static ETL_CONSTEXPR duration zero() ETL_NOEXCEPT
+      {
+        return duration<Rep, Period>(duration_values<Rep>::zero());
+      }
+
+      static ETL_CONSTEXPR duration min() ETL_NOEXCEPT
+      {
+        return duration<Rep, Period>(duration_values<Rep>::min());
+      }
+
+      static ETL_CONSTEXPR duration max() ETL_NOEXCEPT
+      {
+        return duration<Rep, Period>(duration_values<Rep>::max());
+      }
+
+    private:
+      Rep val;
+    };
+
+    template <typename Rep1, typename Period1, typename Rep2, typename Period2>
+    typename common_type<duration<Rep1, Period1>, duration<Rep2, Period2>>::type
+    operator+(duration<Rep1, Period1> const& lhs, duration<Rep2, Period2> const& rhs)
+    {
+      using cd_t = typename common_type<duration<Rep1, Period1>, duration<Rep2, Period2>>::type;
+      return cd_t(cd_t(lhs).count() + cd_t(rhs).count());
+    }
+
+    template <typename Rep1, typename Period1, typename Rep2, typename Period2>
+    typename common_type<duration<Rep1, Period1>, duration<Rep2, Period2>>::type
+    operator-(duration<Rep1, Period1> const& lhs, duration<Rep2, Period2> const& rhs)
+    {
+      using cd_t = typename common_type<duration<Rep1, Period1>, duration<Rep2, Period2>>::type;
+      return cd_t(cd_t(lhs).count() - cd_t(rhs).count());
+    }
+
+    template <typename Rep1, typename Period, typename Rep2>
+    duration<typename common_type<Rep1, Rep2>::type, Period>
+    operator*(duration<Rep1, Period> const& d, Rep2 const& r)
+    {
+      using cd_t = duration<typename common_type<Rep1, Rep2>::type, Period>;
+      return cd_t(cd_t(d).count() * r);
+    }
+
+    template <typename Rep1, typename Rep2, typename Period>
+    duration<typename common_type<Rep2, Rep1>::type, Period>
+    operator*(Rep1 const& r, duration<Rep2, Period> const& d)
+    {
+      return d * r;
+    }
+
+    template <typename Rep1, typename Period, typename Rep2>
+    duration<typename common_type<Rep1, Rep2>::type, Period>
+    operator/(duration<Rep1, Period> const& d, Rep2 const& r)
+    {
+      using cd_t = duration<typename common_type<Rep1, Rep2>::type, Period>;
+      return cd_t(cd_t(d).count() / r);
+    }
+
+    template <typename Rep1, typename Period1, typename Rep2, typename Period2>
+    typename common_type<Rep1, Rep2>::type
+    operator/(duration<Rep1, Period1> const& lhs, duration<Rep2, Period2> const& rhs)
+    {
+      using cd_t = typename common_type<duration<Rep1, Period1>, duration<Rep2, Period2>>::type;
+      return cd_t(lhs).count() / cd_t(rhs).count();
+    }
+
+    template <typename Rep1, typename Period, typename Rep2>
+    duration<typename common_type<Rep1, Rep2>::type, Period>
+    operator%(duration<Rep1, Period> const& d, Rep2 const& r)
+    {
+      using cd_t = duration<typename common_type<Rep1, Rep2>::type, Period>;
+      return cd_t(cd_t(d).count() % r);
+    }
+
+    template <typename Rep1, typename Period1, typename Rep2, typename Period2>
+    typename common_type<duration<Rep1, Period1>, duration<Rep2, Period2>>::type
+    operator%(duration<Rep1, Period1> const& lhs, duration<Rep2, Period2> const& rhs)
+    {
+      using cd_t = typename common_type<duration<Rep1, Period1>, duration<Rep2, Period2>>::type;
+      return cd_t(cd_t(lhs).count() % cd_t(rhs).count());
+    }
+
+    template <typename Rep1, typename Period1, typename Rep2, typename Period2>
+    bool operator==(duration<Rep1, Period1> const& lhs, duration<Rep2, Period2> const& rhs)
+    {
+      using cd_t = typename common_type<duration<Rep1, Period1>, duration<Rep2, Period2>>::type;
+      return cd_t(lhs).count() == cd_t(rhs).count();
+    }
+
+    template <typename Rep1, typename Period1, typename Rep2, typename Period2>
+    bool operator!=(duration<Rep1, Period1> const& lhs, duration<Rep2, Period2> const& rhs)
+    {
+      return !(lhs == rhs);
+    }
+
+    template <typename Rep1, typename Period1, typename Rep2, typename Period2>
+    bool operator<(duration<Rep1, Period1> const& lhs, duration<Rep2, Period2> const& rhs)
+    {
+      using cd_t = typename common_type<duration<Rep1, Period1>, duration<Rep2, Period2>>::type;
+      return cd_t(lhs).count() < cd_t(rhs).count();
+    }
+
+    template <typename Rep1, typename Period1, typename Rep2, typename Period2>
+    bool operator<=(duration<Rep1, Period1> const& lhs, duration<Rep2, Period2> const& rhs)
+    {
+      return !(rhs < lhs);
+    }
+
+    template <typename Rep1, typename Period1, typename Rep2, typename Period2>
+    bool operator>(duration<Rep1, Period1> const& lhs, duration<Rep2, Period2> const& rhs)
+    {
+      return rhs < lhs;
+    }
+
+    template <typename Rep1, typename Period1, typename Rep2, typename Period2>
+    bool operator>=(duration<Rep1, Period1> const& lhs, duration<Rep2, Period2> const& rhs)
+    {
+      return !(lhs < rhs);
+    }
+
+    using nanoseconds = duration<int64_t, nano>;
+    using microseconds = duration<int64_t, micro>;
+    using milliseconds = duration<int64_t, milli>;
+    using seconds = duration<int64_t>;
+    using minutes = duration<int32_t, ratio<60>>;
+    using hours = duration<int32_t, ratio<3600>>;
+    template <typename Clock, typename Dur>
+    struct time_point
+    {
+      using clock = Clock;
+      using duration = Dur;
+      using rep = typename duration::rep;
+      using period = typename duration::period;
+
+      ETL_CONSTEXPR time_point()
+        : dur(duration::zero())
+      {
+      }
+
+      ETL_CONSTEXPR explicit time_point(duration const& d)
+        : dur(d)
+      {
+      }
+
+      ETL_CONSTEXPR time_point(time_point const& rhs)
+        : dur(rhs.dur)
+      {
+      }
+
+      template <typename Dur2>
+      explicit time_point(time_point<Clock, Dur2> const& rhs)
+        : dur(rhs.time_since_epoch())
+      {
+      }
+
+      time_point& operator=(time_point const& rhs)
+      {
+        dur = rhs.dur;
+        return *this;
+      }
+
+      ETL_CONSTEXPR duration time_since_epoch() const
+      {
+        return dur;
+      }
+
+      time_point& operator+=(duration const& rhs)
+      {
+        dur += rhs;
+        return *this;
+      }
+
+      time_point& operator-=(duration const& rhs)
+      {
+        dur -= rhs;
+        return *this;
+      }
+
+      static ETL_CONSTEXPR time_point min() ETL_NOEXCEPT
+      {
+        return time_point(duration::min());
+      }
+
+      static ETL_CONSTEXPR time_point max() ETL_NOEXCEPT
+      {
+        return time_point(duration::max());
+      }
+
+    private:
+      duration dur;
+    };
+
+    template <typename ToDur, typename Clock, typename Dur>
+    time_point<Clock, ToDur> time_point_cast(time_point<Clock, Dur> const& tp)
+    {
+      using time_point_t =
+        typename enable_if<private_chrono::is_duration<ToDur>::value, time_point<Clock, ToDur>>::type;
+      return time_point_t(duration_cast<ToDur>(tp.time_since_epoch()));
+    }
+
+    template <typename Clock, typename Dur1, typename Rep2, typename Period2>
+    time_point<Clock, typename common_type<Dur1, duration<Rep2, Period2>>::type>
+    operator+(time_point<Clock, Dur1> const& lhs, duration<Rep2, Period2> const& rhs)
+    {
+      using ct_t = typename common_type<Dur1, duration<Rep2, Period2>>::type;
+      using time_point_t = time_point<Clock, ct_t>;
+      return time_point_t(lhs.time_since_epoch() + rhs);
+    }
+
+    template <typename Rep1, typename Period1, typename Clock, typename Dur2>
+    time_point<Clock, typename common_type<duration<Rep1, Period1>, Dur2>::type>
+    operator+(duration<Rep1, Period1> const& lhs, time_point<Clock, Dur2> const& rhs)
+    {
+      return rhs + lhs;
+    }
+
+    template <typename Clock, typename Dur1, typename Rep2, typename Period2>
+    time_point<Clock, typename common_type<Dur1, duration<Rep2, Period2>>::type>
+    operator-(time_point<Clock, Dur1> const& lhs, duration<Rep2, Period2> const& rhs)
+    {
+      using ct_t = typename common_type<Dur1, duration<Rep2, Period2>>::type;
+      using time_point_t = time_point<Clock, ct_t>;
+      return time_point_t(lhs.time_since_epoch() - rhs);
+    }
+
+    template <typename Clock, typename Dur1, typename Dur2>
+    typename common_type<Dur1, Dur2>::type
+    operator-(time_point<Clock, Dur1> const& lhs, time_point<Clock, Dur2> const& rhs)
+    {
+      return lhs.time_since_epoch() - rhs.time_since_epoch();
+    }
+
+    //***************************************************************************
+    ///\brief C function supporting etl::chrono::high_resolution_clock
+    ///
+    /// Users of etl::chrono::high_resolution_clock should provide the definition
+    /// of this function.
+    /// etl::chrono::high_resolution_clock depends on it to get time points.
+    /// It should model a std::chrono::steady_clock .
+    ///
+    ///\return current time in nanosecond
+    //***************************************************************************
+    extern "C" uint64_t etl_get_system_time_nanosec();
+
+    class high_resolution_clock
+    {
+    public:
+      using duration = nanoseconds;
+      using rep = duration::rep;
+      using period = duration::period;
+      using time_point = chrono::time_point<high_resolution_clock, duration>;
+
+      static bool ETL_CONSTANT is_steady = true;
+
+      static time_point now() ETL_NOEXCEPT
+      {
+        return time_point(duration(static_cast<int64_t>(etl_get_system_time_nanosec())));
+      }
+    };
+
+    template <typename Clock, typename Dur1, typename Dur2>
+    bool operator==(time_point<Clock, Dur1> const& lhs, time_point<Clock, Dur2> const& rhs)
+    {
+      return lhs.time_since_epoch() == rhs.time_since_epoch();
+    }
+
+    template <typename Clock, typename Dur1, typename Dur2>
+    bool operator!=(time_point<Clock, Dur1> const& lhs, time_point<Clock, Dur2> const& rhs)
+    {
+      return !(lhs == rhs);
+    }
+
+    template <typename Clock, typename Dur1, typename Dur2>
+    bool operator<(time_point<Clock, Dur1> const& lhs, time_point<Clock, Dur2> const& rhs)
+    {
+      return lhs.time_since_epoch() < rhs.time_since_epoch();
+    }
+
+    template <typename Clock, typename Dur1, typename Dur2>
+    bool operator<=(time_point<Clock, Dur1> const& lhs, time_point<Clock, Dur2> const& rhs)
+    {
+      return !(rhs < lhs);
+    }
+
+    template <typename Clock, typename Dur1, typename Dur2>
+    bool operator>(time_point<Clock, Dur1> const& lhs, time_point<Clock, Dur2> const& rhs)
+    {
+      return rhs < lhs;
+    }
+
+    template <typename Clock, typename Dur1, typename Dur2>
+    bool operator>=(time_point<Clock, Dur1> const& lhs, time_point<Clock, Dur2> const& rhs)
+    {
+      return !(lhs < rhs);
+    }
+  }  // namespace chrono
+}  // namespace etl
+
+#endif

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -58,6 +58,7 @@ add_executable(etl_tests
 	test_callback_timer_locked.cpp
 	test_char_traits.cpp
 	test_checksum.cpp
+	test_chrono.cpp
 	test_circular_buffer.cpp
 	test_circular_buffer_external_buffer.cpp
 	test_circular_iterator.cpp

--- a/test/test_chrono.cpp
+++ b/test/test_chrono.cpp
@@ -1,0 +1,555 @@
+/******************************************************************************
+The MIT License(MIT)
+
+Embedded Template Library.
+https://github.com/ETLCPP/etl
+https://www.etlcpp.com
+
+Copyright(c) 2025 BMW AG
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files(the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions :
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+******************************************************************************/
+
+#include "unit_test_framework.h"
+
+#include "etl/chrono.h"
+
+#include <limits>
+#include <type_traits>
+
+namespace chrono = etl::chrono;
+
+static uint64_t currentTimeNs = 0;
+
+extern "C" uint64_t etl_get_system_time_nanosec()
+{
+  return currentTimeNs;
+}
+
+namespace chrono_test
+{
+  struct Clock
+  {
+    using duration = chrono::minutes;
+  };
+
+}  // namespace chrono_test
+
+namespace etl
+{
+  namespace chrono
+  {
+    template struct duration_values<int32_t>;
+    template struct duration<int32_t, etl::milli>;
+    template struct time_point<chrono_test::Clock, duration<int32_t, etl::milli>>;
+
+  }  // namespace chrono
+}  // namespace etl
+
+static_assert(
+  std::is_same<chrono_test::Clock::duration, chrono::time_point<chrono_test::Clock>::duration>::
+    value,
+  "");
+static_assert(
+  std::is_same<chrono::nanoseconds, chrono::high_resolution_clock::duration>::value, "");
+static_assert(
+  std::is_same<chrono::nanoseconds::rep, chrono::high_resolution_clock::rep>::value, "");
+static_assert(
+  std::is_same<chrono::nanoseconds::period, chrono::high_resolution_clock::period>::value, "");
+
+namespace
+{
+  SUITE(test_chrono)
+  {
+    TEST(TetlurationCast)
+    {
+      chrono::duration<int32_t, etl::milli> src(1001);
+      {
+        chrono::duration<int32_t, etl::micro> cut = chrono::duration_cast<chrono::duration<int32_t, etl::micro>>(src);
+        CHECK_EQUAL(1001000, cut.count());
+      }
+      {
+        chrono::duration<int32_t, etl::centi> cut = chrono::duration_cast<const chrono::duration<int32_t, etl::centi>>(src);
+        CHECK_EQUAL(100, cut.count());
+      }
+      {
+        chrono::duration<int16_t, etl::centi> cut = chrono::duration_cast<chrono::duration<int16_t, etl::centi>>(src);
+        CHECK_EQUAL(100, cut.count());
+      }
+      {
+        chrono::duration<int32_t, etl::milli> cut = chrono::duration_cast<const chrono::duration<int32_t, etl::milli>>(src);
+        CHECK_EQUAL(1001, cut.count());
+      }
+      {
+        chrono::duration<int32_t, etl::ratio<2, 15>> cut = chrono::duration_cast<chrono::duration<int32_t, etl::ratio<2, 15>>>(
+          chrono::duration<int32_t, etl::ratio<3, 10>>(4));
+        CHECK_EQUAL(9, cut.count());
+      }
+    }
+
+    TEST(TetlurationConstructors)
+    {
+      {
+        chrono::duration<int16_t, etl::milli> cut;
+        CHECK_EQUAL(0, cut.count());
+      }
+      {
+        chrono::duration<int32_t, etl::nano> cut(1000);
+        CHECK_EQUAL(1000, cut.count());
+      }
+      {
+        chrono::duration<int32_t, etl::micro> src(1000);
+        chrono::duration<int32_t, etl::micro> cut(src);
+        CHECK_EQUAL(1000, cut.count());
+      }
+      {
+        chrono::duration<int64_t, etl::micro> src(1000);
+        chrono::duration<int64_t, etl::nano>  cut(src);
+        CHECK_EQUAL(1000000, cut.count());
+      }
+    }
+
+    TEST(TetlurationAssignment)
+    {
+      chrono::duration<int32_t, etl::milli> src(1000);
+      chrono::duration<int32_t, etl::milli> cut;
+      cut = src;
+      CHECK_EQUAL(1000, cut.count());
+    }
+
+    TEST(TetlurationUnaryPlusMinusOperators)
+    {
+      chrono::duration<int32_t, etl::milli> cut(1000);
+      CHECK_EQUAL(1000, (+cut).count());
+      CHECK_EQUAL(-1000, (-cut).count());
+    }
+
+    TEST(TetlurationIncrementDecrementOperators)
+    {
+      chrono::duration<int32_t, etl::milli> cut(1000);
+      CHECK_EQUAL(1001, (++cut).count());
+      CHECK_EQUAL(1001, cut.count());
+      CHECK_EQUAL(1000, (--cut).count());
+      CHECK_EQUAL(1000, cut.count());
+
+      CHECK_EQUAL(1000, (cut++).count());
+      CHECK_EQUAL(1001, cut.count());
+      CHECK_EQUAL(1001, (cut--).count());
+      CHECK_EQUAL(1000, cut.count());
+    }
+
+    TEST(TetlurationCompoundAssignmentOperators)
+    {
+      chrono::duration<int32_t, etl::milli> cut(1000);
+      chrono::duration<int32_t, etl::milli> other(500);
+      chrono::duration<int32_t, etl::milli> prime(737);
+
+      CHECK_EQUAL(1500, (cut += other).count());
+      CHECK_EQUAL(1500, cut.count());
+      CHECK_EQUAL(1000, (cut -= other).count());
+      CHECK_EQUAL(1000, cut.count());
+      CHECK_EQUAL(3000, (cut *= 3).count());
+      CHECK_EQUAL(3000, cut.count());
+      CHECK_EQUAL(1000, (cut /= 3).count());
+      CHECK_EQUAL(1000, cut.count());
+      CHECK_EQUAL(263, (cut %= 737).count());
+      CHECK_EQUAL(263, cut.count());
+      CHECK_EQUAL(263, (cut %= prime).count());
+      CHECK_EQUAL(263, cut.count());
+    }
+
+    TEST(TetlurationArithmeticOperators)
+    {
+      chrono::duration<int64_t, etl::milli> d1(500);
+      chrono::duration<int32_t, etl::micro> d2(1000);
+      chrono::duration<int16_t, etl::micro> d3(int16_t(250));
+      chrono::duration<int32_t, etl::micro> prime(737);
+
+      {
+        chrono::duration<int64_t, etl::micro> cut = d1 + d2;
+        CHECK_EQUAL(501000, cut.count());
+      }
+      {
+        chrono::duration<int64_t, etl::micro> cut = d1 - d2;
+        CHECK_EQUAL(499000, cut.count());
+      }
+      {
+        chrono::duration<int64_t, etl::milli> cut = d1 * 100;
+        CHECK_EQUAL(50000, cut.count());
+      }
+      {
+        chrono::duration<int64_t, etl::milli> cut = 100 * d1;
+        CHECK_EQUAL(50000, cut.count());
+      }
+      {
+        CHECK_EQUAL(2000, d1 / d3);
+      }
+      {
+        chrono::duration<int64_t, etl::milli> cut = d1 / 250;
+        CHECK_EQUAL(2, cut.count());
+      }
+      {
+        chrono::duration<int64_t, etl::micro> cut = d1 % prime;
+        CHECK_EQUAL(int64_t(500000 % 737), cut.count());
+      }
+      {
+        chrono::duration<int64_t, etl::milli> cut = d1 % 73;
+        CHECK_EQUAL((500 % 73), cut.count());
+      }
+    }
+
+    TEST(TetlurationComparisonOperators)
+    {
+      chrono::duration<int32_t, etl::milli> l1(999);
+      chrono::duration<int32_t, etl::milli> g1(1000);
+      chrono::duration<int32_t, etl::milli> g2(1000);
+
+      CHECK_FALSE(l1 == g1);
+      CHECK_FALSE(g1 == l1);
+      CHECK_TRUE(g1 == g2);
+      CHECK_TRUE(g2 == g1);
+
+      CHECK_TRUE(l1 != g1);
+      CHECK_TRUE(g1 != l1);
+      CHECK_FALSE(g1 != g2);
+      CHECK_FALSE(g2 != g1);
+
+      CHECK_TRUE(l1 < g1);
+      CHECK_FALSE(g1 < l1);
+      CHECK_FALSE(g1 < g2);
+      CHECK_FALSE(g2 < g1);
+
+      CHECK_TRUE(l1 <= g1);
+      CHECK_FALSE(g1 <= l1);
+      CHECK_TRUE(g1 <= g2);
+      CHECK_TRUE(g2 <= g1);
+
+      CHECK_FALSE(l1 > g1);
+      CHECK_TRUE(g1 > l1);
+      CHECK_FALSE(g1 > g2);
+      CHECK_FALSE(g2 > g1);
+
+      CHECK_FALSE(l1 >= g1);
+      CHECK_TRUE(g1 >= l1);
+      CHECK_TRUE(g1 >= g2);
+      CHECK_TRUE(g2 >= g1);
+    }
+
+    TEST(TetlurationConstants)
+    {
+      CHECK_EQUAL(0, (chrono::duration<int8_t, etl::milli>::zero().count()));
+      CHECK_EQUAL(
+        std::numeric_limits<int8_t>::min(),
+        (chrono::duration<int8_t, etl::milli>::min().count()));
+      CHECK_EQUAL(
+        std::numeric_limits<int8_t>::max(),
+        (chrono::duration<int8_t, etl::milli>::max().count()));
+
+      CHECK_EQUAL(0U, (chrono::duration<uint8_t, etl::milli>::zero().count()));
+      CHECK_EQUAL(
+        std::numeric_limits<uint8_t>::min(),
+        (chrono::duration<uint8_t, etl::milli>::min().count()));
+      CHECK_EQUAL(
+        std::numeric_limits<uint8_t>::max(),
+        (chrono::duration<uint8_t, etl::milli>::max().count()));
+
+      CHECK_EQUAL(0, (chrono::duration<int16_t, etl::milli>::zero().count()));
+      CHECK_EQUAL(
+        std::numeric_limits<int16_t>::min(),
+        (chrono::duration<int16_t, etl::milli>::min().count()));
+      CHECK_EQUAL(
+        std::numeric_limits<int16_t>::max(),
+        (chrono::duration<int16_t, etl::milli>::max().count()));
+
+      CHECK_EQUAL(0U, (chrono::duration<uint16_t, etl::milli>::zero().count()));
+      CHECK_EQUAL(
+        std::numeric_limits<uint16_t>::min(),
+        (chrono::duration<uint16_t, etl::milli>::min().count()));
+      CHECK_EQUAL(
+        std::numeric_limits<uint16_t>::max(),
+        (chrono::duration<uint16_t, etl::milli>::max().count()));
+
+      CHECK_EQUAL(0, (chrono::duration<int32_t, etl::milli>::zero().count()));
+      CHECK_EQUAL(
+        std::numeric_limits<int32_t>::min(),
+        (chrono::duration<int32_t, etl::milli>::min().count()));
+      CHECK_EQUAL(
+        std::numeric_limits<int32_t>::max(),
+        (chrono::duration<int32_t, etl::milli>::max().count()));
+
+      CHECK_EQUAL(0U, (chrono::duration<uint32_t, etl::milli>::zero().count()));
+      CHECK_EQUAL(
+        std::numeric_limits<uint32_t>::min(),
+        (chrono::duration<uint32_t, etl::milli>::min().count()));
+      CHECK_EQUAL(
+        std::numeric_limits<uint32_t>::max(),
+        (chrono::duration<uint32_t, etl::milli>::max().count()));
+
+      CHECK_EQUAL(0, (chrono::duration<int64_t, etl::milli>::zero().count()));
+      CHECK_EQUAL(
+        std::numeric_limits<int64_t>::min(),
+        (chrono::duration<int64_t, etl::milli>::min().count()));
+      CHECK_EQUAL(
+        std::numeric_limits<int64_t>::max(),
+        (chrono::duration<int64_t, etl::milli>::max().count()));
+
+      CHECK_EQUAL(0U, (chrono::duration<uint64_t, etl::milli>::zero().count()));
+      CHECK_EQUAL(
+        std::numeric_limits<uint64_t>::min(),
+        (chrono::duration<uint64_t, etl::milli>::min().count()));
+      CHECK_EQUAL(
+        std::numeric_limits<uint64_t>::max(),
+        (chrono::duration<uint64_t, etl::milli>::max().count()));
+    }
+
+    TEST(TestPredefinedTypes)
+    {
+      {
+        chrono::milliseconds cut = chrono::hours(3) + chrono::minutes(16) + chrono::seconds(35) + chrono::milliseconds(26);
+        CHECK_EQUAL((((((3 * 60) + 16) * 60) + 35) * 1000 + 26), cut.count());
+      }
+      {
+        chrono::nanoseconds cut = chrono::milliseconds(251) + chrono::microseconds(365) + chrono::nanoseconds(857);
+        CHECK_EQUAL((((251 * 1000 + 365) * 1000) + 857), cut.count());
+      }
+    }
+
+    TEST(TestTimePointCast)
+    {
+      {
+        chrono::time_point<chrono_test::Clock, chrono::duration<int32_t, etl::milli>> src(
+          chrono::duration<int32_t, etl::milli>(1001));
+        {
+          chrono::time_point<chrono_test::Clock, chrono::duration<int32_t, etl::micro>> cut = chrono::time_point_cast<chrono::duration<int32_t, etl::micro>>(src);
+          CHECK_EQUAL(1001000, cut.time_since_epoch().count());
+        }
+      }
+    }
+
+    TEST(TestTimePointConstructors)
+    {
+      {
+        chrono::time_point<chrono_test::Clock, chrono::milliseconds> cut;
+        CHECK_EQUAL(0, cut.time_since_epoch().count());
+      }
+      {
+        chrono::time_point<chrono_test::Clock, chrono::microseconds> cut(chrono::microseconds(715));
+        CHECK_EQUAL(715, cut.time_since_epoch().count());
+      }
+      {
+        chrono::time_point<chrono_test::Clock, chrono::microseconds> cut(
+          chrono::time_point<chrono_test::Clock, chrono::duration<int16_t, etl::milli>>(
+            chrono::duration<int16_t, etl::milli>(int16_t(715))));
+        CHECK_EQUAL(715000, cut.time_since_epoch().count());
+      }
+      {
+        chrono::time_point<chrono_test::Clock> cut;
+        CHECK_EQUAL(0, cut.time_since_epoch().count());
+      }
+      {
+        // copy constructor
+        chrono::time_point<chrono_test::Clock, chrono::microseconds> cut(chrono::microseconds(715));
+        chrono::time_point<chrono_test::Clock, chrono::microseconds> other(cut);
+        CHECK_EQUAL(715, other.time_since_epoch().count());
+      }
+      {
+        // assignment operator
+        chrono::time_point<chrono_test::Clock, chrono::microseconds> cut(chrono::microseconds(715));
+        chrono::time_point<chrono_test::Clock, chrono::microseconds> other(
+          chrono::microseconds(716));
+
+        other = cut;
+        CHECK_EQUAL(715, other.time_since_epoch().count());
+      }
+    }
+
+    TEST(TestTimePointCompoundAssignmentOperators)
+    {
+      chrono::time_point<chrono_test::Clock, chrono::milliseconds> cut(chrono::milliseconds(1000));
+      chrono::milliseconds                                         duration = chrono::milliseconds(500);
+
+      CHECK_EQUAL(1500, (cut += duration).time_since_epoch().count());
+      CHECK_EQUAL(1500, cut.time_since_epoch().count());
+      CHECK_EQUAL(1000, (cut -= duration).time_since_epoch().count());
+      CHECK_EQUAL(1000, cut.time_since_epoch().count());
+    }
+
+    TEST(TestTimePointArithmeticOperators)
+    {
+      chrono::time_point<chrono_test::Clock, chrono::milliseconds> tp1(chrono::milliseconds(500));
+      chrono::time_point<chrono_test::Clock, chrono::microseconds> tp2(chrono::microseconds(1000));
+      chrono::microseconds                                         d(1000);
+
+      {
+        chrono::time_point<chrono_test::Clock, chrono::microseconds> cut = tp1 + d;
+        CHECK_EQUAL(501000, cut.time_since_epoch().count());
+      }
+      {
+        chrono::time_point<chrono_test::Clock, chrono::microseconds> cut = d + tp1;
+        CHECK_EQUAL(501000, cut.time_since_epoch().count());
+      }
+      {
+        chrono::time_point<chrono_test::Clock, chrono::microseconds> cut = tp1 - d;
+        CHECK_EQUAL(499000, cut.time_since_epoch().count());
+      }
+      {
+        chrono::microseconds cut = tp1 - tp2;
+        CHECK_EQUAL(499000, cut.count());
+      }
+    }
+
+    TEST(TestTimePointComparisonOperators)
+    {
+      chrono::time_point<chrono_test::Clock, chrono::milliseconds> l1(chrono::milliseconds(999));
+      chrono::time_point<chrono_test::Clock, chrono::milliseconds> g1(chrono::milliseconds(1000));
+      chrono::time_point<chrono_test::Clock, chrono::milliseconds> g2(chrono::milliseconds(1000));
+
+      CHECK_FALSE(l1 == g1);
+      CHECK_FALSE(g1 == l1);
+      CHECK_TRUE(g1 == g2);
+      CHECK_TRUE(g2 == g1);
+
+      CHECK_TRUE(l1 != g1);
+      CHECK_TRUE(g1 != l1);
+      CHECK_FALSE(g1 != g2);
+      CHECK_FALSE(g2 != g1);
+
+      CHECK_TRUE(l1 < g1);
+      CHECK_FALSE(g1 < l1);
+      CHECK_FALSE(g1 < g2);
+      CHECK_FALSE(g2 < g1);
+
+      CHECK_TRUE(l1 <= g1);
+      CHECK_FALSE(g1 <= l1);
+      CHECK_TRUE(g1 <= g2);
+      CHECK_TRUE(g2 <= g1);
+
+      CHECK_FALSE(l1 > g1);
+      CHECK_TRUE(g1 > l1);
+      CHECK_FALSE(g1 > g2);
+      CHECK_FALSE(g2 > g1);
+
+      CHECK_FALSE(l1 >= g1);
+      CHECK_TRUE(g1 >= l1);
+      CHECK_TRUE(g1 >= g2);
+      CHECK_TRUE(g2 >= g1);
+    }
+
+    TEST(TestTimePointConstants)
+    {
+      CHECK_EQUAL(
+        std::numeric_limits<int8_t>::min(),
+        (chrono::time_point<chrono_test::Clock, chrono::duration<int8_t, etl::milli>>::min()
+           .time_since_epoch()
+           .count()));
+      CHECK_EQUAL(
+        std::numeric_limits<int8_t>::max(),
+        (chrono::time_point<chrono_test::Clock, chrono::duration<int8_t, etl::milli>>::max()
+           .time_since_epoch()
+           .count()));
+
+      CHECK_EQUAL(
+        std::numeric_limits<uint8_t>::min(),
+        (chrono::time_point<chrono_test::Clock, chrono::duration<uint8_t, etl::milli>>::min()
+           .time_since_epoch()
+           .count()));
+      CHECK_EQUAL(
+        std::numeric_limits<uint8_t>::max(),
+        (chrono::time_point<chrono_test::Clock, chrono::duration<uint8_t, etl::milli>>::max()
+           .time_since_epoch()
+           .count()));
+
+      CHECK_EQUAL(
+        std::numeric_limits<int16_t>::min(),
+        (chrono::time_point<chrono_test::Clock, chrono::duration<int16_t, etl::milli>>::min()
+           .time_since_epoch()
+           .count()));
+      CHECK_EQUAL(
+        std::numeric_limits<int16_t>::max(),
+        (chrono::time_point<chrono_test::Clock, chrono::duration<int16_t, etl::milli>>::max()
+           .time_since_epoch()
+           .count()));
+
+      CHECK_EQUAL(
+        std::numeric_limits<uint16_t>::min(),
+        (chrono::time_point<chrono_test::Clock, chrono::duration<uint16_t, etl::milli>>::min()
+           .time_since_epoch()
+           .count()));
+      CHECK_EQUAL(
+        std::numeric_limits<uint16_t>::max(),
+        (chrono::time_point<chrono_test::Clock, chrono::duration<uint16_t, etl::milli>>::max()
+           .time_since_epoch()
+           .count()));
+
+      CHECK_EQUAL(
+        std::numeric_limits<int32_t>::min(),
+        (chrono::time_point<chrono_test::Clock, chrono::duration<int32_t, etl::milli>>::min()
+           .time_since_epoch()
+           .count()));
+      CHECK_EQUAL(
+        std::numeric_limits<int32_t>::max(),
+        (chrono::time_point<chrono_test::Clock, chrono::duration<int32_t, etl::milli>>::max()
+           .time_since_epoch()
+           .count()));
+
+      CHECK_EQUAL(
+        std::numeric_limits<uint32_t>::min(),
+        (chrono::time_point<chrono_test::Clock, chrono::duration<uint32_t, etl::milli>>::min()
+           .time_since_epoch()
+           .count()));
+      CHECK_EQUAL(
+        std::numeric_limits<uint32_t>::max(),
+        (chrono::time_point<chrono_test::Clock, chrono::duration<uint32_t, etl::milli>>::max()
+           .time_since_epoch()
+           .count()));
+
+      CHECK_EQUAL(
+        std::numeric_limits<int64_t>::min(),
+        (chrono::time_point<chrono_test::Clock, chrono::duration<int64_t, etl::milli>>::min()
+           .time_since_epoch()
+           .count()));
+      CHECK_EQUAL(
+        std::numeric_limits<int64_t>::max(),
+        (chrono::time_point<chrono_test::Clock, chrono::duration<int64_t, etl::milli>>::max()
+           .time_since_epoch()
+           .count()));
+
+      CHECK_EQUAL(
+        std::numeric_limits<uint64_t>::min(),
+        (chrono::time_point<chrono_test::Clock, chrono::duration<uint64_t, etl::milli>>::min()
+           .time_since_epoch()
+           .count()));
+      CHECK_EQUAL(
+        std::numeric_limits<uint64_t>::max(),
+        (chrono::time_point<chrono_test::Clock, chrono::duration<uint64_t, etl::milli>>::max()
+           .time_since_epoch()
+           .count()));
+    }
+
+    TEST(TestHighResolutionClock)
+    {
+      currentTimeNs = 15;
+      CHECK_EQUAL(
+        static_cast<int64_t>(currentTimeNs), chrono::high_resolution_clock::now().time_since_epoch().count());
+      currentTimeNs = 0x7fffffffffffffff;
+      CHECK_EQUAL(
+        static_cast<int64_t>(currentTimeNs), chrono::high_resolution_clock::now().time_since_epoch().count());
+    }
+  }
+}  // namespace


### PR DESCRIPTION
Note that the users of `etl::chrono::high_resolution_clock`
have to provide the definition of the C function `etl_get_system_time_nanosec()` .
If one does not use `etl::chrono::high_resolution_clock` then `etl_get_system_time_nanosec()` can be left undefined/ignored.
 