### PR TITLE
Add missing include to optional

### DIFF
--- a/include/etl/optional.h
+++ b/include/etl/optional.h
@@ -39,6 +39,7 @@ SOFTWARE.
 #include "error_handler.h"
 #include "utility.h"
 #include "placement_new.h"
+#include "initializer_list.h"
 
 namespace etl
 {


### PR DESCRIPTION
When the initializer list is not included, the default std::initializer list is used and ETL_NO_STL would be ignored.