### PR TITLE
Removed UB in type_def bit-shift operators

### DIFF
--- a/include/etl/type_def.h
+++ b/include/etl/type_def.h
@@ -290,14 +290,14 @@ namespace etl
     }
 
     //*********************************************************************
-    ETL_CONSTEXPR14 type_def& operator <<=(int rhs) ETL_NOEXCEPT
+    ETL_CONSTEXPR14 type_def& operator <<=(unsigned int rhs) ETL_NOEXCEPT
     {
       value <<= rhs;
       return *this;
     }
 
     //*********************************************************************
-    ETL_CONSTEXPR14 type_def& operator >>=(int rhs) ETL_NOEXCEPT
+    ETL_CONSTEXPR14 type_def& operator >>=(unsigned int rhs) ETL_NOEXCEPT
     {
       value >>= rhs;
       return *this;
@@ -589,7 +589,7 @@ namespace etl
     //*********************************************************************
     // << operator
     //*********************************************************************
-    friend ETL_CONSTEXPR type_def operator <<(const type_def& lhs, int rhs) ETL_NOEXCEPT
+    friend ETL_CONSTEXPR type_def operator <<(const type_def& lhs, unsigned int rhs) ETL_NOEXCEPT
     {
       return type_def(lhs.value << rhs);
     }
@@ -597,7 +597,7 @@ namespace etl
     //*********************************************************************
     // >> operator
     //*********************************************************************
-    friend ETL_CONSTEXPR type_def operator >>(const type_def& lhs, int rhs) ETL_NOEXCEPT
+    friend ETL_CONSTEXPR type_def operator >>(const type_def& lhs, unsigned int rhs) ETL_NOEXCEPT
     {
       return type_def(lhs.value >> rhs);
     }


### PR DESCRIPTION
Bit-shift operators aren't allowed to use negative numbers for the number of places to shift (which result in undefined behavior).  Changing all `type_def` bit-shift operators to use only use unsigned values.