### PR TITLE
Fix usage of template keyword

### DIFF
--- a/include/etl/parameter_pack.h
+++ b/include/etl/parameter_pack.h
@@ -134,7 +134,7 @@ namespace etl
   inline constexpr size_t parameter_pack_v = etl::parameter_pack<TTypes...>::template index_of_type<T>::value;
 #endif
 
-#if ETL_USING_CPP17 && !ETL_USING_GCC_COMPILER
+#if ETL_USING_CPP17 && !ETL_USING_GCC_COMPILER && !ETL_USING_CLANG_COMPILER
   //***********************************
   template <typename... TTypes>
   template <typename T>


### PR DESCRIPTION
For non-GCC-compilers, the template keyword is being used in parameter_pack.h for referring to a template template member.

However, clang 19 and 20 don't accept this. (e.g. in Debian 13 "trixie" or Ubuntu 25.04 "plucky".)

It should be verified which compiler really needs the template keyword here at all. If not, the if-branch can be removed.