### PR TITLE
Consolidate Dockerfile non-root user to vscode

### DIFF
--- a/.devcontainer/armhf/Dockerfile
+++ b/.devcontainer/armhf/Dockerfile
@@ -24,7 +24,7 @@ RUN dpkg --add-architecture armhf && \
     && rm -rf /var/lib/apt/lists/*
 
 # Create non-root user with stable UID/GID
-ARG USERNAME=devuser
+ARG USERNAME=vscode
 ARG USER_UID=1000
 ARG USER_GID=1000
 

--- a/.devcontainer/i386/Dockerfile
+++ b/.devcontainer/i386/Dockerfile
@@ -24,7 +24,7 @@ RUN dpkg --add-architecture i386 && \
     && rm -rf /var/lib/apt/lists/*
 
 # Create non-root user with stable UID/GID
-ARG USERNAME=devuser
+ARG USERNAME=vscode
 ARG USER_UID=1000
 ARG USER_GID=1000
 

--- a/.devcontainer/powerpc/Dockerfile
+++ b/.devcontainer/powerpc/Dockerfile
@@ -49,7 +49,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # Create non-root user with stable UID/GID
-ARG USERNAME=devuser
+ARG USERNAME=vscode
 ARG USER_UID=1000
 ARG USER_GID=1000
 

--- a/.devcontainer/riscv64/Dockerfile
+++ b/.devcontainer/riscv64/Dockerfile
@@ -24,7 +24,7 @@ RUN dpkg --add-architecture riscv64 && \
     && rm -rf /var/lib/apt/lists/*
 
 # Create non-root user with stable UID/GID
-ARG USERNAME=devuser
+ARG USERNAME=vscode
 ARG USER_UID=1000
 ARG USER_GID=1000
 

--- a/.devcontainer/s390x/Dockerfile
+++ b/.devcontainer/s390x/Dockerfile
@@ -24,7 +24,7 @@ RUN dpkg --add-architecture s390x && \
     && rm -rf /var/lib/apt/lists/*
 
 # Create non-root user with stable UID/GID
-ARG USERNAME=devuser
+ARG USERNAME=vscode
 ARG USER_UID=1000
 ARG USER_GID=1000
 


### PR DESCRIPTION
Previously, we had differently named default users in the containers.

Note: Applies to the development branch only since it fixes the issues there.