### PR TITLE
Use etl::clamp for setting value in cyclic_value

### DIFF
--- a/include/etl/cyclic_value.h
+++ b/include/etl/cyclic_value.h
@@ -109,16 +109,7 @@ namespace etl
     //*************************************************************************
     void set(T value_)
     {
-      if (value_ > Last)
-      {
-        value_ = Last;
-      }
-      else if (value_ < First)
-      {
-        value_ = First;
-      }
-
-      value = value_;
+      value = clamp(value_, First, Last);
     }
 
     //*************************************************************************
@@ -398,16 +389,7 @@ namespace etl
     //*************************************************************************
     void set(T value_)
     {
-      if (value_ > last_value)
-      {
-        value_ = last_value;
-      }
-      else if (value_ < first_value)
-      {
-        value_ = first_value;
-      }
-
-      value = value_;
+      value = clamp(value_, first_value, last_value);
     }
 
     //*************************************************************************


### PR DESCRIPTION
The current implementation was generating a compiler error for Tasking under C++14 for a pointless comparison of 0 when the type was unsigned. Use etl::clamp to reduce duplication and fix the error.