### PR TITLE
Fix delegate not being cleared by assigning empty braces

### DIFF
--- a/.devcontainer/powerpc/Dockerfile
+++ b/.devcontainer/powerpc/Dockerfile
@@ -20,6 +20,14 @@ RUN dpkg --add-architecture powerpc && \
     debian-ports-archive-keyring \
     && rm -rf /var/lib/apt/lists/*
 
+RUN cat <<EOF > /etc/apt/sources.list.d/debian.sources
+Types: deb
+URIs: http://snapshot.debian.org/archive/debian/20260406T000000Z
+Suites: sid
+Components: main
+Signed-By: /usr/share/keyrings/debian-archive-keyring.pgp
+EOF
+
 RUN cat <<EOF > /etc/apt/sources.list.d/powerpc.sources
 Types: deb
 URIs: http://snapshot.debian.org/archive/debian-ports/20260406T000000Z

--- a/include/etl/private/delegate_cpp11.h
+++ b/include/etl/private/delegate_cpp11.h
@@ -172,7 +172,7 @@ namespace etl
     //*************************************************************************
     // Construct from a function pointer.
     //*************************************************************************
-    delegate(function_ptr fp) ETL_NOEXCEPT
+    explicit delegate(function_ptr fp) ETL_NOEXCEPT
     {
       assign(fp, function_ptr_stub);
     }
@@ -534,7 +534,14 @@ namespace etl
     //*************************************************************************
     delegate& operator=(function_ptr fp) ETL_NOEXCEPT
     {
-      assign(fp, function_ptr_stub);
+      if (fp == ETL_NULLPTR)
+      {
+        invocation.clear();
+      }
+      else
+      {
+        assign(fp, function_ptr_stub);
+      }
       return *this;
     }
 

--- a/test/test_delegate.cpp
+++ b/test/test_delegate.cpp
@@ -373,6 +373,27 @@ namespace
     }
 
     //*************************************************************************
+    TEST_FIXTURE(SetupFixture, test_is_valid_after_init_empty_braces)
+    {
+      etl::delegate<void(void)> d = {};
+
+      CHECK_FALSE(d.is_valid());
+    }
+
+    //*************************************************************************
+    TEST_FIXTURE(SetupFixture, test_is_valid_after_assign_empty_braces)
+    {
+      auto lambda = [] {
+      };
+
+      etl::delegate<void(void)> d(lambda);
+
+      CHECK_TRUE(d.is_valid());
+      d = {};
+      CHECK_FALSE(d.is_valid());
+    }
+
+    //*************************************************************************
     TEST_FIXTURE(SetupFixture, test_free_void)
     {
       auto d = etl::delegate<void(void)>::create<free_void>();


### PR DESCRIPTION
Fixes issue #1399.

The non-capturing lambda support (PR#1295) added a non-explicit delegate(function_ptr) constructor and operator=(function_ptr). This caused `delegate = {}` to implicitly convert `{}` to a null function pointer and bind it via function_ptr_stub, leaving the delegate appearing valid (stub != nullptr) but invoking through a null pointer (undefined behavior).

Fix:
- Mark delegate(function_ptr) constructor explicit to prevent implicit conversion from `{}` during initialization.
- In operator=(function_ptr), clear the delegate when fp is null instead of binding a null pointer through function_ptr_stub.

Added tests verifying that both `delegate d = {}` and `d = {}` produce an invalid (cleared) delegate.