### PR TITLE
Add support for CRC8-NRSC5

### DIFF
--- a/include/etl/crc.h
+++ b/include/etl/crc.h
@@ -45,6 +45,7 @@ SOFTWARE.
 #include "crc8_maxim.h"
 #include "crc8_rohc.h"
 #include "crc8_wcdma.h"
+#include "crc8_nrsc5.h"
 
 #include "crc16.h"
 #include "crc16_a.h"

--- a/include/etl/crc8_nrsc5.h
+++ b/include/etl/crc8_nrsc5.h
@@ -1,0 +1,76 @@
+///\file
+
+/******************************************************************************
+The MIT License(MIT)
+
+Embedded Template Library.
+https://github.com/ETLCPP/etl
+https://www.etlcpp.com
+
+Copyright(c) 2021 John Wellbelove
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files(the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions :
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+******************************************************************************/
+
+#ifndef ETL_CRC8_NRSC5_INCLUDED
+#define ETL_CRC8_NRSC5_INCLUDED
+
+#include "platform.h"
+#include "private/crc_implementation.h"
+
+namespace etl
+{
+#if ETL_USING_CPP11 && !defined(ETL_CRC_FORCE_CPP03_IMPLEMENTATION)
+  template <size_t Table_Size>
+  using crc8_nrsc5_t = etl::crc_type<etl::private_crc::crc8_nrsc5_parameters, Table_Size>;
+#else
+  template <size_t Table_Size>
+  class crc8_nrsc5_t : public etl::crc_type<etl::private_crc::crc8_nrsc5_parameters, Table_Size>
+  {
+  public:
+
+    //*************************************************************************
+    /// Default constructor.
+    //*************************************************************************
+    crc8_nrsc5_t()
+    {
+      this->reset();
+    }
+
+    //*************************************************************************
+    /// Constructor from range.
+    /// \param begin Start of the range.
+    /// \param end   End of the range.
+    //*************************************************************************
+    template<typename TIterator>
+    crc8_nrsc5_t(TIterator begin, const TIterator end)
+    {
+      this->reset();
+      this->add(begin, end);
+    }
+  };
+#endif
+
+  typedef crc8_nrsc5_t<256U> crc8_nrsc5_t256;
+  typedef crc8_nrsc5_t<16U>  crc8_nrsc5_t16;
+  typedef crc8_nrsc5_t<4U>   crc8_nrsc5_t4;
+  typedef crc8_nrsc5_t256    crc8_nrsc5;
+}
+
+#endif

--- a/include/etl/private/crc_parameters.h
+++ b/include/etl/private/crc_parameters.h
@@ -81,6 +81,7 @@ namespace etl
     typedef crc_parameters<uint8_t, 0x9BU, 0x00U, 0x00U, true>  crc8_wcdma_parameters;
     typedef crc_parameters<uint8_t, 0x1DU, 0xFFU, 0xFFU, false> crc8_j1850_parameters;
     typedef crc_parameters<uint8_t, 0x1DU, 0x00U, 0x00U, false> crc8_j1850_zero_parameters;
+    typedef crc_parameters<uint8_t, 0x31U, 0xFFU, 0x00U, false> crc8_nrsc5_parameters;
 
     // 16 bit.
     typedef crc_parameters<uint16_t, 0x8005U, 0x0000U, 0x0000U, true>  crc16_parameters;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -136,6 +136,7 @@ add_executable(etl_tests
 	test_crc8_maxim.cpp
 	test_crc8_rohc.cpp
 	test_crc8_wcdma.cpp
+	test_crc8_nrsc5.cpp
 	test_cyclic_value.cpp
 	test_debounce.cpp
 	test_delegate.cpp

--- a/test/test_crc8_nrsc5.cpp
+++ b/test/test_crc8_nrsc5.cpp
@@ -1,0 +1,296 @@
+/******************************************************************************
+The MIT License(MIT)
+
+Embedded Template Library.
+https://github.com/ETLCPP/etl
+https://www.etlcpp.com
+
+Copyright(c) 2021 John Wellbelove
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files(the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions :
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+******************************************************************************/
+
+#include "unit_test_framework.h"
+
+#include <iterator>
+#include <string>
+#include <vector>
+#include <stdint.h>
+
+#include "etl/crc8_nrsc5.h"
+
+//*****************************************************************************
+// The results for these tests were created from https://crccalc.com/
+//*****************************************************************************
+
+namespace
+{
+  SUITE(test_crc8_nrsc5)
+  {
+    //*************************************************************************
+    // Table size 4
+    //*************************************************************************
+    TEST(test_crc8_nrsc5_4_constructor)
+    {
+      std::string data("123456789");
+
+      uint8_t crc = etl::crc8_nrsc5_t4(data.begin(), data.end());
+
+      CHECK_EQUAL(0xF7U, int(crc));
+    }
+
+#if ETL_USING_CPP14 && !defined(ETL_CRC_FORCE_CPP03_IMPLEMENTATION)
+    //*************************************************************************
+    TEST(test_crc8_nrsc5_4_constructor_constexpr)
+    {
+      constexpr char data[] = "123456789";
+      constexpr uint8_t crc = etl::crc8_nrsc5_t4(data, data + 9);
+
+      CHECK_EQUAL(0xF7U, int(crc));
+    }
+#endif
+
+    //*************************************************************************
+    TEST(test_crc8_nrsc5_4_add_values)
+    {
+      std::string data("123456789");
+
+      etl::crc8_nrsc5_t4 crc_calculator;
+
+      for (size_t i = 0UL; i < data.size(); ++i)
+      {
+        crc_calculator.add(data[i]);
+      }
+
+      uint8_t crc = crc_calculator;
+
+      CHECK_EQUAL(0xF7U, int(crc));
+    }
+
+    //*************************************************************************
+    TEST(test_crc8_nrsc5_4_add_range)
+    {
+      std::string data("123456789");
+
+      etl::crc8_nrsc5_t4 crc_calculator;
+
+      crc_calculator.add(data.begin(), data.end());
+
+      uint8_t crc = crc_calculator.value();
+
+      CHECK_EQUAL(0xF7U, int(crc));
+    }
+
+    //*************************************************************************
+    TEST(test_crc8_nrsc5_4_add_range_via_iterator)
+    {
+      std::string data("123456789");
+
+      etl::crc8_nrsc5_t4 crc_calculator;
+
+      std::copy(data.begin(), data.end(), crc_calculator.input());
+
+      uint8_t crc = crc_calculator.value();
+
+      CHECK_EQUAL(0xF7U, int(crc));
+    }
+
+    //*************************************************************************
+    TEST(test_crc8_nrsc5_4_add_range_endian)
+    {
+      std::vector<uint8_t>  data1 = { 0x01U, 0x02U, 0x03U, 0x04U, 0x05U, 0x06U, 0x07U, 0x08U };
+      std::vector<uint32_t> data2 = { 0x04030201UL, 0x08070605UL };
+      std::vector<uint8_t>  data3 = { 0x08U, 0x07U, 0x06U, 0x05U, 0x04U, 0x03U, 0x02U, 0x01U };
+
+      uint8_t crc1 = etl::crc8_nrsc5_t4(data1.begin(), data1.end());
+      uint8_t crc2 = etl::crc8_nrsc5_t4((uint8_t*)&data2[0], (uint8_t*)(&data2[0] + data2.size()));
+      CHECK_EQUAL(int(crc1), int(crc2));
+
+      uint8_t crc3 = etl::crc8_nrsc5_t4(data3.rbegin(), data3.rend());
+      CHECK_EQUAL(int(crc1), int(crc3));
+    }
+
+    //*************************************************************************
+    // Table size 16
+    //*************************************************************************
+    TEST(test_crc8_nrsc5_16_constructor)
+    {
+      std::string data("123456789");
+
+      uint8_t crc = etl::crc8_nrsc5_t16(data.begin(), data.end());
+
+      CHECK_EQUAL(0xF7U, int(crc));
+    }
+
+#if ETL_USING_CPP14 && !defined(ETL_CRC_FORCE_CPP03_IMPLEMENTATION)
+    //*************************************************************************
+    TEST(test_crc8_nrsc5_16_constructor_constexpr)
+    {
+      constexpr char data[] = "123456789";
+      constexpr uint8_t crc = etl::crc8_nrsc5_t16(data, data + 9);
+
+      CHECK_EQUAL(0xF7U, int(crc));
+    }
+#endif
+
+    //*************************************************************************
+    TEST(test_crc8_nrsc5_16_add_values)
+    {
+      std::string data("123456789");
+
+      etl::crc8_nrsc5_t16 crc_calculator;
+
+      for (size_t i = 0UL; i < data.size(); ++i)
+      {
+        crc_calculator.add(data[i]);
+      }
+
+      uint8_t crc = crc_calculator;
+
+      CHECK_EQUAL(0xF7U, int(crc));
+    }
+
+    //*************************************************************************
+    TEST(test_crc8_nrsc5_16_add_range)
+    {
+      std::string data("123456789");
+
+      etl::crc8_nrsc5_t16 crc_calculator;
+
+      crc_calculator.add(data.begin(), data.end());
+
+      uint8_t crc = crc_calculator.value();
+
+      CHECK_EQUAL(0xF7U, int(crc));
+    }
+
+    //*************************************************************************
+    TEST(test_crc8_nrsc5_16_add_range_via_iterator)
+    {
+      std::string data("123456789");
+
+      etl::crc8_nrsc5_t16 crc_calculator;
+
+      std::copy(data.begin(), data.end(), crc_calculator.input());
+
+      uint8_t crc = crc_calculator.value();
+
+      CHECK_EQUAL(0xF7U, int(crc));
+    }
+
+    //*************************************************************************
+    TEST(test_crc8_nrsc5_16_add_range_endian)
+    {
+      std::vector<uint8_t>  data1 = { 0x01U, 0x02U, 0x03U, 0x04U, 0x05U, 0x06U, 0x07U, 0x08U };
+      std::vector<uint32_t> data2 = { 0x04030201UL, 0x08070605UL };
+      std::vector<uint8_t>  data3 = { 0x08U, 0x07U, 0x06U, 0x05U, 0x04U, 0x03U, 0x02U, 0x01U };
+
+      uint8_t crc1 = etl::crc8_nrsc5_t16(data1.begin(), data1.end());
+      uint8_t crc2 = etl::crc8_nrsc5_t16((uint8_t*)&data2[0], (uint8_t*)(&data2[0] + data2.size()));
+      CHECK_EQUAL(int(crc1), int(crc2));
+
+      uint8_t crc3 = etl::crc8_nrsc5_t16(data3.rbegin(), data3.rend());
+      CHECK_EQUAL(int(crc1), int(crc3));
+    }
+
+    //*************************************************************************
+    // Table size 256
+    //*************************************************************************
+    TEST(test_crc8_nrsc5_256_constructor)
+    {
+      std::string data("123456789");
+
+      uint8_t crc = etl::crc8_nrsc5(data.begin(), data.end());
+
+      CHECK_EQUAL(0xF7U, int(crc));
+    }
+
+#if ETL_USING_CPP14 && !defined(ETL_CRC_FORCE_CPP03_IMPLEMENTATION)
+    //*************************************************************************
+    TEST(test_crc8_nrsc5_256_constructor_constexpr)
+    {
+      constexpr char data[] = "123456789";
+      constexpr uint8_t crc = etl::crc8_nrsc5(data, data + 9);
+
+      CHECK_EQUAL(0xF7U, int(crc));
+    }
+#endif
+
+    //*************************************************************************
+    TEST(test_crc8_nrsc5_256_add_values)
+    {
+      std::string data("123456789");
+
+      etl::crc8_nrsc5 crc_calculator;
+
+      for (size_t i = 0UL; i < data.size(); ++i)
+      {
+        crc_calculator.add(data[i]);
+      }
+
+      uint8_t crc = crc_calculator;
+
+      CHECK_EQUAL(0xF7U, int(crc));
+    }
+
+    //*************************************************************************
+    TEST(test_crc8_nrsc5_256_add_range)
+    {
+      std::string data("123456789");
+
+      etl::crc8_nrsc5 crc_calculator;
+
+      crc_calculator.add(data.begin(), data.end());
+
+      uint8_t crc = crc_calculator.value();
+
+      CHECK_EQUAL(0xF7U, int(crc));
+    }
+
+    //*************************************************************************
+    TEST(test_crc8_nrsc5_256_add_range_via_iterator)
+    {
+      std::string data("123456789");
+
+      etl::crc8_nrsc5 crc_calculator;
+
+      std::copy(data.begin(), data.end(), crc_calculator.input());
+
+      uint8_t crc = crc_calculator.value();
+
+      CHECK_EQUAL(0xF7U, int(crc));
+    }
+
+    //*************************************************************************
+    TEST(test_crc8_nrsc5_256_add_range_endian)
+    {
+      std::vector<uint8_t>  data1 = { 0x01U, 0x02U, 0x03U, 0x04U, 0x05U, 0x06U, 0x07U, 0x08U };
+      std::vector<uint32_t> data2 = { 0x04030201UL, 0x08070605UL };
+      std::vector<uint8_t>  data3 = { 0x08U, 0x07U, 0x06U, 0x05U, 0x04U, 0x03U, 0x02U, 0x01U };
+
+      uint8_t crc1 = etl::crc8_nrsc5(data1.begin(), data1.end());
+      uint8_t crc2 = etl::crc8_nrsc5((uint8_t*)&data2[0], (uint8_t*)(&data2[0] + data2.size()));
+      CHECK_EQUAL(int(crc1), int(crc2));
+
+      uint8_t crc3 = etl::crc8_nrsc5(data3.rbegin(), data3.rend());
+      CHECK_EQUAL(int(crc1), int(crc3));
+    }
+  };
+}
+


### PR DESCRIPTION
Adds support for the CRC8-NRSC5 algorithm, from [https://crccalc.com](https://crccalc.com).

1) Added the algorithm parameters to `crc_parameters.h`
2) Added header file for the new algorithm, also include it in `crc.h`
3) Added tests based on existing algorithms.

Built & ran tests locally (they passed), hopefully I didn't miss anything else.