### PR TITLE
Fix numeric overflow in bip buffer's get_write_reserve

### DIFF
--- a/include/etl/bip_buffer_spsc_atomic.h
+++ b/include/etl/bip_buffer_spsc_atomic.h
@@ -247,7 +247,7 @@ namespace etl
       else // read_index > write_index
       {
         // Doesn't fit
-        if ((write_index + *psize) >= read_index)
+        if (*psize >= read_index - write_index)
         {
           *psize = read_index - write_index - 1;
         }


### PR DESCRIPTION
The bug happens because  `psize` is set to `numeric_limits<size_type>::max()`  so the code path in get_write_reserve has numeric overflow and won't update `psize`.

The following sequence reproduces the issue:
```cpp
#include <format>
#include <iostream>

#include <etl/bip_buffer_spsc_atomic.h>

int main()
{
    etl::bip_buffer_spsc_atomic<uint8_t, 256> buf;

    auto b1 = buf.write_reserve_optimal();
    assert(b1.size() == 256);
    buf.write_commit(b1.first(256));

    auto b2 = buf.read_reserve();
    assert(b2.size() == 256);

    auto b3 = buf.write_reserve_optimal();
    assert(b3.size() == 0);

    buf.read_commit(b2.first(17));

    auto b4 = buf.read_reserve();
    assert(b4.size() == 239);

    auto b5 = buf.write_reserve_optimal();
    assert(b5.size() == 16);
    buf.write_commit(b5.first(16));

    buf.read_commit(b4.first(10));

    auto b6 = buf.read_reserve();
    assert(b6.size() == 229);

    auto b7 = buf.write_reserve_optimal(); // will cause numeric overflow and return huge span
    std::cout << std::format("b7.size() = {}\n", b7.size());
    assert(b7.size() <= 256);

    return 0;
}
```