### PR TITLE
Fix discrepancy with STL in max_element and minmax_element

### DIFF
--- a/include/etl/algorithm.h
+++ b/include/etl/algorithm.h
@@ -1528,7 +1528,7 @@ namespace etl
 
       while (begin != end)
       {
-        if (!compare(*begin, *maximum))
+        if (compare(*maximum, *begin))
         {
           maximum = begin;
         }
@@ -1582,7 +1582,7 @@ namespace etl
           minimum = begin;
         }
 
-        if (compare(*maximum, *begin))
+        if (!compare(*begin, *maximum))
         {
           maximum = begin;
         }

--- a/test/test_algorithm.cpp
+++ b/test/test_algorithm.cpp
@@ -53,7 +53,7 @@ namespace
   std::mt19937 urng(rng());
 
   using Vector = std::vector<int>;
-  Vector data = { 2, 1, 4, 3, 6, 5, 8, 7, 10, 9 };
+  Vector data = { 2, 1, 1, 4, 3, 6, 5, 8, 7, 10, 10, 9 };
 
   using VectorM = std::vector<ItemM>;
 


### PR DESCRIPTION
There was a discrepancy with STL with the handling of multiple maximum values.

- In STL: max_element returns the first value when there are multiple equal maximum values.  Currently in ETL: max_element returns the last value.
- In STL: minmax_element returns the last value when there are multiple equal maximum values.  Currently in ETL: minmax_element returns the first value.

The behavior of minimum values already matched.  The test values did not contain multiple min and max values so this discrepancy wasn't seen in the tests.  This PR changes the behavior of the max values to match STL.

https://en.cppreference.com/w/cpp/algorithm/max_element.html

https://en.cppreference.com/w/cpp/algorithm/minmax_element.html