### PR TITLE
Various cleanup

### DIFF
--- a/test/test_rounded_integral_division.cpp
+++ b/test/test_rounded_integral_division.cpp
@@ -624,7 +624,7 @@ namespace
       CHECK_EQUAL(std::numeric_limits<int32_t>::max(), etl::divide_round_half_down(std::numeric_limits<int32_t>::max(), int32_t(1)));
       CHECK_EQUAL(int32_t(0),                          etl::divide_round_half_down(int32_t(1),                          std::numeric_limits<int32_t>::max()));
       CHECK_EQUAL(std::numeric_limits<int32_t>::min(), etl::divide_round_half_down(std::numeric_limits<int32_t>::min(), int32_t(1)));
-      CHECK_EQUAL(int32_t(-1),                         etl::divide_round_half_down(int32_t(1),                          std::numeric_limits<int32_t>::min()));
+      CHECK_EQUAL(int32_t(0),                          etl::divide_round_half_down(int32_t(1),                          std::numeric_limits<int32_t>::min()));
     }
 
     //*************************************************************************
@@ -840,7 +840,7 @@ namespace
       CHECK_EQUAL(std::numeric_limits<int32_t>::max(), etl::divide_round_half_odd(std::numeric_limits<int32_t>::max(), int32_t(1)));
       CHECK_EQUAL(int32_t(0),                          etl::divide_round_half_odd(int32_t(1),                          std::numeric_limits<int32_t>::max()));
       CHECK_EQUAL(std::numeric_limits<int32_t>::min(), etl::divide_round_half_odd(std::numeric_limits<int32_t>::min(), int32_t(1)));
-      CHECK_EQUAL(int32_t(-1),                         etl::divide_round_half_odd(int32_t(1),                          std::numeric_limits<int32_t>::min()));
+      CHECK_EQUAL(int32_t(0),                          etl::divide_round_half_odd(int32_t(1),                          std::numeric_limits<int32_t>::min()));
     }
 
     //*************************************************************************


### PR DESCRIPTION
This is separated-out from https://github.com/ETLCPP/etl/pull/1235 to keep cleanup / typo fixes separate from bugfixes in build and tests.

Individual commits:
* Fix typo for remainder in rounded_integral_division.h
* Use etl::make_unsigned instead of std::make_unsigned
* Fix divide_round_half_down and divide_round_half_odd