### PR TITLE
Fix is_truncated in basic_string

### DIFF
--- a/include/etl/basic_string.h
+++ b/include/etl/basic_string.h
@@ -764,7 +764,7 @@ namespace etl
       set_truncated(n > CAPACITY);
 
 #if ETL_HAS_ERROR_ON_STRING_TRUNCATION
-      ETL_ASSERT(is_truncated == false, ETL_ERROR(string_truncation));
+      ETL_ASSERT(is_truncated() == false, ETL_ERROR(string_truncation));
 #endif
 #endif
 
@@ -912,7 +912,7 @@ namespace etl
       set_truncated(n > free_space);
 
 #if ETL_HAS_ERROR_ON_STRING_TRUNCATION
-      ETL_ASSERT(is_truncated == false, ETL_ERROR(string_truncation));
+      ETL_ASSERT(is_truncated() == false, ETL_ERROR(string_truncation));
 #endif
 #endif
 
@@ -2753,7 +2753,7 @@ namespace etl
       set_truncated((count > free_space) || this->is_truncated() || truncated);
 
 #if ETL_HAS_ERROR_ON_STRING_TRUNCATION
-      ETL_ASSERT(is_truncated == false, ETL_ERROR(string_truncation));
+      ETL_ASSERT(is_truncated() == false, ETL_ERROR(string_truncation));
 #endif
 #endif
 
@@ -2799,7 +2799,7 @@ namespace etl
 #if ETL_HAS_STRING_TRUNCATION_CHECKS
       set_truncated(truncated);
 #if ETL_HAS_ERROR_ON_STRING_TRUNCATION
-      ETL_ASSERT(is_truncated == false, ETL_ERROR(string_truncation));
+      ETL_ASSERT(is_truncated() == false, ETL_ERROR(string_truncation));
 #endif
 #endif
 

--- a/test/test_make_string.cpp
+++ b/test/test_make_string.cpp
@@ -141,7 +141,6 @@ namespace
     TEST_FIXTURE(SetupFixture, test_make_string_with_capacity_truncated)
     {
       constexpr size_t CAPACITY = 10UL;
-      size_t length = strlen("Hello World");
 
 #if ETL_HAS_ERROR_ON_STRING_TRUNCATION
       CHECK_THROW(auto ctext   = etl::make_string_with_capacity<CAPACITY>("Hello World"),  etl::string_truncation);
@@ -149,6 +148,8 @@ namespace
       CHECK_THROW(auto u16text = etl::make_string_with_capacity<CAPACITY>(u"Hello World"), etl::string_truncation);;
       CHECK_THROW(auto u32text = etl::make_string_with_capacity<CAPACITY>(U"Hello World"), etl::string_truncation);;
 #else
+      size_t length = strlen("Hello World");
+
       auto ctext   = etl::make_string_with_capacity<CAPACITY>("Hello World");
       auto wtext   = etl::make_string_with_capacity<CAPACITY>(L"Hello World");
       auto u16text = etl::make_string_with_capacity<CAPACITY>(u"Hello World");


### PR DESCRIPTION
The library failed to build when ETL_ENABLE_ERROR_ON_STRING_TRUNCATION was defined, because is_truncated was used as a bool, not as a function.