### PR TITLE
Fix West support and add ETL configuration options to Kconfig

### DIFF
--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -1,2 +1,8 @@
-add_subdirectory_ifdef(CONFIG_ETL ${CMAKE_CURRENT_LIST_DIR}/.. etl)
-zephyr_link_interface_ifdef(CONFIG_ETL etl)
+if(CONFIG_ETL)
+  add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/.. etl)
+  zephyr_link_interface(etl)
+
+  zephyr_compile_definitions_ifdef(CONFIG_ETL_DEBUG ETL_DEBUG)
+  zephyr_compile_definitions_ifdef(CONFIG_ETL_CHECK_PUSH_POP ETL_CHECK_PUSH_POP)
+  zephyr_compile_definitions_ifdef(CONFIG_ETL_LOG_ERRORS ETL_LOG_ERRORS)
+endif()

--- a/zephyr/Kconfig
+++ b/zephyr/Kconfig
@@ -3,3 +3,17 @@ config ETL
   depends on CPP
   help
     This option enables the 'ETL' library.
+
+if ETL
+
+config ETL_DEBUG
+  bool "Build ETL with debugging checks"
+  default y if DEBUG
+
+config ETL_CHECK_PUSH_POP
+  bool "Enable push/pop checks in ETL"
+
+config ETL_LOG_ERRORS
+  bool "Call ETL error handler instead of assert"
+
+endif # ETL

--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -1,6 +1,4 @@
 name: etl
 build:
-  cmake-ext: true
-  kconfig-ext: true
   cmake: zephyr
   kconfig: zephyr/Kconfig


### PR DESCRIPTION
The file `zephyr/module.yml` was mangled in aa0d8b322ccfa191bab57ae30b4cf7ba127a6384, making it generate errors when used as a Zephyr module.

This PR fixes the mangling and adds options to `Kconfig` to allow users to configure ETL functionality in Zephyr projects.