### PR TITLE
Remove -Wuseless-cast

### DIFF
--- a/test/etl_error_handler/assert_function/CMakeLists.txt
+++ b/test/etl_error_handler/assert_function/CMakeLists.txt
@@ -77,7 +77,6 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "GNU")
 			-Wextra
 			-Werror
 			-Wfloat-equal
-			-Wuseless-cast
 			-Wshadow
 			-Wnull-dereference
 			)

--- a/test/etl_error_handler/exceptions/CMakeLists.txt
+++ b/test/etl_error_handler/exceptions/CMakeLists.txt
@@ -74,7 +74,6 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "GNU")
 			-Wextra
 			-Werror
 			-Wfloat-equal
-			-Wuseless-cast
 			-Wshadow
 			-Wnull-dereference
 			)

--- a/test/etl_error_handler/log_errors/CMakeLists.txt
+++ b/test/etl_error_handler/log_errors/CMakeLists.txt
@@ -75,7 +75,6 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "GNU")
 			-Wextra
 			-Werror
 			-Wfloat-equal
-			-Wuseless-cast
 			-Wshadow
 			-Wnull-dereference
 			)

--- a/test/etl_error_handler/log_errors_and_exceptions/CMakeLists.txt
+++ b/test/etl_error_handler/log_errors_and_exceptions/CMakeLists.txt
@@ -75,7 +75,6 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "GNU")
 			-Wextra
 			-Werror
 			-Wfloat-equal
-			-Wuseless-cast
 			-Wshadow
 			-Wnull-dereference
 			)

--- a/test/etl_initializer_list/CMakeLists.txt
+++ b/test/etl_initializer_list/CMakeLists.txt
@@ -75,7 +75,6 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "GNU")
 			-Wextra
 			-Werror
 			-Wfloat-equal
-			-Wuseless-cast
 			-Wshadow
 			-Wnull-dereference
 			)


### PR DESCRIPTION
In test/CMakeLists.txt, -Wuseless-cast was removed. Doing it for the subdirectories also.