### PR TITLE
Fix build of tuple on clang >= 19

### DIFF
--- a/include/etl/tuple.h
+++ b/include/etl/tuple.h
@@ -1277,7 +1277,8 @@ namespace etl
 
 namespace std
 {
-#if ETL_NOT_USING_STL && !(defined(ETL_DEVELOPMENT_OS_APPLE) && defined(ETL_COMPILER_CLANG))
+#if ETL_NOT_USING_STL && !((defined(ETL_DEVELOPMENT_OS_APPLE) || \
+    (ETL_COMPILER_FULL_VERSION >= 190000)) && defined(ETL_COMPILER_CLANG))
   template <typename T>
   struct tuple_size;
 


### PR DESCRIPTION
When using clang 19, tuple defines tuple_size even though tuple_size is already defined via other headers from ETL. Especially, limits.h needs math.h which in this case defines the tuple_size base template.

This PR conditionally defines the base template depending on the clang version.