### PR TITLE
Fix compile error in closure.h by using etl::forward

### DIFF
--- a/include/etl/closure.h
+++ b/include/etl/closure.h
@@ -121,7 +121,7 @@ namespace etl
     void bind_impl(etl::index_sequence<Indexes...>, UArgs&&... args)
     {
       // Use an initializer list to expand the pack and assign each argument
-      int dummy[] = {0, (etl::get<Indexes>(m_args) = std::forward<UArgs>(args), 0)...};
+      int dummy[] = {0, (etl::get<Indexes>(m_args) = etl::forward<UArgs>(args), 0)...};
       (void)dummy; // Suppress unused variable warning
     }
 


### PR DESCRIPTION
Using std::forward in the new closure breaks compile if not including it explicitly. Since etl::forward is used already in closure.h, we can use it here also instead.