### PR TITLE
Add enable_if restriction for span constructor from c array

### DIFF
--- a/include/etl/span.h
+++ b/include/etl/span.h
@@ -102,7 +102,7 @@ namespace etl
     //*************************************************************************
     /// Construct from C array
     //*************************************************************************
-    template<size_t Array_Size>
+    template<size_t Array_Size, typename = typename etl::enable_if<(Extent == etl::dynamic_extent) || (Array_Size == Extent), void>::type>
     ETL_CONSTEXPR span(element_type(&begin_)[Array_Size]) ETL_NOEXCEPT
       : pbegin(begin_)
     {

--- a/include/etl/span.h
+++ b/include/etl/span.h
@@ -102,7 +102,7 @@ namespace etl
     //*************************************************************************
     /// Construct from C array
     //*************************************************************************
-    template<size_t Array_Size, typename = typename etl::enable_if<(Extent == etl::dynamic_extent) || (Array_Size == Extent), void>::type>
+    template<size_t Array_Size, typename = etl::enable_if<(Extent == etl::dynamic_extent) || (Array_Size == Extent), void>::type>
     ETL_CONSTEXPR span(element_type(&begin_)[Array_Size]) ETL_NOEXCEPT
       : pbegin(begin_)
     {

--- a/include/etl/span.h
+++ b/include/etl/span.h
@@ -102,7 +102,7 @@ namespace etl
     //*************************************************************************
     /// Construct from C array
     //*************************************************************************
-    template<size_t Array_Size, typename = etl::enable_if<(Extent == etl::dynamic_extent) || (Array_Size == Extent), void>::type>
+    template<size_t Array_Size, typename = typename etl::enable_if<(Extent == etl::dynamic_extent) || (Array_Size == Extent), void>::type>
     ETL_CONSTEXPR span(element_type(&begin_)[Array_Size]) ETL_NOEXCEPT
       : pbegin(begin_)
     {


### PR DESCRIPTION
A small change to the static span constructor from c array to require that `Extent` is equal to `Array_Size`.  std span on gcc also does this same check.

This prevents the following code from compiling:

```
int arr[5]{};
etl::span<int, 10> span1(arr);  //currently no compile error here.  equivalent std span on gcc does have compile error
```