### PR TITLE
Vector checks

### DIFF
--- a/include/etl/vector.h
+++ b/include/etl/vector.h
@@ -279,6 +279,7 @@ namespace etl
     //*********************************************************************
     reference operator [](size_t i)
     {
+      ETL_ASSERT_CHECK_INDEX_OPERATOR(i < size(), ETL_ERROR(vector_out_of_bounds));
       return p_buffer[i];
     }
 
@@ -289,6 +290,7 @@ namespace etl
     //*********************************************************************
     const_reference operator [](size_t i) const
     {
+      ETL_ASSERT_CHECK_INDEX_OPERATOR(i < size(), ETL_ERROR(vector_out_of_bounds));
       return p_buffer[i];
     }
 
@@ -322,6 +324,7 @@ namespace etl
     //*********************************************************************
     reference front()
     {
+      ETL_ASSERT_CHECK_EXTRA(size() > 0, ETL_ERROR(vector_out_of_bounds));
       return *p_buffer;
     }
 
@@ -331,6 +334,7 @@ namespace etl
     //*********************************************************************
     const_reference front() const
     {
+      ETL_ASSERT_CHECK_EXTRA(size() > 0, ETL_ERROR(vector_out_of_bounds));
       return *p_buffer;
     }
 
@@ -340,6 +344,7 @@ namespace etl
     //*********************************************************************
     reference back()
     {
+      ETL_ASSERT_CHECK_EXTRA(size() > 0, ETL_ERROR(vector_out_of_bounds));
       return *(p_end - 1);
     }
 
@@ -349,6 +354,7 @@ namespace etl
     //*********************************************************************
     const_reference back() const
     {
+      ETL_ASSERT_CHECK_EXTRA(size() > 0, ETL_ERROR(vector_out_of_bounds));
       return *(p_end - 1);
     }
 
@@ -570,6 +576,7 @@ namespace etl
     iterator insert(const_iterator position, const_reference value)
     {
       ETL_ASSERT(size() != CAPACITY, ETL_ERROR(vector_full));
+      ETL_ASSERT_CHECK_EXTRA(cbegin() <= position && position <= cend(), ETL_ERROR(vector_out_of_bounds));
 
       iterator position_ = to_iterator(position);
 
@@ -597,6 +604,7 @@ namespace etl
     iterator insert(const_iterator position, rvalue_reference value)
     {
       ETL_ASSERT(size() != CAPACITY, ETL_ERROR(vector_full));
+      ETL_ASSERT_CHECK_EXTRA(cbegin() <= position && position <= cend(), ETL_ERROR(vector_out_of_bounds));
 
       iterator position_ = to_iterator(position);
 
@@ -623,6 +631,7 @@ namespace etl
     iterator emplace(const_iterator position, Args && ... args)
     {
       ETL_ASSERT(!full(), ETL_ERROR(vector_full));
+      ETL_ASSERT_CHECK_EXTRA(cbegin() <= position && position <= cend(), ETL_ERROR(vector_out_of_bounds));
 
       iterator position_ = to_iterator(position);
 
@@ -650,6 +659,7 @@ namespace etl
     iterator emplace(const_iterator position, const T1& value1)
     {
       ETL_ASSERT(!full(), ETL_ERROR(vector_full));
+      ETL_ASSERT_CHECK_EXTRA(cbegin() <= position && position <= cend(), ETL_ERROR(vector_out_of_bounds));
 
       iterator position_ = to_iterator(position);
 
@@ -677,6 +687,7 @@ namespace etl
     iterator emplace(const_iterator position, const T1& value1, const T2& value2)
     {
       ETL_ASSERT(!full(), ETL_ERROR(vector_full));
+      ETL_ASSERT_CHECK_EXTRA(cbegin() <= position && position <= cend(), ETL_ERROR(vector_out_of_bounds));
 
       iterator position_ = to_iterator(position);
 
@@ -704,6 +715,7 @@ namespace etl
     iterator emplace(const_iterator position, const T1& value1, const T2& value2, const T3& value3)
     {
       ETL_ASSERT(!full(), ETL_ERROR(vector_full));
+      ETL_ASSERT_CHECK_EXTRA(cbegin() <= position && position <= cend(), ETL_ERROR(vector_out_of_bounds));
 
       iterator position_ = to_iterator(position);
 
@@ -731,6 +743,7 @@ namespace etl
     iterator emplace(const_iterator position, const T1& value1, const T2& value2, const T3& value3, const T4& value4)
     {
       ETL_ASSERT(!full(), ETL_ERROR(vector_full));
+      ETL_ASSERT_CHECK_EXTRA(cbegin() <= position && position <= cend(), ETL_ERROR(vector_out_of_bounds));
 
       iterator position_ = to_iterator(position);
 
@@ -765,6 +778,7 @@ namespace etl
     void insert(const_iterator position, size_t n, parameter_t value)
     {
       ETL_ASSERT_OR_RETURN((size() + n) <= CAPACITY, ETL_ERROR(vector_full));
+      ETL_ASSERT_CHECK_EXTRA(cbegin() <= position && position <= cend(), ETL_ERROR(vector_out_of_bounds));
 
       iterator position_ = to_iterator(position);
 
@@ -804,8 +818,8 @@ namespace etl
       etl::uninitialized_fill_n(p_end, construct_new_n, value);
       ETL_ADD_DEBUG_COUNT(construct_new_n);
 
-        // Copy new.
-        etl::fill_n(p_buffer + insert_begin, copy_new_n, value);
+      // Copy new.
+      etl::fill_n(p_buffer + insert_begin, copy_new_n, value);
 
       p_end += n;
     }
@@ -824,6 +838,7 @@ namespace etl
       size_t count = etl::distance(first, last);
 
       ETL_ASSERT_OR_RETURN((size() + count) <= CAPACITY, ETL_ERROR(vector_full));
+      ETL_ASSERT_CHECK_EXTRA(cbegin() <= position && position <= cend(), ETL_ERROR(vector_out_of_bounds));
 
       size_t insert_n = count;
       size_t insert_begin = etl::distance(cbegin(), position);
@@ -874,6 +889,8 @@ namespace etl
     //*********************************************************************
     iterator erase(iterator i_element)
     {
+      ETL_ASSERT_CHECK_EXTRA(cbegin() <= i_element && i_element < cend(), ETL_ERROR(vector_out_of_bounds));
+
       etl::move(i_element + 1, end(), i_element);
       destroy_back();
 
@@ -887,6 +904,8 @@ namespace etl
     //*********************************************************************
     iterator erase(const_iterator i_element)
     {
+      ETL_ASSERT_CHECK_EXTRA(cbegin() <= i_element && i_element < cend(), ETL_ERROR(vector_out_of_bounds));
+
       iterator i_element_ = to_iterator(i_element);
 
       etl::move(i_element_ + 1, end(), i_element_);
@@ -905,6 +924,8 @@ namespace etl
     //*********************************************************************
     iterator erase(const_iterator first, const_iterator last)
     {
+      ETL_ASSERT_CHECK_EXTRA(cbegin() <= first && first <= last && last <= cend(), ETL_ERROR(vector_out_of_bounds));
+
       iterator first_ = to_iterator(first);
       iterator last_  = to_iterator(last);
 

--- a/test/test_vector.cpp
+++ b/test/test_vector.cpp
@@ -554,7 +554,6 @@ namespace
       CHECK_THROW(emptyData.back(), etl::vector_out_of_bounds);
     }
 
-
     //*************************************************************************
     TEST_FIXTURE(SetupFixture, test_data)
     {

--- a/test/test_vector.cpp
+++ b/test/test_vector.cpp
@@ -276,8 +276,8 @@ namespace
       Data data(10);
       const Data constData(10);
 
-      CHECK_EQUAL(&data[10], data.end());
-      CHECK_EQUAL(&constData[10], constData.end());
+      CHECK_EQUAL(data.begin() + data.size(), data.end());
+      CHECK_EQUAL(constData.begin() + constData.size(), constData.end());
     }
 
     //*************************************************************************

--- a/test/test_vector.cpp
+++ b/test/test_vector.cpp
@@ -526,7 +526,7 @@ namespace
 
       CHECK(data.front() == compare_data.front());
 
-      Data emptyData;
+      const Data emptyData;
       CHECK_THROW(emptyData.front(), etl::vector_out_of_bounds);
     }
 
@@ -550,7 +550,7 @@ namespace
 
       CHECK(data.back() == compare_data.back());
 
-      Data emptyData;
+      const Data emptyData;
       CHECK_THROW(emptyData.back(), etl::vector_out_of_bounds);
     }
 

--- a/test/test_vector.cpp
+++ b/test/test_vector.cpp
@@ -459,6 +459,8 @@ namespace
       {
         CHECK_EQUAL(data[i], compare_data[i]);
       }
+
+      CHECK_THROW(data[data.size()], etl::vector_out_of_bounds);
     }
 
     //*************************************************************************
@@ -472,6 +474,8 @@ namespace
       {
         CHECK_EQUAL(data[i], compare_data[i]);
       }
+
+      CHECK_THROW(data[data.size()], etl::vector_out_of_bounds);
     }
 
     //*************************************************************************
@@ -509,6 +513,9 @@ namespace
       Data data(initial_data.begin(), initial_data.end());
 
       CHECK(data.front() == compare_data.front());
+
+      Data emptyData;
+      CHECK_THROW(emptyData.front(), etl::vector_out_of_bounds);
     }
 
     //*************************************************************************
@@ -518,6 +525,9 @@ namespace
       const Data data(initial_data.begin(), initial_data.end());
 
       CHECK(data.front() == compare_data.front());
+
+      Data emptyData;
+      CHECK_THROW(emptyData.front(), etl::vector_out_of_bounds);
     }
 
     //*************************************************************************
@@ -527,6 +537,9 @@ namespace
       Data data(initial_data.begin(), initial_data.end());
 
       CHECK(data.back() == compare_data.back());
+
+      Data emptyData;
+      CHECK_THROW(emptyData.back(), etl::vector_out_of_bounds);
     }
 
     //*************************************************************************
@@ -536,6 +549,9 @@ namespace
       const Data data(initial_data.begin(), initial_data.end());
 
       CHECK(data.back() == compare_data.back());
+
+      Data emptyData;
+      CHECK_THROW(emptyData.back(), etl::vector_out_of_bounds);
     }
 
 
@@ -776,6 +792,11 @@ namespace
 
         CHECK(is_equal);
       }
+
+      Data data;
+      data.assign(initial_data.begin(), initial_data.begin() + INITIAL_SIZE);
+      CHECK_THROW(data.insert(data.cbegin() - 1, INITIAL_VALUE), etl::vector_out_of_bounds);
+      CHECK_THROW(data.insert(data.cbegin() + INITIAL_SIZE + 1, INITIAL_VALUE), etl::vector_out_of_bounds);
     }
 
     //*************************************************************************
@@ -803,6 +824,11 @@ namespace
 
         CHECK(is_equal);
       }
+
+      Data data;
+      data.assign(initial_data.begin(), initial_data.begin() + INITIAL_SIZE);
+      CHECK_THROW(data.emplace(data.cbegin() - 1, INITIAL_VALUE), etl::vector_out_of_bounds);
+      CHECK_THROW(data.emplace(data.cbegin() + INITIAL_SIZE + 1, INITIAL_VALUE), etl::vector_out_of_bounds);
     }
 
     //*************************************************************************
@@ -847,6 +873,14 @@ namespace
       compare_data.fill(S());
 
       CHECK_TRUE(std::equal(compare_data.begin(), compare_data.end(), data.begin()));
+    }
+
+    //*************************************************************************
+    TEST(test_emplace_out_of_range)
+    {
+      etl::vector<int, SIZE> data;
+
+      CHECK_THROW(data.emplace(data.end() + 1);, etl::vector_out_of_bounds);
     }
 
     //*************************************************************************
@@ -944,6 +978,14 @@ namespace
     }
 
     //*************************************************************************
+    TEST_FIXTURE(SetupFixture, test_insert_position_n_value_outofbounds)
+    {
+      Data data;
+
+      CHECK_THROW(data.insert(data.end() + 1, 1, 0);, etl::vector_out_of_bounds);
+    }
+
+    //*************************************************************************
     TEST_FIXTURE(SetupFixture, test_insert_position_n_value_excess)
     {
       const size_t INITIAL_SIZE = SIZE;
@@ -997,6 +1039,14 @@ namespace
     }
 
     //*************************************************************************
+    TEST_FIXTURE(SetupFixture, test_insert_position_range_out_of_bounds)
+    {
+      Data data;
+
+      CHECK_THROW(data.insert(data.end() + 1, insert_data.cbegin(), insert_data.cend());, etl::vector_out_of_bounds);
+    }
+
+    //*************************************************************************
     TEST_FIXTURE(SetupFixture, test_insert_position_range_excess)
     {
       const size_t INITIAL_SIZE = 5;
@@ -1047,6 +1097,14 @@ namespace
     }
 
     //*************************************************************************
+    TEST_FIXTURE(SetupFixture, test_erase_single_iterator_outofbounds)
+    {
+      Data data(initial_data.begin(), initial_data.end());
+
+      CHECK_THROW(data.erase(data.end() + 1);, etl::vector_out_of_bounds);
+    }
+
+    //*************************************************************************
     TEST_FIXTURE(SetupFixture, test_erase_single_const_iterator)
     {
       Compare_Data compare_data(initial_data.begin(), initial_data.end());
@@ -1072,6 +1130,14 @@ namespace
     }
 
     //*************************************************************************
+    TEST_FIXTURE(SetupFixture, test_erase_single_const_iterator_outofbounds)
+    {
+      Data data(initial_data.begin(), initial_data.end());
+
+      CHECK_THROW(data.erase(data.cend() + 1);, etl::vector_out_of_bounds);
+    }
+
+    //*************************************************************************
     TEST_FIXTURE(SetupFixture, test_erase_range)
     {
       Compare_Data compare_data(initial_data.begin(), initial_data.end());
@@ -1094,6 +1160,14 @@ namespace
                                 compare_data.begin());
 
       CHECK(is_equal);
+    }
+
+    //*************************************************************************
+    TEST_FIXTURE(SetupFixture, test_erase_range_outofbounds)
+    {
+      Data data(initial_data.begin(), initial_data.end());
+
+      CHECK_THROW(data.erase(data.begin(), data.end() + 1);, etl::vector_out_of_bounds);
     }
 
     //*************************************************************************

--- a/test/test_vector_external_buffer.cpp
+++ b/test/test_vector_external_buffer.cpp
@@ -462,6 +462,8 @@ namespace
       {
         CHECK_EQUAL(data[i], compare_data[i]);
       }
+
+      CHECK_THROW(data[data.size()], etl::vector_out_of_bounds);
     }
 
     //*************************************************************************
@@ -475,6 +477,8 @@ namespace
       {
         CHECK_EQUAL(data[i], compare_data[i]);
       }
+
+      CHECK_THROW(data[data.size()], etl::vector_out_of_bounds);
     }
 
     //*************************************************************************
@@ -512,6 +516,9 @@ namespace
       Data data(initial_data.begin(), initial_data.end(), buffer1, SIZE);
 
       CHECK_EQUAL(compare_data.front(), data.front());
+
+      Data emptyData(buffer1, SIZE);
+      CHECK_THROW(emptyData.front(), etl::vector_out_of_bounds);
     }
 
     //*************************************************************************
@@ -521,6 +528,9 @@ namespace
       const Data data(initial_data.begin(), initial_data.end(), buffer1, SIZE);
 
       CHECK_EQUAL(compare_data.front(), data.front());
+
+      const Data emptyData(buffer1, SIZE);
+      CHECK_THROW(emptyData.front(), etl::vector_out_of_bounds);
     }
 
     //*************************************************************************
@@ -530,6 +540,9 @@ namespace
       Data data(initial_data.begin(), initial_data.end(), buffer1, SIZE);
 
       CHECK_EQUAL(compare_data.back(), data.back());
+
+      Data emptyData(buffer1, SIZE);
+      CHECK_THROW(emptyData.back(), etl::vector_out_of_bounds);
     }
 
     //*************************************************************************
@@ -539,6 +552,9 @@ namespace
       const Data data(initial_data.begin(), initial_data.end(), buffer1, SIZE);
 
       CHECK_EQUAL(compare_data.back(), data.back());
+
+      const Data emptyData(buffer1, SIZE);
+      CHECK_THROW(emptyData.back(), etl::vector_out_of_bounds);
     }
 
 
@@ -779,6 +795,11 @@ namespace
 
         CHECK(is_equal);
       }
+
+      Data data(buffer1, SIZE);
+      data.assign(initial_data.begin(), initial_data.begin() + INITIAL_SIZE);
+      CHECK_THROW(data.insert(data.cbegin() - 1, INITIAL_VALUE), etl::vector_out_of_bounds);
+      CHECK_THROW(data.insert(data.cbegin() + INITIAL_SIZE + 1, INITIAL_VALUE), etl::vector_out_of_bounds);
     }
 
     //*************************************************************************

--- a/test/test_vector_external_buffer.cpp
+++ b/test/test_vector_external_buffer.cpp
@@ -268,8 +268,8 @@ namespace
       Data data(10, buffer1, SIZE);
       const Data constData(10, buffer1, SIZE);
 
-      CHECK_EQUAL(&data[10], data.end());
-      CHECK_EQUAL(&constData[10], constData.end());
+      CHECK_EQUAL(data.begin() + data.size(), data.end());
+      CHECK_EQUAL(constData.begin() + constData.size(), constData.end());
     }
 
     //*************************************************************************

--- a/test/test_vector_external_buffer.cpp
+++ b/test/test_vector_external_buffer.cpp
@@ -557,7 +557,6 @@ namespace
       CHECK_THROW(emptyData.back(), etl::vector_out_of_bounds);
     }
 
-
     //*************************************************************************
     TEST_FIXTURE(SetupFixture, test_data)
     {
@@ -853,6 +852,14 @@ namespace
     }
 
     //*************************************************************************
+    TEST_FIXTURE(SetupFixture, test_insert_position_n_value_outofbounds)
+    {
+      Data data(buffer1, SIZE);
+
+      CHECK_THROW(data.insert(data.end() + 1, 1, 0);, etl::vector_out_of_bounds);
+    }
+
+    //*************************************************************************
     TEST_FIXTURE(SetupFixture, test_insert_position_n_value_excess)
     {
       const size_t INITIAL_SIZE = SIZE;
@@ -930,6 +937,13 @@ namespace
       CHECK_THROW(data.insert(data.begin() + offset, initial_data.begin(), initial_data.end()), etl::vector_full);
     }
 
+    //*************************************************************************
+    TEST_FIXTURE(SetupFixture, test_insert_position_range_out_of_bounds)
+    {
+      Data data(buffer1, SIZE);
+
+      CHECK_THROW(data.insert(data.end() + 1, insert_data.cbegin(), insert_data.cend());, etl::vector_out_of_bounds);
+    }
 
     //*************************************************************************
     TEST_FIXTURE(SetupFixture, test_erase_single)
@@ -951,6 +965,14 @@ namespace
     }
 
     //*************************************************************************
+    TEST_FIXTURE(SetupFixture, test_erase_single_iterator_outofbounds)
+    {
+      Data data(initial_data.begin(), initial_data.end(), buffer1, SIZE);
+
+      CHECK_THROW(data.erase(data.end() + 1);, etl::vector_out_of_bounds);
+    }
+
+    //*************************************************************************
     TEST_FIXTURE(SetupFixture, test_erase_range)
     {
       Compare_Data compare_data(initial_data.begin(), initial_data.end());
@@ -967,6 +989,14 @@ namespace
                                 compare_data.begin());
 
       CHECK(is_equal);
+    }
+
+    //*************************************************************************
+    TEST_FIXTURE(SetupFixture, test_erase_range_outofbounds)
+    {
+      Data data(initial_data.begin(), initial_data.end(), buffer1, SIZE);
+
+      CHECK_THROW(data.erase(data.begin(), data.end() + 1);, etl::vector_out_of_bounds);
     }
 
     //*************************************************************************

--- a/test/test_vector_non_trivial.cpp
+++ b/test/test_vector_non_trivial.cpp
@@ -465,6 +465,8 @@ namespace
       {
         CHECK_EQUAL(data[i], compare_data[i]);
       }
+
+      CHECK_THROW(data[data.size()], etl::vector_out_of_bounds);
     }
 
     //*************************************************************************
@@ -478,6 +480,8 @@ namespace
       {
         CHECK_EQUAL(data[i], compare_data[i]);
       }
+
+      CHECK_THROW(data[data.size()], etl::vector_out_of_bounds);
     }
 
     //*************************************************************************
@@ -515,6 +519,9 @@ namespace
       DataNDC data(initial_data.begin(), initial_data.end());
 
       CHECK(data.front() == compare_data.front());
+
+      DataNDC emptyData;
+      CHECK_THROW(emptyData.front(), etl::vector_out_of_bounds);
     }
 
     //*************************************************************************
@@ -524,6 +531,9 @@ namespace
       const DataNDC data(initial_data.begin(), initial_data.end());
 
       CHECK(data.front() == compare_data.front());
+
+      const DataNDC emptyData;
+      CHECK_THROW(emptyData.front(), etl::vector_out_of_bounds);
     }
 
     //*************************************************************************
@@ -533,6 +543,9 @@ namespace
       DataNDC data(initial_data.begin(), initial_data.end());
 
       CHECK(data.back() == compare_data.back());
+
+      DataNDC emptyData;
+      CHECK_THROW(emptyData.back(), etl::vector_out_of_bounds);
     }
 
     //*************************************************************************
@@ -542,6 +555,9 @@ namespace
       const DataNDC data(initial_data.begin(), initial_data.end());
 
       CHECK(data.back() == compare_data.back());
+
+      const DataNDC emptyData;
+      CHECK_THROW(emptyData.back(), etl::vector_out_of_bounds);
     }
 
     //*************************************************************************
@@ -932,6 +948,11 @@ namespace
 
         CHECK(is_equal);
       }
+
+      DataNDC data;
+      data.assign(initial_data.begin(), initial_data.begin() + INITIAL_SIZE);
+      CHECK_THROW(data.insert(data.cbegin() - 1, INITIAL_VALUE), etl::vector_out_of_bounds);
+      CHECK_THROW(data.insert(data.cbegin() + INITIAL_SIZE + 1, INITIAL_VALUE), etl::vector_out_of_bounds);
     }
 
     //*************************************************************************
@@ -959,6 +980,20 @@ namespace
 
         CHECK(is_equal);
       }
+
+      DataNDC data;
+      data.assign(initial_data.begin(), initial_data.begin() + INITIAL_SIZE);
+      CHECK_THROW(data.emplace(data.cbegin() - 1, INITIAL_VALUE), etl::vector_out_of_bounds);
+      CHECK_THROW(data.emplace(data.cbegin() + INITIAL_SIZE + 1, INITIAL_VALUE), etl::vector_out_of_bounds);
+    }
+
+    //*************************************************************************
+    TEST(test_emplace_out_of_range)
+    {
+      DataNDC data;
+      const std::string INITIAL_VALUE("1");
+
+      CHECK_THROW(data.emplace(data.end() + 1, INITIAL_VALUE);, etl::vector_out_of_bounds);
     }
 
     //*************************************************************************
@@ -1010,6 +1045,15 @@ namespace
 
         CHECK(is_equal);
       }
+    }
+
+    //*************************************************************************
+    TEST_FIXTURE(SetupFixture, test_insert_position_n_value_outofbounds)
+    {
+      DataNDC data;
+      const NDC INITIAL_VALUE("1");
+
+      CHECK_THROW(data.insert(data.end() + 1, 1, INITIAL_VALUE);, etl::vector_out_of_bounds);
     }
 
     //*************************************************************************
@@ -1092,6 +1136,14 @@ namespace
     }
 
     //*************************************************************************
+    TEST_FIXTURE(SetupFixture, test_insert_position_range_out_of_bounds)
+    {
+      DataNDC data;
+
+      CHECK_THROW(data.insert(data.end() + 1, insert_data.cbegin(), insert_data.cend());, etl::vector_out_of_bounds);
+    }
+
+    //*************************************************************************
     TEST_FIXTURE(SetupFixture, test_erase_single)
     {
       CompareDataNDC compare_data(initial_data.begin(), initial_data.end());
@@ -1111,6 +1163,14 @@ namespace
     }
 
     //*************************************************************************
+    TEST_FIXTURE(SetupFixture, test_erase_single_iterator_outofbounds)
+    {
+      DataNDC data(initial_data.begin(), initial_data.end());
+
+      CHECK_THROW(data.erase(data.end() + 1);, etl::vector_out_of_bounds);
+    }
+
+    //*************************************************************************
     TEST_FIXTURE(SetupFixture, test_erase_range)
     {
       CompareDataNDC compare_data(initial_data.begin(), initial_data.end());
@@ -1127,6 +1187,14 @@ namespace
                                 compare_data.begin());
 
       CHECK(is_equal);
+    }
+
+    //*************************************************************************
+    TEST_FIXTURE(SetupFixture, test_erase_range_outofbounds)
+    {
+      DataNDC data(initial_data.begin(), initial_data.end());
+
+      CHECK_THROW(data.erase(data.begin(), data.end() + 1);, etl::vector_out_of_bounds);
     }
 
     //*************************************************************************

--- a/test/test_vector_non_trivial.cpp
+++ b/test/test_vector_non_trivial.cpp
@@ -364,8 +364,8 @@ namespace
       DataDC data(10);
       const DataDC constData(10);
 
-      CHECK_EQUAL(&data[10], data.end());
-      CHECK_EQUAL(&constData[10], constData.end());
+      CHECK_EQUAL(data.begin() + data.size(), data.end());
+      CHECK_EQUAL(constData.begin() + constData.size(), constData.end());
     }
 
     //*************************************************************************


### PR DESCRIPTION
Continuing #1188, this is adding `ETL_ASSERT_CHECK_INDEX_OPERATOR` and `ETL_ASSERT_CHECK_EXTRA` checks to `etl::vector` and `etl::vector_ext`.  Also adds tests for the assertions.

The existing tests for the end iterator were changed because they were indexing out of bounds in order to test the end iterator.  It was instead changed to incrementing the begin iterator.

I'm not sure if `vector_pointer` and `vector_pointer_ext` are still in use, but this PR does not cover those because they use a different base class.