### PR TITLE
Potential fix for span construct

### DIFF
--- a/include/etl/span.h
+++ b/include/etl/span.h
@@ -55,11 +55,13 @@ SOFTWARE.
 
 namespace etl
 {
+  //empty base optimization means this has zero size
+  class span_base {};
   //***************************************************************************
   /// Span - Fixed Extent
   //***************************************************************************
   template <typename T, size_t Extent = etl::dynamic_extent>
-  class span
+  class span : span_base
   {
   public:
 
@@ -113,7 +115,8 @@ namespace etl
     /// Construct from a container or other type that supports
     /// data() and size() member functions.
     //*************************************************************************
-    template <typename TContainer, typename = typename etl::enable_if<!etl::is_pointer<etl::remove_reference_t<TContainer>>::value &&
+    template <typename TContainer, typename = typename etl::enable_if<!etl::is_base_of<span_base, etl::remove_reference_t<TContainer>>::value &&
+                                                                      !etl::is_pointer<etl::remove_reference_t<TContainer>>::value &&
                                                                       !etl::is_array<etl::remove_reference_t<TContainer>>::value&&
                                                                       etl::is_same<etl::remove_cv_t<T>, etl::remove_cv_t<typename etl::remove_reference_t<TContainer>::value_type>>::value, void>::type>
       ETL_CONSTEXPR span(TContainer&& a) ETL_NOEXCEPT
@@ -158,7 +161,7 @@ namespace etl
     /// Copy constructor
     //*************************************************************************
     template <typename U, size_t N>
-    ETL_CONSTEXPR span(const etl::span<U, N>& other, typename etl::enable_if<(Extent == etl::dynamic_extent) || (N == etl::dynamic_extent) || (N == Extent), void>::type) ETL_NOEXCEPT
+    ETL_CONSTEXPR span(const etl::span<U, N>& other, typename etl::enable_if<(Extent == etl::dynamic_extent) || (N == etl::dynamic_extent) || (N == Extent), void>::type* = 0) ETL_NOEXCEPT
       : pbegin(other.data())
     {
     }
@@ -511,7 +514,8 @@ namespace etl
     /// Construct from a container or other type that supports
     /// data() and size() member functions.
     //*************************************************************************
-    template <typename TContainer, typename = typename etl::enable_if<!etl::is_pointer<etl::remove_reference_t<TContainer>>::value &&
+    template <typename TContainer, typename = typename etl::enable_if<!etl::is_base_of<span_base, etl::remove_reference_t<TContainer>>::value &&
+                                                                      !etl::is_pointer<etl::remove_reference_t<TContainer>>::value &&
                                                                       !etl::is_array<etl::remove_reference_t<TContainer>>::value &&
                                                                       etl::is_same<etl::remove_cv_t<T>, etl::remove_cv_t<typename etl::remove_reference_t<TContainer>::value_type>>::value, void>::type>
       ETL_CONSTEXPR span(TContainer&& a) ETL_NOEXCEPT

--- a/include/etl/span.h
+++ b/include/etl/span.h
@@ -61,7 +61,7 @@ namespace etl
   /// Span - Fixed Extent
   //***************************************************************************
   template <typename T, size_t Extent = etl::dynamic_extent>
-  class span : span_base
+  class span : public span_base
   {
   public:
 


### PR DESCRIPTION
Potential fix for #1050 

I was checking for static checks in the span constructors that should throw compiler errors.  This code compiles using etl::span but the equivalent std::span code will correctly have a compiler error.

```
int arr[5]{};
etl::span span1(arr);
etl::span<int, 10> span2(span1);  //no compile error here despite different extents.  equivalent std span on gcc does have compile error
```

I believe the cause of the problem is that the intended copy constructors are not used because the extents don't match, but it is falling back on the "generic" constructor that does not check the extents.

My workaround is to disable the generic constructor when constructor from another span.  I think there was also an error with the enable_if statement of the second copy constructor that caused it to always evaluate false.  I changed it to match the 3rd example from [cppreference](https://en.cppreference.com/w/cpp/types/enable_if).

With this change the code example correctly has compiler error.  Feel free to suggest any other method that could be used to disable the "generic" constructor.