### PR TITLE
Fix value_or not taking const in optional

### DIFF
--- a/include/etl/optional.h
+++ b/include/etl/optional.h
@@ -470,7 +470,7 @@ namespace etl
       etl::enable_if_t<etl::is_convertible<U, T>::value, T>
         value_or(U&& default_value) const&
       {
-        return has_value() ? value() : etl::forward<T>(default_value);
+        return has_value() ? value() : static_cast<T>(etl::forward<U>(default_value));
       }
 
       //***************************************************************************
@@ -481,7 +481,7 @@ namespace etl
       etl::enable_if_t<etl::is_convertible<U, T>::value, T>
         value_or(U&& default_value)&&
       {
-        return has_value() ? etl::move(value()) : etl::forward<T>(default_value);
+        return has_value() ? etl::move(value()) : static_cast<T>(etl::forward<U>(default_value));
       }
 #endif
 
@@ -1084,7 +1084,7 @@ namespace etl
       etl::enable_if_t<etl::is_convertible<U, T>::value, T>
         value_or(U&& default_value) const&
       {
-        return has_value() ? value() : etl::forward<T>(default_value);
+        return has_value() ? value() : static_cast<T>(etl::forward<U>(default_value));
       }
 
       //***************************************************************************
@@ -1095,7 +1095,7 @@ namespace etl
       etl::enable_if_t<etl::is_convertible<U, T>::value, T>
         value_or(U&& default_value)&&
       {
-        return has_value() ? etl::move(value()) : etl::forward<T>(default_value);
+        return has_value() ? etl::move(value()) : static_cast<T>(etl::forward<U>(default_value));
       }
 #endif
 

--- a/test/test_optional.cpp
+++ b/test/test_optional.cpp
@@ -299,6 +299,21 @@ namespace
     }
 
     //*************************************************************************
+    TEST(test_value_or_const)
+    {
+      using FundamentalType = int;
+      using NonFundamentalType = std::string;
+
+      const FundamentalType constFT{ 5 };
+      int resultFT = etl::optional<FundamentalType>{}.value_or(constFT);
+      CHECK_EQUAL(5, resultFT);
+
+      const NonFundamentalType constNFT{ "Default" };
+      NonFundamentalType resultNFT = etl::optional<NonFundamentalType>{}.value_or(constNFT);
+      CHECK_EQUAL("Default", resultNFT);
+    }
+
+    //*************************************************************************
     struct github_bug_720_bug_helper
     {
       int value{ 5 };


### PR DESCRIPTION
Makes possible passing a const value into `value_or`.
Added a unit test that does not compile without this fix.

Fixes #1224 