### PR TITLE
Add full West support for ETL in Zephyr builds

### DIFF
--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -1,0 +1,2 @@
+add_subdirectory_ifdef(CONFIG_ETL ${CMAKE_CURRENT_LIST_DIR}/.. etl)
+zephyr_link_interface_ifdef(CONFIG_ETL etl)

--- a/zephyr/Kconfig
+++ b/zephyr/Kconfig
@@ -1,0 +1,5 @@
+config ETL
+  bool "ETL (Embedded Template Library)"
+  depends on CPP
+  help
+    This option enables the 'ETL' library.

--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -1,4 +1,4 @@
 name: etl
 build:
-  cmake-ext: true
-  kconfig-ext: true
+  cmake: zephyr
+  kconfig: zephyr/Kconfig


### PR DESCRIPTION
This will allow ETL to be included via west in a zephyr build without any additional wrappers or external kconfigs.

All files for zephyr support will be contained within the `<etl_root>/zephyr/` directory so as not to clutter the root of the project. 

`add_subdirectory_ifdef()` and `zephyr_link_interface_ifdef()` are functions added by zephyr's cmake extensions. Since this cmake file will only ever be called when building for zephyr, these functions will always be provided by the build system. They will also not impact any builds aside from zephyr builds, as these files will be ignored by other build systems. 

In `zephyr/module.yml`, the "cmake:" and "kconfig:" fields are paths relative to the root of the project that instructs the zephyr build system where to find the relevant `cmakelists.txt` file. In this case, they instruct the zephyr build system to look in the `<etl_root>/zephyr/` directory for a `cmakelists.txt` and that the kconfig file is located at `<etl_root>/zephyr/Kconfig`. 
More information on this topic can be found in the Zephyr docs: https://docs.zephyrproject.org/latest/develop/modules.html#modules-build-settings