### PR TITLE
Workaround for link libraries call on Zephyr platform

### DIFF
--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -1,6 +1,6 @@
 if(CONFIG_ETL)
   add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/.. etl)
-  zephyr_link_interface(etl)
+  zephyr_link_libraries(etl::etl)
 
   zephyr_compile_definitions_ifdef(CONFIG_ETL_DEBUG ETL_DEBUG)
   zephyr_compile_definitions_ifdef(CONFIG_ETL_CHECK_PUSH_POP ETL_CHECK_PUSH_POP)


### PR DESCRIPTION
zephyr_link_interface() does not work as intended because the implementation in zephyr/cmake/modules/extensions.cmake:

function(zephyr_link_interface interface)
  target_link_libraries(${interface} INTERFACE zephyr_interface)
endfunction()

is backwards, i.e., target_link_libraries(etl INTERFACE zephyr_interface) vs. target_link_libraries(zephyr_interface INTERFACE etl).

The workaround results in the following CMake code being executed:

target_link_libraries(zephyr_interface INTERFACE etl::etl)