### PR TITLE
Suppress warnings from std in optimized builds

### DIFF
--- a/include/etl/algorithm.h
+++ b/include/etl/algorithm.h
@@ -338,7 +338,9 @@ namespace etl
   template <typename TIterator1, typename TIterator2>
   ETL_CONSTEXPR20 TIterator2 move_backward(TIterator1 sb, TIterator1 se, TIterator2 de)
   {
+#include "etl/private/diagnostic_array_bounds_push.h"
     return std::move_backward(sb, se, de);
+#include "etl/private/diagnostic_pop.h"
   }
 #elif ETL_USING_CPP11
   // For C++11

--- a/include/etl/memory.h
+++ b/include/etl/memory.h
@@ -382,9 +382,13 @@ namespace etl
   ///\ingroup memory
   //*****************************************************************************
   template <typename TInputIterator, typename TOutputIterator>
-  TOutputIterator  uninitialized_move(TInputIterator i_begin, TInputIterator i_end, TOutputIterator o_begin)
+  TOutputIterator uninitialized_move(TInputIterator i_begin, TInputIterator i_end, TOutputIterator o_begin)
   {
+#include "etl/private/diagnostic_array_bounds_push.h"
+#include "etl/private/diagnostic_stringop_overflow_push.h"
     return std::uninitialized_move(i_begin, i_end, o_begin);
+#include "etl/private/diagnostic_pop.h"
+#include "etl/private/diagnostic_pop.h"
   }
 
   //*****************************************************************************
@@ -398,7 +402,9 @@ namespace etl
   {
     count += int32_t(etl::distance(i_begin, i_end));
 
+#include "etl/private/diagnostic_array_bounds_push.h"
     return std::uninitialized_move(i_begin, i_end, o_begin);
+#include "etl/private/diagnostic_pop.h"
   }
 #else
   //*****************************************************************************


### PR DESCRIPTION
When testing with ./run-tests.sh 23 3 10, some warnings from std surfaced which resulted in build errors.