### PR TITLE
Add missing header wchar.h for usage of wcslen()

### DIFF
--- a/include/etl/basic_string.h
+++ b/include/etl/basic_string.h
@@ -50,6 +50,7 @@ SOFTWARE.
 #include <stddef.h>
 #include <stdint.h>
 #include <string.h>
+#include <wchar.h>
 
 #if ETL_USING_STL && ETL_USING_CPP17
   #include <string_view>


### PR DESCRIPTION
Newly added usage of wcslen() broke application code. Include wchar.h also.