### PR TITLE
Print test names at test time

### DIFF
--- a/.github/workflows/clang-c++11.yml
+++ b/.github/workflows/clang-c++11.yml
@@ -28,7 +28,7 @@ jobs:
         make -j $(getconf _NPROCESSORS_ONLN)
 
     - name: Run tests
-      run: ./test/etl_tests
+      run: ./test/etl_tests -v
 
   build-clang-cpp11-linux-no-stl:
     name: Clang C++11 Linux - No STL
@@ -50,4 +50,4 @@ jobs:
         make -j $(getconf _NPROCESSORS_ONLN)
 
     - name: Run tests
-      run: ./test/etl_tests
+      run: ./test/etl_tests -v

--- a/.github/workflows/clang-c++14.yml
+++ b/.github/workflows/clang-c++14.yml
@@ -28,7 +28,7 @@ jobs:
         make -j $(getconf _NPROCESSORS_ONLN)
 
     - name: Run tests
-      run: ./test/etl_tests
+      run: ./test/etl_tests -v
 
   build-clang-cpp14-linux-no-stl:
     name: Clang C++14 Linux - No STL
@@ -50,4 +50,4 @@ jobs:
         make -j $(getconf _NPROCESSORS_ONLN)
 
     - name: Run tests
-      run: ./test/etl_tests
+      run: ./test/etl_tests -v

--- a/.github/workflows/clang-c++17.yml
+++ b/.github/workflows/clang-c++17.yml
@@ -28,7 +28,7 @@ jobs:
         make -j $(getconf _NPROCESSORS_ONLN)
 
     - name: Run tests
-      run: ./test/etl_tests
+      run: ./test/etl_tests -v
 
   build-clang-cpp17-linux-no-stl:
     name: Clang C++17 Linux - No STL
@@ -50,4 +50,4 @@ jobs:
         make -j $(getconf _NPROCESSORS_ONLN)
 
     - name: Run tests
-      run: ./test/etl_tests
+      run: ./test/etl_tests -v

--- a/.github/workflows/clang-c++20.yml
+++ b/.github/workflows/clang-c++20.yml
@@ -35,7 +35,7 @@ jobs:
         make -j $(getconf _NPROCESSORS_ONLN)
     
     - name: Run tests
-      run: ./test/etl_tests
+      run: ./test/etl_tests -v
 
   build-clang-cpp20-linux-stl-force-cpp03:
     name: Clang C++20 Linux - STL - Force C++03
@@ -64,7 +64,7 @@ jobs:
         make -j $(getconf _NPROCESSORS_ONLN)
 
     - name: Run tests
-      run: ./test/etl_tests
+      run: ./test/etl_tests -v
 
   build-clang-cpp20-linux-no-stl-force-cpp03:
     name: Clang C++20 Linux - No STL - Force C++03
@@ -93,7 +93,7 @@ jobs:
         make -j $(getconf _NPROCESSORS_ONLN)
 
     - name: Run tests
-      run: ./test/etl_tests
+      run: ./test/etl_tests -v
 
   build-clang-cpp20-osx-stl:
     name: Clang C++20 OSX - STL
@@ -115,7 +115,7 @@ jobs:
         make -j $(getconf _NPROCESSORS_ONLN)
 
     - name: Run tests
-      run: ./test/etl_tests
+      run: ./test/etl_tests -v
 
   build-clang-cpp20-osx-no-stl:
     name: Clang C++20 OSX - No STL
@@ -137,7 +137,7 @@ jobs:
         make -j $(getconf _NPROCESSORS_ONLN)
 
     - name: Run tests
-      run: ./test/etl_tests
+      run: ./test/etl_tests -v
 
   build-clang-cpp20-osx-stl-force-cpp03:
     name: Clang C++20 OSX - STL - Force C++03
@@ -159,7 +159,7 @@ jobs:
         make -j $(getconf _NPROCESSORS_ONLN)
 
     - name: Run tests
-      run: ./test/etl_tests
+      run: ./test/etl_tests -v
 
   build-clang-cpp20-osx-no-stl-force-cpp03:
     name: Clang C++20 OSX - No STL - Force C++03
@@ -181,5 +181,5 @@ jobs:
         make -j $(getconf _NPROCESSORS_ONLN)
 
     - name: Run tests
-      run: ./test/etl_tests
+      run: ./test/etl_tests -v
 

--- a/.github/workflows/clang-c++23.yml
+++ b/.github/workflows/clang-c++23.yml
@@ -35,7 +35,7 @@ jobs:
         make -j $(getconf _NPROCESSORS_ONLN)
     
     - name: Run tests
-      run: ./test/etl_tests
+      run: ./test/etl_tests -v
 
   build-clang-cpp23-linux-stl-force-cpp03:
     name: Clang C++23 Linux - STL - Force C++03
@@ -64,7 +64,7 @@ jobs:
         make -j $(getconf _NPROCESSORS_ONLN)
 
     - name: Run tests
-      run: ./test/etl_tests
+      run: ./test/etl_tests -v
 
   build-clang-cpp2-linux-no-stl-force-cpp03:
     name: Clang C++23 Linux - No STL - Force C++03
@@ -93,7 +93,7 @@ jobs:
         make -j $(getconf _NPROCESSORS_ONLN)
 
     - name: Run tests
-      run: ./test/etl_tests
+      run: ./test/etl_tests -v
 
   build-clang-cpp23-osx-stl:
     name: Clang C++23 OSX - STL
@@ -115,7 +115,7 @@ jobs:
         make -j $(getconf _NPROCESSORS_ONLN)
 
     - name: Run tests
-      run: ./test/etl_tests
+      run: ./test/etl_tests -v
 
   build-clang-cpp23-osx-no-stl:
     name: Clang C++23 OSX - No STL
@@ -137,7 +137,7 @@ jobs:
         make -j $(getconf _NPROCESSORS_ONLN)
 
     - name: Run tests
-      run: ./test/etl_tests
+      run: ./test/etl_tests -v
 
   build-clang-cpp23-osx-stl-force-cpp03:
     name: Clang C++23 OSX - STL - Force C++03
@@ -159,7 +159,7 @@ jobs:
         make -j $(getconf _NPROCESSORS_ONLN)
 
     - name: Run tests
-      run: ./test/etl_tests
+      run: ./test/etl_tests -v
 
   build-clang-cpp23-osx-no-stl-force-cpp03:
     name: Clang C++23 OSX - No STL - Force C++03
@@ -181,5 +181,5 @@ jobs:
         make -j $(getconf _NPROCESSORS_ONLN)
 
     - name: Run tests
-      run: ./test/etl_tests
+      run: ./test/etl_tests -v
 

--- a/.github/workflows/gcc-c++11.yml
+++ b/.github/workflows/gcc-c++11.yml
@@ -29,7 +29,7 @@ jobs:
         make -j $(getconf _NPROCESSORS_ONLN)
     
     - name: Run tests
-      run: ./test/etl_tests
+      run: ./test/etl_tests -v
 
   build-gcc-cpp11-linux-no-stl:
     name: GCC C++11 Linux - No STL
@@ -52,4 +52,4 @@ jobs:
         make -j $(getconf _NPROCESSORS_ONLN)
     
     - name: Run tests
-      run: ./test/etl_tests
+      run: ./test/etl_tests -v

--- a/.github/workflows/gcc-c++14.yml
+++ b/.github/workflows/gcc-c++14.yml
@@ -28,7 +28,7 @@ jobs:
         make -j $(getconf _NPROCESSORS_ONLN)
     
     - name: Run tests
-      run: ./test/etl_tests
+      run: ./test/etl_tests -v
 
   build-gcc-cpp14-linux-no-stl:
     name: GCC C++14 Linux - No STL
@@ -50,4 +50,4 @@ jobs:
         make -j $(getconf _NPROCESSORS_ONLN)
     
     - name: Run tests
-      run: ./test/etl_tests
+      run: ./test/etl_tests -v

--- a/.github/workflows/gcc-c++17.yml
+++ b/.github/workflows/gcc-c++17.yml
@@ -28,7 +28,7 @@ jobs:
         make -j $(getconf _NPROCESSORS_ONLN)
     
     - name: Run tests
-      run: ./test/etl_tests
+      run: ./test/etl_tests -v
 
   build-gcc-cpp17-linux-no-stl:
     name: GCC C++17 Linux - No STL
@@ -50,4 +50,4 @@ jobs:
         make -j $(getconf _NPROCESSORS_ONLN)
     
     - name: Run tests
-      run: ./test/etl_tests
+      run: ./test/etl_tests -v

--- a/.github/workflows/gcc-c++20.yml
+++ b/.github/workflows/gcc-c++20.yml
@@ -28,7 +28,7 @@ jobs:
         make -j $(getconf _NPROCESSORS_ONLN)
     
     - name: Run tests
-      run: ./test/etl_tests
+      run: ./test/etl_tests -v
 
   build-gcc-cpp20-linux-no-stl:
     name: GCC C++20 Linux - No STL
@@ -50,7 +50,7 @@ jobs:
         make -j $(getconf _NPROCESSORS_ONLN)
     
     - name: Run tests
-      run: ./test/etl_tests
+      run: ./test/etl_tests -v
 
   build-gcc-cpp20-linux-stl-force-cpp03:
     name: GCC C++20 Linux - STL - Force C++03
@@ -72,7 +72,7 @@ jobs:
         make -j $(getconf _NPROCESSORS_ONLN)
 
     - name: Run tests
-      run: ./test/etl_tests
+      run: ./test/etl_tests -v
 
   build-gcc-cpp20-linux-no-stl-force-cpp03:
     name: GCC C++20 Linux - No STL - Force C++03
@@ -94,4 +94,4 @@ jobs:
         make -j $(getconf _NPROCESSORS_ONLN)
     
     - name: Run tests
-      run: ./test/etl_tests
+      run: ./test/etl_tests -v

--- a/.github/workflows/gcc-c++23.yml
+++ b/.github/workflows/gcc-c++23.yml
@@ -28,7 +28,7 @@ jobs:
         make -j $(getconf _NPROCESSORS_ONLN)
     
     - name: Run tests
-      run: ./test/etl_tests
+      run: ./test/etl_tests -v
 
   build-gcc-cpp23-linux-no-stl:
     name: GCC C++23 Linux - No STL
@@ -50,7 +50,7 @@ jobs:
         make -j $(getconf _NPROCESSORS_ONLN)
     
     - name: Run tests
-      run: ./test/etl_tests
+      run: ./test/etl_tests -v
 
   build-gcc-cpp23-linux-stl-force-cpp03:
     name: GCC C++23 Linux - STL - Force C++03
@@ -72,7 +72,7 @@ jobs:
         make -j $(getconf _NPROCESSORS_ONLN)
 
     - name: Run tests
-      run: ./test/etl_tests
+      run: ./test/etl_tests -v
 
   build-gcc-cpp23-linux-no-stl-force-cpp03:
     name: GCC C++23 Linux - No STL - Force C++03
@@ -94,4 +94,4 @@ jobs:
         make -j $(getconf _NPROCESSORS_ONLN)
     
     - name: Run tests
-      run: ./test/etl_tests
+      run: ./test/etl_tests -v

--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -27,7 +27,7 @@ jobs:
         MSBuild.exe .\etl.sln
         
     - name: Run tests
-      run: test/Debug/etl_tests.exe
+      run: test/Debug/etl_tests.exe -v
 
   build-windows-msvc-no-stl:
     name: Windows - No STL
@@ -48,7 +48,7 @@ jobs:
         MSBuild.exe .\etl.sln
         
     - name: Run tests
-      run: test/Debug/etl_tests.exe
+      run: test/Debug/etl_tests.exe -v
 
   build-windows-msvc-stl-force-cpp03:
     name: Windows - STL - Force C++03
@@ -70,7 +70,7 @@ jobs:
         MSBuild.exe .\etl.sln
 
     - name: Run tests
-      run: test/Debug/etl_tests.exe
+      run: test/Debug/etl_tests.exe -v
         
   build-windows-msvc-no-stl-force-cpp03:
     name: Windows - No STL - Force C++03
@@ -92,5 +92,5 @@ jobs:
         MSBuild.exe .\etl.sln
 
     - name: Run tests
-      run: test/Debug/etl_tests.exe
+      run: test/Debug/etl_tests.exe -v
 

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -27,7 +27,88 @@ SOFTWARE.
 
 #include "unit_test_framework.h"
 
-int main()
+#include "UnitTest++/TestReporter.h"
+#include "UnitTest++/TestReporterStdout.h"
+#include "UnitTest++/TestRunner.h"
+#include "UnitTest++/TestDetails.h"
+
+#include <cstring>
+#include <iostream>
+#include <iomanip>
+
+class VerboseTestReporter : public UnitTest::TestReporter
 {
-  return UnitTest::RunAllTests();
+public:
+  VerboseTestReporter() : m_testIndex(0), m_currentTestFailed(false) {}
+
+  void ReportTestStart(UnitTest::TestDetails const& test) override
+  {
+    ++m_testIndex;
+    m_currentTestFailed = false;
+    std::cout << "[START #" << m_testIndex << "] "
+              << test.suiteName << "::" << test.testName << std::endl;
+    std::cout.flush();
+    std::cerr.flush();
+  }
+
+  void ReportTestFinish(UnitTest::TestDetails const& test, float secondsElapsed) override
+  {
+    std::cout.flush();
+    std::cerr.flush();
+    std::cout << "[" << (m_currentTestFailed ? "FAILED" : "PASSED")
+              << "  #" << m_testIndex << "] "
+              << test.suiteName << "::" << test.testName
+              << " (" << std::fixed << std::setprecision(4) << secondsElapsed << " s)"
+              << std::endl;
+  }
+
+  void ReportFailure(UnitTest::TestDetails const& details, char const* failure) override
+  {
+    m_currentTestFailed = true;
+#if defined(__APPLE__) || defined(__GNUG__)
+    std::cerr << details.filename << ":" << details.lineNumber << ":1: error: Failure in "
+              << details.testName << ": " << failure << std::endl;
+#else
+    std::cerr << details.filename << "(" << details.lineNumber << "): error: Failure in "
+              << details.testName << ": " << failure << std::endl;
+#endif
+  }
+
+  void ReportSummary(int totalTestCount, int failedTestCount,
+                     int failureCount, float secondsElapsed) override
+  {
+    if (failureCount > 0)
+      std::cout << "FAILURE: " << failedTestCount << " out of " << totalTestCount
+                << " tests failed (" << failureCount << " failures)." << std::endl;
+    else
+      std::cout << "Success: " << totalTestCount << " tests passed." << std::endl;
+
+    std::cout << "Test time: " << std::fixed << std::setprecision(2)
+              << secondsElapsed << " seconds." << std::endl;
+  }
+
+private:
+  int  m_testIndex;
+  bool m_currentTestFailed;
+};
+
+int main(int argc, char* argv[])
+{
+  bool verbose = false;
+  for (int i = 1; i < argc; ++i)
+  {
+    if (strcmp(argv[i], "-v") == 0 || strcmp(argv[i], "--verbose") == 0)
+      verbose = true;
+  }
+
+  if (verbose)
+  {
+    VerboseTestReporter reporter;
+    UnitTest::TestRunner runner(reporter);
+    return runner.RunTestsIf(UnitTest::Test::GetTestList(), NULL, UnitTest::True(), 0);
+  }
+  else
+  {
+    return UnitTest::RunAllTests();
+  }
 }

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -38,9 +38,10 @@ PrintHeader()
 	echo " Configuration   : $configuration_name" | tee -a log.txt
 	echo " Compiler        : $compiler          " | tee -a log.txt
 	echo " Language        : C++$cxx_standard   " | tee -a log.txt
-    echo " Optimisation    : $opt               " | tee -a log.txt
+	echo " Optimisation    : $opt               " | tee -a log.txt
 	echo " Sanitizer       : $sanitize          " | tee -a log.txt
 	echo " Compiler select : $compiler_enabled  " | tee -a log.txt
+	echo " Verbose         : $verbose           " | tee -a log.txt
 	echo " ETL version     : $etl_version       " | tee -a log.txt
 	echo " Git branch      : $(ParseGitBranch)  " | tee -a log.txt
 	echo " Processes       : ${CMAKE_BUILD_PARALLEL_LEVEL}" | tee -a log.txt
@@ -51,14 +52,15 @@ PrintHeader()
 PrintHelp()
 {
 	echo "$HelpColour"
-	echo "------------------------------------------------------------------------------------------------"
-	echo " Syntax          : ./run-tests.sh <C++ Standard> <Optimisation> <Threads> <Sanitizer> <Compiler>"
-	echo " C++ Standard    : 11, 14, 17, 20 or 23                                                         "
-	echo " Optimisation    : 0, 1, 2 or 3. Default = 0                                                    "
-	echo " Threads         : Number of threads to use. Default = 4                                        "
-	echo " Sanitizer       : s enables sanitizer checks, n disables. Default disabled                     "
-	echo " Compiler select : gcc or clang. Default All compilers                                          "
-	echo "------------------------------------------------------------------------------------------------"
+	echo "----------------------------------------------------------------------------------------------------------"
+	echo " Syntax          : ./run-tests.sh <C++ Standard> <Optimisation> <Threads> <Sanitizer> <Compiler> <Verbose>"
+	echo " C++ Standard    : 11, 14, 17, 20 or 23                                                                   "
+	echo " Optimisation    : 0, 1, 2 or 3. Default = 0                                                              "
+	echo " Threads         : Number of threads to use. Default = 4                                                  "
+	echo " Sanitizer       : s enables sanitizer checks, n disables. Default disabled                               "
+	echo " Compiler select : gcc or clang. Default All compilers                                                    "
+	echo " Verbose         : v enables verbose log, n disables. Default disabled                                    "
+	echo "----------------------------------------------------------------------------------------------------------"
 	echo "$NoColour"
 }
 
@@ -174,6 +176,17 @@ else
 fi
 
 #******************************************************************************
+# Set the verbose enable. Default OFF
+#******************************************************************************
+if [ "$6" = "v" ]; then
+  verbose="On"
+  verbose_flag="-v"
+else
+  verbose="Off"
+  verbose_flag=""
+fi
+
+#******************************************************************************
 # Get the ETL version
 #******************************************************************************
 etl_version_raw=$(cat ../version.txt)
@@ -210,7 +223,7 @@ while read i ; do
       FailedCompilation
       exit $?
     fi
-    ./etl_tests
+    ./etl_tests $verbose_flag
     if [ $? -eq 0 ]; then
       PassedTests
     else


### PR DESCRIPTION
For supporting safety features (e.g. supporting ISO 26262), we need to establish traceability to unit tests. To see if concrete unit tests are actually executed, this is activated optionally with a new "-v" option to the etl_tests executable.

By default, it is deactivated to not bother developers in their workflow. In the CI workflows, it is activated. So the test logs explicitly include the test names being executed. To find failing tests there, you can still easily search for "failed" or "error:".

test/run-tests.sh gets a new optional parameter "v" which activates the feature there if you need it.