### PR TITLE
Basic string checks

### DIFF
--- a/include/etl/basic_string.h
+++ b/include/etl/basic_string.h
@@ -1082,6 +1082,7 @@ namespace etl
     iterator insert(const_iterator position, TIterator first, TIterator last)
     {
       ETL_ASSERT_CHECK_EXTRA(cbegin() <= position && position <= cend(), ETL_ERROR(string_out_of_bounds));
+      ETL_ASSERT_CHECK_EXTRA(first <= last, ETL_ERROR(string_iterator));
       
       iterator position_ = to_iterator(position);
 

--- a/test/test_string_char.cpp
+++ b/test/test_string_char.cpp
@@ -1560,6 +1560,17 @@ namespace
     }
 
     //*************************************************************************
+    TEST_FIXTURE(SetupFixture, test_insert_position_range_swapped_iterators)
+    {
+      const size_t INITIAL_SIZE = 5UL;
+
+      Text text;
+      text.assign(initial_text.begin(), initial_text.begin() + INITIAL_SIZE);
+
+      CHECK_THROW(text.insert(text.cbegin(), insert_text.cend(), insert_text.cbegin()), etl::string_iterator);
+    }
+
+    //*************************************************************************
     TEST_FIXTURE(SetupFixture, test_insert_position_range_excess)
     {
       const size_t INITIAL_SIZE = 5UL;

--- a/test/test_string_char_external_buffer.cpp
+++ b/test/test_string_char_external_buffer.cpp
@@ -1778,6 +1778,18 @@ namespace
     }
 
     //*************************************************************************
+    TEST_FIXTURE(SetupFixture, test_insert_position_range_swapped_iterators)
+    {
+      const size_t INITIAL_SIZE = 5UL;
+
+      TextBuffer buffer{0};
+      Text text(buffer.data(), buffer.size());
+      text.assign(initial_text.begin(), initial_text.begin() + INITIAL_SIZE);
+
+      CHECK_THROW(text.insert(text.cbegin(), insert_text.cend(), insert_text.cbegin()), etl::string_iterator);
+    }
+
+    //*************************************************************************
     TEST_FIXTURE(SetupFixture, test_insert_position_range_excess)
     {
       const size_t INITIAL_SIZE = 5UL;

--- a/test/test_string_u16.cpp
+++ b/test/test_string_u16.cpp
@@ -1632,6 +1632,17 @@ namespace
     }
 
     //*************************************************************************
+    TEST_FIXTURE(SetupFixture, test_insert_position_range_swapped_iterators)
+    {
+      const size_t INITIAL_SIZE = 5UL;
+
+      Text text;
+      text.assign(initial_text.begin(), initial_text.begin() + INITIAL_SIZE);
+
+      CHECK_THROW(text.insert(text.cbegin(), insert_text.cend(), insert_text.cbegin()), etl::string_iterator);
+    }
+
+    //*************************************************************************
     TEST_FIXTURE(SetupFixture, test_insert_position_range_excess)
     {
       const size_t INITIAL_SIZE = 5UL;

--- a/test/test_string_u16_external_buffer.cpp
+++ b/test/test_string_u16_external_buffer.cpp
@@ -1879,6 +1879,18 @@ namespace
     }
 
     //*************************************************************************
+    TEST_FIXTURE(SetupFixture, test_insert_position_range_swapped_iterators)
+    {
+      const size_t INITIAL_SIZE = 5UL;
+
+      TextBuffer buffer{0};
+      Text text(buffer.data(), buffer.size());
+      text.assign(initial_text.begin(), initial_text.begin() + INITIAL_SIZE);
+
+      CHECK_THROW(text.insert(text.cbegin(), insert_text.cend(), insert_text.cbegin()), etl::string_iterator);
+    }
+
+    //*************************************************************************
     TEST_FIXTURE(SetupFixture, test_insert_position_range_excess)
     {
       const size_t INITIAL_SIZE = 5UL;

--- a/test/test_string_u32.cpp
+++ b/test/test_string_u32.cpp
@@ -1632,6 +1632,17 @@ namespace
     }
 
     //*************************************************************************
+    TEST_FIXTURE(SetupFixture, test_insert_position_range_swapped_iterators)
+    {
+      const size_t INITIAL_SIZE = 5UL;
+
+      Text text;
+      text.assign(initial_text.begin(), initial_text.begin() + INITIAL_SIZE);
+
+      CHECK_THROW(text.insert(text.cbegin(), insert_text.cend(), insert_text.cbegin()), etl::string_iterator);
+    }
+
+    //*************************************************************************
     TEST_FIXTURE(SetupFixture, test_insert_position_range_excess)
     {
       const size_t INITIAL_SIZE = 5UL;

--- a/test/test_string_u32_external_buffer.cpp
+++ b/test/test_string_u32_external_buffer.cpp
@@ -1879,6 +1879,18 @@ namespace
     }
 
     //*************************************************************************
+    TEST_FIXTURE(SetupFixture, test_insert_position_range_swapped_iterators)
+    {
+      const size_t INITIAL_SIZE = 5UL;
+
+      TextBuffer buffer{0};
+      Text text(buffer.data(), buffer.size());
+      text.assign(initial_text.begin(), initial_text.begin() + INITIAL_SIZE);
+
+      CHECK_THROW(text.insert(text.cbegin(), insert_text.cend(), insert_text.cbegin()), etl::string_iterator);
+    }
+
+    //*************************************************************************
     TEST_FIXTURE(SetupFixture, test_insert_position_range_excess)
     {
       const size_t INITIAL_SIZE = 5UL;

--- a/test/test_string_u8.cpp
+++ b/test/test_string_u8.cpp
@@ -1577,6 +1577,17 @@ namespace
     }
 
     //*************************************************************************
+    TEST_FIXTURE(SetupFixture, test_insert_position_range_swapped_iterators)
+    {
+      const size_t INITIAL_SIZE = 5UL;
+
+      Text text;
+      text.assign(initial_text.begin(), initial_text.begin() + INITIAL_SIZE);
+
+      CHECK_THROW(text.insert(text.cbegin(), insert_text.cend(), insert_text.cbegin()), etl::string_iterator);
+    }
+
+    //*************************************************************************
     TEST_FIXTURE(SetupFixture, test_insert_position_range_excess)
     {
       const size_t INITIAL_SIZE = 5UL;

--- a/test/test_string_u8_external_buffer.cpp
+++ b/test/test_string_u8_external_buffer.cpp
@@ -1795,6 +1795,18 @@ namespace
     }
 
     //*************************************************************************
+    TEST_FIXTURE(SetupFixture, test_insert_position_range_swapped_iterators)
+    {
+      const size_t INITIAL_SIZE = 5UL;
+
+      TextBuffer buffer{0};
+      Text text(buffer.data(), buffer.size());
+      text.assign(initial_text.begin(), initial_text.begin() + INITIAL_SIZE);
+
+      CHECK_THROW(text.insert(text.cbegin(), insert_text.cend(), insert_text.cbegin()), etl::string_iterator);
+    }
+
+    //*************************************************************************
     TEST_FIXTURE(SetupFixture, test_insert_position_range_excess)
     {
       const size_t INITIAL_SIZE = 5UL;

--- a/test/test_string_wchar_t.cpp
+++ b/test/test_string_wchar_t.cpp
@@ -1633,6 +1633,17 @@ namespace
     }
 
     //*************************************************************************
+    TEST_FIXTURE(SetupFixture, test_insert_position_range_swapped_iterators)
+    {
+      const size_t INITIAL_SIZE = 5UL;
+
+      Text text;
+      text.assign(initial_text.begin(), initial_text.begin() + INITIAL_SIZE);
+
+      CHECK_THROW(text.insert(text.cbegin(), insert_text.cend(), insert_text.cbegin()), etl::string_iterator);
+    }
+
+    //*************************************************************************
     TEST_FIXTURE(SetupFixture, test_insert_position_range_excess)
     {
       const size_t INITIAL_SIZE = 5UL;

--- a/test/test_string_wchar_t_external_buffer.cpp
+++ b/test/test_string_wchar_t_external_buffer.cpp
@@ -1882,6 +1882,18 @@ namespace
     }
 
     //*************************************************************************
+    TEST_FIXTURE(SetupFixture, test_insert_position_range_swapped_iterators)
+    {
+      const size_t INITIAL_SIZE = 5UL;
+
+      TextBuffer buffer{0};
+      Text text(buffer.data(), buffer.size());
+      text.assign(initial_text.begin(), initial_text.begin() + INITIAL_SIZE);
+
+      CHECK_THROW(text.insert(text.cbegin(), insert_text.cend(), insert_text.cbegin()), etl::string_iterator);
+    }
+
+    //*************************************************************************
     TEST_FIXTURE(SetupFixture, test_insert_position_range_excess)
     {
       const size_t INITIAL_SIZE = 5UL;


### PR DESCRIPTION
Add `ETL_ASSERT_CHECK_INDEX_OPERATOR` to index operations.  Some tests needed to be updated to not trigger the assertion.

Add `ETL_ASSERT_CHECK_EXTRA` to various `front()`, `back()`, `insert()` and `erase()` overloads.  Add tests for the various assertions.