### PR TITLE
Fix incorrect namespace for iter_swap calls

### DIFF
--- a/include/etl/algorithm.h
+++ b/include/etl/algorithm.h
@@ -186,7 +186,7 @@ namespace etl
   {
     while (first1 != last1)
     {
-      iter_swap(first1, first2);
+      etl::iter_swap(first1, first2);
       ++first1;
       ++first2;
     }

--- a/include/etl/private/ivectorpointer.h
+++ b/include/etl/private/ivectorpointer.h
@@ -483,7 +483,7 @@ namespace etl
       ivector<T*>& smaller = other.size() > this->size() ? *this : other;
       ivector<T*>& larger = other.size() > this->size() ? other : *this;
 
-      ETL_OR_STD::swap_ranges(smaller.begin(), smaller.end(), larger.begin());
+      etl::swap_ranges(smaller.begin(), smaller.end(), larger.begin());
 
       typename ivector<T*>::iterator larger_itr = etl::next(larger.begin(), smaller.size());
 
@@ -931,7 +931,7 @@ namespace etl
       ivector<const T*>& smaller = other.size() > this->size() ? *this : other;
       ivector<const T*>& larger = other.size() > this->size() ? other : *this;
 
-      ETL_OR_STD::swap_ranges(smaller.begin(), smaller.end(), larger.begin());
+      etl::swap_ranges(smaller.begin(), smaller.end(), larger.begin());
 
       typename ivector<const T*>::iterator larger_itr = etl::next(larger.begin(), smaller.size());
 

--- a/include/etl/vector.h
+++ b/include/etl/vector.h
@@ -963,7 +963,7 @@ namespace etl
       ivector<T>& smaller = other.size() > this->size() ? *this : other;
       ivector<T>& larger = other.size() > this->size() ? other : *this;
 
-      ETL_OR_STD::swap_ranges(smaller.begin(), smaller.end(), larger.begin());
+      etl::swap_ranges(smaller.begin(), smaller.end(), larger.begin());
 
       typename ivector<T>::iterator larger_itr = etl::next(larger.begin(), smaller.size());
 


### PR DESCRIPTION
itr_swap should not need to be called using ETL_OR_STD::
Changed ETL_OR_STD:: to etl::