### PR TITLE
Fix bug in the `void etl::unlink(first, last)` for bidirectional links.

### DIFF
--- a/include/etl/intrusive_links.h
+++ b/include/etl/intrusive_links.h
@@ -882,7 +882,6 @@ namespace etl
       if (first.etl_previous != ETL_NULLPTR)
       {
         first.etl_previous->etl_next = last.etl_next;
-        last.clear();
       }
 
       first.etl_previous = ETL_NULLPTR;

--- a/test/test_intrusive_links.cpp
+++ b/test/test_intrusive_links.cpp
@@ -1225,15 +1225,14 @@ namespace
       etl::link<BLink1>(data1, data0);
       etl::link<BLink1>(data0, nullptr);
 
+      // According to the documentation, `data1`/`data2` remain linked to each other.
       etl::unlink<BLink0>(data1, data2);
-      data1.BLink0::clear();
-      data2.BLink0::clear();
 
       CHECK(data0.BLink0::etl_previous == nullptr);
       CHECK(data0.BLink0::etl_next == &data3);
       CHECK(data1.BLink0::etl_previous == nullptr);
-      CHECK(data1.BLink0::etl_next == nullptr);
-      CHECK(data2.BLink0::etl_previous == nullptr);
+      CHECK(data1.BLink0::etl_next == &data2);
+      CHECK(data2.BLink0::etl_previous == &data1);
       CHECK(data2.BLink0::etl_next == nullptr);
       CHECK(data3.BLink0::etl_previous == &data0);
       CHECK(data3.BLink0::etl_next == nullptr);

--- a/test/test_intrusive_list.cpp
+++ b/test/test_intrusive_list.cpp
@@ -1420,6 +1420,12 @@ namespace
       CHECK(are_equal);
 
       CHECK_EQUAL(data0.size(), compare0.size());
+
+      // Double check that after splicing `etl_previous` is also correct - `.reverse()` easy way to do so.
+      data0.reverse();
+      compare0.reverse();
+      are_equal = std::equal(data0.begin(), data0.end(), compare0.begin());
+      CHECK(are_equal);
     }
 
     //*************************************************************************


### PR DESCRIPTION
According to the [documentation](https://www.etlcpp.com/intrusive_links.html) `void etl::unlink(first, last)` for biderectional links should keep `first`/`last` linked to each other.

But the `last` node is actually cleared up (IMO by mistake).
As a result you can still traverse from `first` to `last` but not vice versa.

The bug also affects `intrusive_list::splice` method which uses erronous `unlink` 

The bug repoduced by...
- correcting `test_unlink_range_bidirectional_link` unit test according to the documentation - now this test fails detecting broken `last.etl_previous`.
- enhancing `test_intrusive_list::test_splice_range_self` unit test to verify also `etl_previous` links after splicing lists - now unit test crashes (b/c reversed list can't be traversed anymore for the same reason).

After one liner fix (removal of the incorrect `last.clear()`) all tests are green, including the 2 above.
