### PR TITLE
Use std::byteswap only if available 

### DIFF
--- a/include/etl/binary.h
+++ b/include/etl/binary.h
@@ -738,7 +738,7 @@ namespace etl
     typename etl::enable_if<etl::is_integral<T>::value && etl::is_unsigned<T>::value && (etl::integral_limits<T>::bits == 16U), T>::type
     reverse_bytes(T value)
   {
-#if ETL_CPP23_SUPPORTED && ETL_USING_STL
+#if ETL_CPP23_SUPPORTED && ETL_USING_STL && ETL_STD_BYTESWAP_SUPPORTED
     return std::byteswap(value);
 #else
     return (value >> 8U) | (value << 8U);
@@ -754,7 +754,7 @@ namespace etl
     typename etl::enable_if<etl::is_integral<T>::value && etl::is_unsigned<T>::value && (etl::integral_limits<T>::bits == 32U), T>::type
     reverse_bytes(T value)
   {
-#if ETL_CPP23_SUPPORTED && ETL_USING_STL
+#if ETL_CPP23_SUPPORTED && ETL_USING_STL && ETL_STD_BYTESWAP_SUPPORTED
     return std::byteswap(value);
 #else
     value = ((value & 0xFF00FF00UL) >> 8U) | ((value & 0x00FF00FFUL) << 8U);
@@ -774,7 +774,7 @@ namespace etl
     typename etl::enable_if<etl::is_integral<T>::value && etl::is_unsigned<T>::value && (etl::integral_limits<T>::bits == 64U), T>::type
     reverse_bytes(T value)
   {
-#if ETL_CPP23_SUPPORTED && ETL_USING_STL
+#if ETL_CPP23_SUPPORTED && ETL_USING_STL && ETL_STD_BYTESWAP_SUPPORTED
     return std::byteswap(value);
 #else
     value = ((value & 0xFF00FF00FF00FF00ULL) >> 8U)  | ((value & 0x00FF00FF00FF00FFULL) << 8U);

--- a/include/etl/profiles/determine_compiler_language_support.h
+++ b/include/etl/profiles/determine_compiler_language_support.h
@@ -218,4 +218,19 @@ SOFTWARE.
   #define ETL_NO_CPP_NAN_SUPPORT
 #endif
 
+#if defined(__has_include)
+  #if !__has_include(<version>)
+    #include <version>
+
+    #if defined(__cpp_lib_byteswap)
+      #if __cpp_lib_byteswap != 0
+        #define ETL_STD_BYTESWAP_SUPPORTED 1
+      #endif
+    #endif
+  #endif
+#endif
+#ifndef ETL_STD_BYTESWAP_SUPPORTED
+#define ETL_STD_BYTESWAP_SUPPORTED 0
+#endif
+
 #endif


### PR DESCRIPTION
When clang 17 is in use, and in -std=c++23 mode, it does not support std::byteswap even when standards expects it.

Therefore, detect availability of std::byteswap via macros.