### PR TITLE
Add detection of C++23

### DIFF
--- a/include/etl/profiles/determine_compiler_language_support.h
+++ b/include/etl/profiles/determine_compiler_language_support.h
@@ -37,7 +37,19 @@ SOFTWARE.
 
 // Determine C++23 support
 #if !defined(ETL_CPP23_SUPPORTED)
-  #define ETL_CPP23_SUPPORTED 0
+  #if defined(__cplusplus)
+    #if defined(ETL_COMPILER_MICROSOFT)
+      #define ETL_CPP23_SUPPORTED (__cplusplus >= 202302L)
+    #elif defined(ETL_COMPILER_ARM5)
+      #define ETL_CPP23_SUPPORTED 0
+    #elif defined(ETL_COMPILER_GCC)
+      #define ETL_CPP23_SUPPORTED (__cplusplus >= 202302L)
+    #else
+      #define ETL_CPP23_SUPPORTED (__cplusplus >= 202302L)
+    #endif
+  #else
+    #define ETL_CPP23_SUPPORTED 0
+  #endif
 #endif
 
 #if ETL_CPP23_SUPPORTED

--- a/test/test_etl_traits.cpp
+++ b/test/test_etl_traits.cpp
@@ -47,6 +47,7 @@ namespace
       CHECK_EQUAL((ETL_USING_CPP14 == 1),                      etl::traits::using_cpp14);
       CHECK_EQUAL((ETL_USING_CPP17 == 1),                      etl::traits::using_cpp17);
       CHECK_EQUAL((ETL_USING_CPP20 == 1),                      etl::traits::using_cpp20);
+      CHECK_EQUAL((ETL_USING_CPP23 == 1),                      etl::traits::using_cpp23);
       CHECK_EQUAL((ETL_USING_EXCEPTIONS == 1),                 etl::traits::using_exceptions);
       CHECK_EQUAL((ETL_USING_GCC_COMPILER == 1),               etl::traits::using_gcc_compiler);
       CHECK_EQUAL((ETL_USING_MICROSOFT_COMPILER == 1),         etl::traits::using_microsoft_compiler);
@@ -85,7 +86,9 @@ namespace
       CHECK_EQUAL(ETL_VERSION_MINOR,                           etl::traits::version_minor);
       CHECK_EQUAL(ETL_VERSION_PATCH,                           etl::traits::version_patch);
       CHECK_EQUAL(ETL_VERSION_VALUE,                           etl::traits::version);
-#if ETL_USING_CPP20
+#if ETL_USING_CPP23
+      CHECK_EQUAL(23,                                          etl::traits::language_standard);
+#elif ETL_USING_CPP20
       CHECK_EQUAL(20,                                          etl::traits::language_standard);
 #elif ETL_USING_CPP17
       CHECK_EQUAL(17,                                          etl::traits::language_standard);


### PR DESCRIPTION
Currently, C++23 needs to be handled as a special case in etl_profile.h for ETL_CPP23_SUPPORTED.

This PR detects it via determine_compiler_language_support.h as for the other C++ versions.