### PR TITLE
Change generators to reflect changes in fsm.h and type_traits.h

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -10,7 +10,9 @@ COPY ./reinstall-cmake.sh /tmp/
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y install --no-install-recommends \
         git \
-        wget
+        wget \
+        python3-cogapp \
+    && rm -rf /var/lib/apt/lists/*
 
 RUN if [ "${REINSTALL_CMAKE_VERSION_FROM_SOURCE}" != "none" ]; then \
         chmod +x /tmp/reinstall-cmake.sh && /tmp/reinstall-cmake.sh ${REINSTALL_CMAKE_VERSION_FROM_SOURCE}; \

--- a/.github/workflows/generator.yml
+++ b/.github/workflows/generator.yml
@@ -1,0 +1,25 @@
+name: generator checks
+on:
+  push:
+    branches: [ master, development, pull-request/* ]
+  pull_request:
+    branches: [ master, pull-request/* ]
+    types: [opened, synchronize, reopened]
+
+jobs:
+  generator-run:
+    name: Header Generator
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Generate
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y python3-cogapp
+        cd include/etl/generators && bash generate.bat
+
+    - name: Check Generated Headers For Changes
+      run: |
+        git diff --exit-code

--- a/include/etl/generators/fsm_generator.h
+++ b/include/etl/generators/fsm_generator.h
@@ -180,18 +180,6 @@ namespace etl
   };
 
   //***************************************************************************
-  /// Exception for forbidden state changes.
-  //***************************************************************************
-  class fsm_state_composite_state_change_forbidden : public etl::fsm_exception
-  {
-  public:
-    fsm_state_composite_state_change_forbidden(string_type file_name_, numeric_type line_number_)
-      : etl::fsm_exception(ETL_ERROR_TEXT("fsm:change in composite state forbidden", ETL_FSM_FILE_ID"E"), file_name_, line_number_)
-    {
-    }
-  };
-
-  //***************************************************************************
   /// Exception for message received but not started.
   //***************************************************************************
   class fsm_not_started : public etl::fsm_exception
@@ -356,7 +344,6 @@ namespace etl
 
       if (p_default_child == ETL_NULLPTR)
       {
-        p_active_child = &state;
         p_default_child = &state;
       }
     }
@@ -507,7 +494,7 @@ namespace etl
     virtual void start(bool call_on_enter_state = true)
     {
       // Can only be started once.
-      if (p_state == ETL_NULLPTR)
+      if (!is_started())
       {
         p_state = state_list[0];
         ETL_ASSERT(p_state != ETL_NULLPTR, ETL_ERROR(etl::fsm_null_state_exception));
@@ -615,7 +602,7 @@ namespace etl
     //*******************************************
     virtual void reset(bool call_on_exit_state = false)
     {
-      if ((p_state != ETL_NULLPTR) && call_on_exit_state)
+      if (is_started() && call_on_exit_state)
       {
         p_state->on_exit_state();
       }
@@ -662,6 +649,12 @@ namespace etl
     //*******************************************
     virtual etl::fsm_state_id_t process_state_change(etl::fsm_state_id_t next_state_id)
     {
+      if (is_self_transition(next_state_id))
+      {
+        p_state->on_exit_state();
+        next_state_id = p_state->on_enter_state();
+      }
+      
       if (have_changed_state(next_state_id))
       {
         ETL_ASSERT_OR_RETURN_VALUE(next_state_id < number_of_states, ETL_ERROR(etl::fsm_state_id_exception), p_state->get_state_id());
@@ -680,11 +673,6 @@ namespace etl
             p_next_state = state_list[next_state_id];
           }
         } while (p_next_state != p_state); // Have we changed state again?
-      }
-      else if (is_self_transition(next_state_id))
-      {
-        p_state->on_exit_state();
-        p_state->on_enter_state();
       }
 
       return p_state->get_state_id();

--- a/include/etl/generators/type_traits_generator.h
+++ b/include/etl/generators/type_traits_generator.h
@@ -2489,6 +2489,28 @@ typedef integral_constant<bool, true>  true_type;
   template <typename T, template <typename...> class Template>
   inline constexpr bool is_specialization_v = etl::is_specialization<T, Template>::value;
 #endif
+
+  //*********************************************
+  // is_constant_evaluated
+  ETL_CONSTEXPR inline bool is_constant_evaluated() ETL_NOEXCEPT
+  {
+#if ETL_USING_CPP23
+    if consteval
+    {
+      return true;
+    }
+    else
+    {
+      return false;
+    }
+#elif ETL_USING_BUILTIN_IS_CONSTANT_EVALUATED == 1
+    // fallback for C++20 on supported compilers
+    return __builtin_is_constant_evaluated();
+#else
+    // default if unsupported
+    return false;
+#endif
+  }
 }
 
 // Helper macros


### PR DESCRIPTION
Previous changes were wrongfully made in fsm.h and type_traits.h instead of in their generator counterparts.

Add CI check to ensure generated files are in sync.