### PR TITLE
support etl as an ESP-IDF component

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,11 @@
 #######################################################################
 cmake_minimum_required(VERSION 3.10)
 
+if (ESP_PLATFORM)
+    idf_component_register(INCLUDE_DIRS "include")
+    return()
+endif()
+
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/helpers.cmake)
 
 set(MSG_PREFIX "etl |")


### PR DESCRIPTION
This change is intended to make etl integration into the ESP-IDF ecosystem painless. Without this patch, it took me a while to figure out a way to integrate this library into the build, here is what's needed:
1. In the ESP-IDF project CMakeLists.txt:
```cmake
include(FetchContent)
FetchContent_Declare(etl SOURCE_DIR ${WORKSPACE_DIR}/etl)
FetchContent_MakeAvailable(etl)
```
2. In the ESP-IDF component (e.g. `main`) CMakeLists.txt:
```cmake
target_link_libraries(${COMPONENT_LIB} # e.g. __idf_main
    PUBLIC etl
)
```

This change aims to support etl with ESP-IDF's component system. The return from the cmake file processing early is necessary because ESP-IDF runs cmake in script mode, where all paths are flattened, and `${CMAKE_CURRENT_SOURCE_DIR}/cmake/helpers.cmake` is resolved incorrectly, failing the build. With this modification, etl can be used with the established component syntax:
```cmake
list(APPEND EXTRA_COMPONENT_DIRS "${WORKSPACE_DIR}/etl")
```
```cmake
idf_component_register(
    REQUIRES
        etl
    INCLUDE_DIRS
    SRCS
        main.cpp
)
```