### PR TITLE
fix missing is_secure function

### DIFF
--- a/include/etl/basic_string.h
+++ b/include/etl/basic_string.h
@@ -270,15 +270,19 @@ namespace etl
     {
       flags.set<CLEAR_AFTER_USE>();
     }
+#endif
 
     //*************************************************************************
     /// Gets the 'secure' state flag.
     //*************************************************************************
     bool is_secure() const
     {
+#if ETL_HAS_STRING_CLEAR_AFTER_USE
       return flags.test<CLEAR_AFTER_USE>();
-    }
+#else
+      return false;
 #endif
+    }
 
   protected:
 


### PR DESCRIPTION
 when building without ETL_HAS_STRING_CLEAR_AFTER_USE
 
 Fixes: https://github.com/ETLCPP/etl/issues/1064