### PR TITLE
Add Zephyr build system module.yml

### DIFF
--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -1,0 +1,4 @@
+name: etl
+build:
+  cmake-ext: true
+  kconfig-ext: true


### PR DESCRIPTION
The Zephyr build system requires that modules have a `module.yml` file to specify where the module cmake and kconfig files are located.  These can also be explicitly set as "external" meaning that they do not exist within the module tree, itself. 

These build file can still be specified elsewhere via cmake variables, explained more in-depth here: https://docs.zephyrproject.org/latest/develop/modules.html#modules-module-ext-root This change makes it such that ETL can be included more easily in zephyr projects running on embedded systems. 

A similar change can be observed in the public nanopb repository, where the repo only requires its own `zephyr/module.yml` file to be found by the zephyr build system, but the kconfig and cmake additions can exist outside of the library repository. https://github.com/nanopb/nanopb/blob/master/zephyr/module.yml