### PR TITLE
Run C++26 workflows with docker

### DIFF
--- a/.devcontainer/ubuntu-26.04/Dockerfile
+++ b/.devcontainer/ubuntu-26.04/Dockerfile
@@ -1,0 +1,20 @@
+FROM ubuntu:26.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    cmake \
+    git \
+    ninja-build \
+    python3 \
+    python3-pip \
+    clang \
+    docker.io \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN useradd -m -s /bin/bash vscode
+
+WORKDIR /etl
+
+CMD ["/bin/bash"]

--- a/.github/workflows/clang-c++26.yml
+++ b/.github/workflows/clang-c++26.yml
@@ -10,95 +10,91 @@ jobs:
 
   build-clang-cpp26-linux-stl:
     name: Clang C++26 Linux - STL
-    if: false # enabled when ubuntu-26.04 is available in github
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-26.04]
+    runs-on: ubuntu-24.04
 
     steps:
     - uses: actions/checkout@v4
 
-    - name: Build
-      run: |
-        export CC=clang
-        export CXX=clang++
-        export ASAN_OPTIONS=alloc_dealloc_mismatch=0,detect_leaks=0
-        cmake -DBUILD_TESTS=ON -DNO_STL=OFF -DETL_USE_TYPE_TRAITS_BUILTINS=OFF -DETL_USER_DEFINED_TYPE_TRAITS=OFF -DETL_FORCE_TEST_CPP03_IMPLEMENTATION=OFF -DETL_CXX_STANDARD=26 ./
-        clang --version
-        make -j "$(getconf _NPROCESSORS_ONLN)"
+    - name: Build Docker image
+      run: docker build -t etl-ubuntu-2604 -f .devcontainer/ubuntu-26.04/Dockerfile .
 
-    - name: Run tests
-      run: ./test/etl_tests -v
+    - name: Build and run tests
+      run: |
+        docker run --rm --user root -v ${{ github.workspace }}:/workspaces/etl etl-ubuntu-2604 bash -c "\
+          cd /workspaces/etl && \
+          export CC=clang && \
+          export CXX=clang++ && \
+          export ASAN_OPTIONS=alloc_dealloc_mismatch=0,detect_leaks=0 && \
+          cmake -DBUILD_TESTS=ON -DNO_STL=OFF -DETL_USE_TYPE_TRAITS_BUILTINS=OFF -DETL_USER_DEFINED_TYPE_TRAITS=OFF -DETL_FORCE_TEST_CPP03_IMPLEMENTATION=OFF -DETL_CXX_STANDARD=26 ./ && \
+          clang --version && \
+          make -j \$(getconf _NPROCESSORS_ONLN) && \
+          ./test/etl_tests -v"
 
   build-clang-cpp26-linux-no-stl:
     name: Clang C++26 Linux - No STL
-    if: false # enabled when ubuntu-26.04 is available in github
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-26.04]
+    runs-on: ubuntu-24.04
 
     steps:
     - uses: actions/checkout@v4
 
-    - name: Build
-      run: |
-        export CC=clang
-        export CXX=clang++
-        export ASAN_OPTIONS=alloc_dealloc_mismatch=0,detect_leaks=0
-        cmake -DBUILD_TESTS=ON -DNO_STL=ON -DETL_USE_TYPE_TRAITS_BUILTINS=OFF -DETL_USER_DEFINED_TYPE_TRAITS=OFF -DETL_FORCE_TEST_CPP03_IMPLEMENTATION=OFF -DETL_CXX_STANDARD=26 ./
-        clang --version
-        make -j "$(getconf _NPROCESSORS_ONLN)"
+    - name: Build Docker image
+      run: docker build -t etl-ubuntu-2604 -f .devcontainer/ubuntu-26.04/Dockerfile .
 
-    - name: Run tests
-      run: ./test/etl_tests -v
+    - name: Build and run tests
+      run: |
+        docker run --rm --user root -v ${{ github.workspace }}:/workspaces/etl etl-ubuntu-2604 bash -c "\
+          cd /workspaces/etl && \
+          export CC=clang && \
+          export CXX=clang++ && \
+          export ASAN_OPTIONS=alloc_dealloc_mismatch=0,detect_leaks=0 && \
+          cmake -DBUILD_TESTS=ON -DNO_STL=ON -DETL_USE_TYPE_TRAITS_BUILTINS=OFF -DETL_USER_DEFINED_TYPE_TRAITS=OFF -DETL_FORCE_TEST_CPP03_IMPLEMENTATION=OFF -DETL_CXX_STANDARD=26 ./ && \
+          clang --version && \
+          make -j \$(getconf _NPROCESSORS_ONLN) && \
+          ./test/etl_tests -v"
 
   build-clang-cpp26-linux-stl-force-cpp03:
     name: Clang C++26 Linux - STL - Force C++03
-    if: false # enabled when ubuntu-26.04 is available in github
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-26.04]
+    runs-on: ubuntu-24.04
 
     steps:
     - uses: actions/checkout@v4
 
-    - name: Build
-      run: |
-        export CC=clang
-        export CXX=clang++
-        export ASAN_OPTIONS=alloc_dealloc_mismatch=0,detect_leaks=0
-        cmake -D BUILD_TESTS=ON -DNO_STL=OFF -DETL_USE_TYPE_TRAITS_BUILTINS=OFF -DETL_USER_DEFINED_TYPE_TRAITS=OFF -DETL_FORCE_TEST_CPP03_IMPLEMENTATION=ON -DETL_CXX_STANDARD=26 ./
-        clang --version
-        make -j "$(getconf _NPROCESSORS_ONLN)"
+    - name: Build Docker image
+      run: docker build -t etl-ubuntu-2604 -f .devcontainer/ubuntu-26.04/Dockerfile .
 
-    - name: Run tests
-      run: ./test/etl_tests -v
+    - name: Build and run tests
+      run: |
+        docker run --rm --user root -v ${{ github.workspace }}:/workspaces/etl etl-ubuntu-2604 bash -c "\
+          cd /workspaces/etl && \
+          export CC=clang && \
+          export CXX=clang++ && \
+          export ASAN_OPTIONS=alloc_dealloc_mismatch=0,detect_leaks=0 && \
+          cmake -DBUILD_TESTS=ON -DNO_STL=OFF -DETL_USE_TYPE_TRAITS_BUILTINS=OFF -DETL_USER_DEFINED_TYPE_TRAITS=OFF -DETL_FORCE_TEST_CPP03_IMPLEMENTATION=ON -DETL_CXX_STANDARD=26 ./ && \
+          clang --version && \
+          make -j \$(getconf _NPROCESSORS_ONLN) && \
+          ./test/etl_tests -v"
 
   build-clang-cpp26-linux-no-stl-force-cpp03:
     name: Clang C++26 Linux - No STL - Force C++03
-    if: false # enabled when ubuntu-26.04 is available in github
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-26.04]
+    runs-on: ubuntu-24.04
 
     steps:
     - uses: actions/checkout@v4
 
-    - name: Build
-      run: |
-        export CC=clang
-        export CXX=clang++
-        export ASAN_OPTIONS=alloc_dealloc_mismatch=0,detect_leaks=0
-        cmake -D BUILD_TESTS=ON -DNO_STL=ON -DETL_USE_TYPE_TRAITS_BUILTINS=OFF -DETL_USER_DEFINED_TYPE_TRAITS=OFF -DETL_FORCE_TEST_CPP03_IMPLEMENTATION=ON -DETL_CXX_STANDARD=26 ./
-        clang --version
-        make -j "$(getconf _NPROCESSORS_ONLN)"
+    - name: Build Docker image
+      run: docker build -t etl-ubuntu-2604 -f .devcontainer/ubuntu-26.04/Dockerfile .
 
-    - name: Run tests
-      run: ./test/etl_tests -v
+    - name: Build and run tests
+      run: |
+        docker run --rm --user root -v ${{ github.workspace }}:/workspaces/etl etl-ubuntu-2604 bash -c "\
+          cd /workspaces/etl && \
+          export CC=clang && \
+          export CXX=clang++ && \
+          export ASAN_OPTIONS=alloc_dealloc_mismatch=0,detect_leaks=0 && \
+          cmake -DBUILD_TESTS=ON -DNO_STL=ON -DETL_USE_TYPE_TRAITS_BUILTINS=OFF -DETL_USER_DEFINED_TYPE_TRAITS=OFF -DETL_FORCE_TEST_CPP03_IMPLEMENTATION=ON -DETL_CXX_STANDARD=26 ./ && \
+          clang --version && \
+          make -j \$(getconf _NPROCESSORS_ONLN) && \
+          ./test/etl_tests -v"
 
   build-clang-cpp26-osx-stl:
     name: Clang C++26 OSX - STL

--- a/.github/workflows/clang-syntax-checks.yml
+++ b/.github/workflows/clang-syntax-checks.yml
@@ -405,76 +405,80 @@ jobs:
 
   build-clang-cpp26-linux-STL:
     name: Syntax Check - Clang C++26 Linux STL
-    if: false # enabled when ubuntu-26.04 is available in github
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-26.04]
+    runs-on: ubuntu-24.04
 
     steps:
     - uses: actions/checkout@v4
 
+    - name: Build Docker image
+      run: docker build -t etl-ubuntu-2604 -f .devcontainer/ubuntu-26.04/Dockerfile .
+
     - name: Build
       run: |
-        export CC=clang
-        export CXX=clang++
-        cmake -DNO_STL=OFF -DETL_USE_TYPE_TRAITS_BUILTINS=OFF -DETL_USER_DEFINED_TYPE_TRAITS=OFF -DETL_FORCE_TEST_CPP03_IMPLEMENTATION=OFF -DETL_CXX_STANDARD=26 ./test/syntax_check
-        clang++ --version
-        make -j "$(getconf _NPROCESSORS_ONLN)"
+        docker run --rm --user root -v ${{ github.workspace }}:/workspaces/etl etl-ubuntu-2604 bash -c "\
+          cd /workspaces/etl && \
+          export CC=clang && \
+          export CXX=clang++ && \
+          cmake -DNO_STL=OFF -DETL_USE_TYPE_TRAITS_BUILTINS=OFF -DETL_USER_DEFINED_TYPE_TRAITS=OFF -DETL_FORCE_TEST_CPP03_IMPLEMENTATION=OFF -DETL_CXX_STANDARD=26 ./test/syntax_check && \
+          clang++ --version && \
+          make -j \$(getconf _NPROCESSORS_ONLN)"
 
   build-clang-cpp26-linux-No-STL:
     name: Syntax Check - Clang C++26 Linux No STL
-    if: false # enabled when ubuntu-26.04 is available in github
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-26.04]
+    runs-on: ubuntu-24.04
 
     steps:
     - uses: actions/checkout@v4
 
+    - name: Build Docker image
+      run: docker build -t etl-ubuntu-2604 -f .devcontainer/ubuntu-26.04/Dockerfile .
+
     - name: Build
       run: |
-        export CC=clang
-        export CXX=clang++
-        cmake -DNO_STL=ON -DETL_USE_TYPE_TRAITS_BUILTINS=OFF -DETL_USER_DEFINED_TYPE_TRAITS=OFF -DETL_FORCE_TEST_CPP03_IMPLEMENTATION=OFF -DETL_CXX_STANDARD=26 ./test/syntax_check
-        clang++ --version
-        make -j "$(getconf _NPROCESSORS_ONLN)"
+        docker run --rm --user root -v ${{ github.workspace }}:/workspaces/etl etl-ubuntu-2604 bash -c "\
+          cd /workspaces/etl && \
+          export CC=clang && \
+          export CXX=clang++ && \
+          cmake -DNO_STL=ON -DETL_USE_TYPE_TRAITS_BUILTINS=OFF -DETL_USER_DEFINED_TYPE_TRAITS=OFF -DETL_FORCE_TEST_CPP03_IMPLEMENTATION=OFF -DETL_CXX_STANDARD=26 ./test/syntax_check && \
+          clang++ --version && \
+          make -j \$(getconf _NPROCESSORS_ONLN)"
 
   build-clang-cpp26-linux-STL-Force-CPP03:
     name: Syntax Check - Clang C++26 Linux STL Force C++03
-    if: false # enabled when ubuntu-26.04 is available in github
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-26.04]
+    runs-on: ubuntu-24.04
 
     steps:
     - uses: actions/checkout@v4
 
+    - name: Build Docker image
+      run: docker build -t etl-ubuntu-2604 -f .devcontainer/ubuntu-26.04/Dockerfile .
+
     - name: Build
       run: |
-        export CC=clang
-        export CXX=clang++
-        cmake -DNO_STL=OFF -DETL_USE_TYPE_TRAITS_BUILTINS=OFF -DETL_USER_DEFINED_TYPE_TRAITS=OFF -DETL_FORCE_TEST_CPP03_IMPLEMENTATION=ON -DETL_CXX_STANDARD=26 ./test/syntax_check
-        clang++ --version
-        make -j "$(getconf _NPROCESSORS_ONLN)"
+        docker run --rm --user root -v ${{ github.workspace }}:/workspaces/etl etl-ubuntu-2604 bash -c "\
+          cd /workspaces/etl && \
+          export CC=clang && \
+          export CXX=clang++ && \
+          cmake -DNO_STL=OFF -DETL_USE_TYPE_TRAITS_BUILTINS=OFF -DETL_USER_DEFINED_TYPE_TRAITS=OFF -DETL_FORCE_TEST_CPP03_IMPLEMENTATION=ON -DETL_CXX_STANDARD=26 ./test/syntax_check && \
+          clang++ --version && \
+          make -j \$(getconf _NPROCESSORS_ONLN)"
 
   build-clang-cpp26-linux-No-STL-Force-CPP03:
     name: Syntax Check - Clang C++26 Linux No STL Force C++03
-    if: false # enabled when ubuntu-26.04 is available in github
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-26.04]
+    runs-on: ubuntu-24.04
 
     steps:
     - uses: actions/checkout@v4
 
+    - name: Build Docker image
+      run: docker build -t etl-ubuntu-2604 -f .devcontainer/ubuntu-26.04/Dockerfile .
+
     - name: Build
       run: |
-        export CC=clang
-        export CXX=clang++
-        cmake -DNO_STL=ON -DETL_USE_TYPE_TRAITS_BUILTINS=OFF -DETL_USER_DEFINED_TYPE_TRAITS=OFF -DETL_FORCE_TEST_CPP03_IMPLEMENTATION=ON -DETL_CXX_STANDARD=26 ./test/syntax_check
-        clang++ --version
-        make -j "$(getconf _NPROCESSORS_ONLN)"
+        docker run --rm --user root -v ${{ github.workspace }}:/workspaces/etl etl-ubuntu-2604 bash -c "\
+          cd /workspaces/etl && \
+          export CC=clang && \
+          export CXX=clang++ && \
+          cmake -DNO_STL=ON -DETL_USE_TYPE_TRAITS_BUILTINS=OFF -DETL_USER_DEFINED_TYPE_TRAITS=OFF -DETL_FORCE_TEST_CPP03_IMPLEMENTATION=ON -DETL_CXX_STANDARD=26 ./test/syntax_check && \
+          clang++ --version && \
+          make -j \$(getconf _NPROCESSORS_ONLN)"

--- a/.github/workflows/gcc-c++26.yml
+++ b/.github/workflows/gcc-c++26.yml
@@ -10,92 +10,88 @@ jobs:
 
   build-gcc-cpp26-linux-stl:
     name: GCC C++26 Linux - STL
-    if: false # enabled when ubuntu-26.04 is available in github
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-26.04]
+    runs-on: ubuntu-24.04
 
     steps:
     - uses: actions/checkout@v4
 
-    - name: Build
-      run: |
-        export ASAN_OPTIONS=alloc_dealloc_mismatch=0,detect_leaks=0
-        export CC=gcc
-        export CXX=g++
-        cmake -DBUILD_TESTS=ON -DNO_STL=OFF -DETL_USE_TYPE_TRAITS_BUILTINS=OFF -DETL_USER_DEFINED_TYPE_TRAITS=OFF -DETL_FORCE_TEST_CPP03_IMPLEMENTATION=OFF -DETL_CXX_STANDARD=26 ./
-        gcc --version
-        make -j "$(getconf _NPROCESSORS_ONLN)"
+    - name: Build Docker image
+      run: docker build -t etl-ubuntu-2604 -f .devcontainer/ubuntu-26.04/Dockerfile .
 
-    - name: Run tests
-      run: ./test/etl_tests -v
+    - name: Build and run tests
+      run: |
+        docker run --rm --user root -v ${{ github.workspace }}:/workspaces/etl etl-ubuntu-2604 bash -c "\
+          cd /workspaces/etl && \
+          export ASAN_OPTIONS=alloc_dealloc_mismatch=0,detect_leaks=0 && \
+          export CC=gcc && \
+          export CXX=g++ && \
+          cmake -DBUILD_TESTS=ON -DNO_STL=OFF -DETL_USE_TYPE_TRAITS_BUILTINS=OFF -DETL_USER_DEFINED_TYPE_TRAITS=OFF -DETL_FORCE_TEST_CPP03_IMPLEMENTATION=OFF -DETL_CXX_STANDARD=26 ./ && \
+          gcc --version && \
+          make -j \$(getconf _NPROCESSORS_ONLN) && \
+          ./test/etl_tests -v"
 
   build-gcc-cpp26-linux-no-stl:
     name: GCC C++26 Linux - No STL
-    if: false # enabled when ubuntu-26.04 is available in github
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-26.04]
+    runs-on: ubuntu-24.04
 
     steps:
     - uses: actions/checkout@v4
 
-    - name: Build
-      run: |
-        export ASAN_OPTIONS=alloc_dealloc_mismatch=0,detect_leaks=0
-        export CC=gcc
-        export CXX=g++
-        cmake -DBUILD_TESTS=ON -DNO_STL=ON -DETL_USE_TYPE_TRAITS_BUILTINS=OFF -DETL_USER_DEFINED_TYPE_TRAITS=OFF -DETL_FORCE_TEST_CPP03_IMPLEMENTATION=OFF -DETL_CXX_STANDARD=26 ./
-        gcc --version
-        make -j "$(getconf _NPROCESSORS_ONLN)"
+    - name: Build Docker image
+      run: docker build -t etl-ubuntu-2604 -f .devcontainer/ubuntu-26.04/Dockerfile .
 
-    - name: Run tests
-      run: ./test/etl_tests -v
+    - name: Build and run tests
+      run: |
+        docker run --rm --user root -v ${{ github.workspace }}:/workspaces/etl etl-ubuntu-2604 bash -c "\
+          cd /workspaces/etl && \
+          export ASAN_OPTIONS=alloc_dealloc_mismatch=0,detect_leaks=0 && \
+          export CC=gcc && \
+          export CXX=g++ && \
+          cmake -DBUILD_TESTS=ON -DNO_STL=ON -DETL_USE_TYPE_TRAITS_BUILTINS=OFF -DETL_USER_DEFINED_TYPE_TRAITS=OFF -DETL_FORCE_TEST_CPP03_IMPLEMENTATION=OFF -DETL_CXX_STANDARD=26 ./ && \
+          gcc --version && \
+          make -j \$(getconf _NPROCESSORS_ONLN) && \
+          ./test/etl_tests -v"
 
   build-gcc-cpp26-linux-stl-force-cpp03:
     name: GCC C++26 Linux - STL - Force C++03
-    if: false # enabled when ubuntu-26.04 is available in github
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-26.04]
+    runs-on: ubuntu-24.04
 
     steps:
     - uses: actions/checkout@v4
 
-    - name: Build
-      run: |
-        export ASAN_OPTIONS=alloc_dealloc_mismatch=0,detect_leaks=0
-        export CC=gcc
-        export CXX=g++
-        cmake -DBUILD_TESTS=ON -DNO_STL=OFF -DETL_USE_TYPE_TRAITS_BUILTINS=OFF -DETL_USER_DEFINED_TYPE_TRAITS=OFF -DETL_FORCE_TEST_CPP03_IMPLEMENTATION=ON -DETL_CXX_STANDARD=26 ./
-        gcc --version
-        make -j "$(getconf _NPROCESSORS_ONLN)"
+    - name: Build Docker image
+      run: docker build -t etl-ubuntu-2604 -f .devcontainer/ubuntu-26.04/Dockerfile .
 
-    - name: Run tests
-      run: ./test/etl_tests -v
+    - name: Build and run tests
+      run: |
+        docker run --rm --user root -v ${{ github.workspace }}:/workspaces/etl etl-ubuntu-2604 bash -c "\
+          cd /workspaces/etl && \
+          export ASAN_OPTIONS=alloc_dealloc_mismatch=0,detect_leaks=0 && \
+          export CC=gcc && \
+          export CXX=g++ && \
+          cmake -DBUILD_TESTS=ON -DNO_STL=OFF -DETL_USE_TYPE_TRAITS_BUILTINS=OFF -DETL_USER_DEFINED_TYPE_TRAITS=OFF -DETL_FORCE_TEST_CPP03_IMPLEMENTATION=ON -DETL_CXX_STANDARD=26 ./ && \
+          gcc --version && \
+          make -j \$(getconf _NPROCESSORS_ONLN) && \
+          ./test/etl_tests -v"
 
   build-gcc-cpp26-linux-no-stl-force-cpp03:
     name: GCC C++26 Linux - No STL - Force C++03
-    if: false # enabled when ubuntu-26.04 is available in github
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-26.04]
+    runs-on: ubuntu-24.04
 
     steps:
     - uses: actions/checkout@v4
 
-    - name: Build
-      run: |
-        export ASAN_OPTIONS=alloc_dealloc_mismatch=0,detect_leaks=0
-        export CC=gcc
-        export CXX=g++
-        cmake -DBUILD_TESTS=ON -DNO_STL=ON -DETL_USE_TYPE_TRAITS_BUILTINS=OFF -DETL_USER_DEFINED_TYPE_TRAITS=OFF -DETL_FORCE_TEST_CPP03_IMPLEMENTATION=ON -DETL_CXX_STANDARD=26 ./
-        gcc --version
-        make -j "$(getconf _NPROCESSORS_ONLN)"
+    - name: Build Docker image
+      run: docker build -t etl-ubuntu-2604 -f .devcontainer/ubuntu-26.04/Dockerfile .
 
-    - name: Run tests
-      run: ./test/etl_tests -v
+    - name: Build and run tests
+      run: |
+        docker run --rm --user root -v ${{ github.workspace }}:/workspaces/etl etl-ubuntu-2604 bash -c "\
+          cd /workspaces/etl && \
+          export ASAN_OPTIONS=alloc_dealloc_mismatch=0,detect_leaks=0 && \
+          export CC=gcc && \
+          export CXX=g++ && \
+          cmake -DBUILD_TESTS=ON -DNO_STL=ON -DETL_USE_TYPE_TRAITS_BUILTINS=OFF -DETL_USER_DEFINED_TYPE_TRAITS=OFF -DETL_FORCE_TEST_CPP03_IMPLEMENTATION=ON -DETL_CXX_STANDARD=26 ./ && \
+          gcc --version && \
+          make -j \$(getconf _NPROCESSORS_ONLN) && \
+          ./test/etl_tests -v"

--- a/.github/workflows/gcc-syntax-checks.yml
+++ b/.github/workflows/gcc-syntax-checks.yml
@@ -405,76 +405,80 @@ jobs:
 
   build-gcc-cpp26-linux-STL:
     name: Syntax Check - GCC C++26 Linux STL
-    if: false # enabled when ubuntu-26.04 is available in github
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-26.04]
+    runs-on: ubuntu-24.04
 
     steps:
     - uses: actions/checkout@v4
 
+    - name: Build Docker image
+      run: docker build -t etl-ubuntu-2604 -f .devcontainer/ubuntu-26.04/Dockerfile .
+
     - name: Build
       run: |
-        export CC=gcc
-        export CXX=g++
-        cmake -DNO_STL=OFF -DETL_USE_TYPE_TRAITS_BUILTINS=OFF -DETL_USER_DEFINED_TYPE_TRAITS=OFF -DETL_FORCE_TEST_CPP03_IMPLEMENTATION=OFF -DETL_CXX_STANDARD=26 ./test/syntax_check
-        gcc --version
-        make -j "$(getconf _NPROCESSORS_ONLN)"
+        docker run --rm --user root -v ${{ github.workspace }}:/workspaces/etl etl-ubuntu-2604 bash -c "\
+          cd /workspaces/etl && \
+          export CC=gcc && \
+          export CXX=g++ && \
+          cmake -DNO_STL=OFF -DETL_USE_TYPE_TRAITS_BUILTINS=OFF -DETL_USER_DEFINED_TYPE_TRAITS=OFF -DETL_FORCE_TEST_CPP03_IMPLEMENTATION=OFF -DETL_CXX_STANDARD=26 ./test/syntax_check && \
+          gcc --version && \
+          make -j \$(getconf _NPROCESSORS_ONLN)"
 
   build-gcc-cpp26-linux-No-STL:
     name: Syntax Check - GCC C++26 Linux No STL
-    if: false # enabled when ubuntu-26.04 is available in github
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-26.04]
+    runs-on: ubuntu-24.04
 
     steps:
     - uses: actions/checkout@v4
 
+    - name: Build Docker image
+      run: docker build -t etl-ubuntu-2604 -f .devcontainer/ubuntu-26.04/Dockerfile .
+
     - name: Build
       run: |
-        export CC=gcc
-        export CXX=g++
-        cmake -DNO_STL=ON -DETL_USE_TYPE_TRAITS_BUILTINS=OFF -DETL_USER_DEFINED_TYPE_TRAITS=OFF -DETL_FORCE_TEST_CPP03_IMPLEMENTATION=OFF -DETL_CXX_STANDARD=26 ./test/syntax_check
-        gcc --version
-        make -j "$(getconf _NPROCESSORS_ONLN)"
+        docker run --rm --user root -v ${{ github.workspace }}:/workspaces/etl etl-ubuntu-2604 bash -c "\
+          cd /workspaces/etl && \
+          export CC=gcc && \
+          export CXX=g++ && \
+          cmake -DNO_STL=ON -DETL_USE_TYPE_TRAITS_BUILTINS=OFF -DETL_USER_DEFINED_TYPE_TRAITS=OFF -DETL_FORCE_TEST_CPP03_IMPLEMENTATION=OFF -DETL_CXX_STANDARD=26 ./test/syntax_check && \
+          gcc --version && \
+          make -j \$(getconf _NPROCESSORS_ONLN)"
 
   build-gcc-cpp26-linux-STL-Force-CPP03:
     name: Syntax Check - GCC C++26 Linux STL Force C++03
-    if: false # enabled when ubuntu-26.04 is available in github
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-26.04]
+    runs-on: ubuntu-24.04
 
     steps:
     - uses: actions/checkout@v4
 
+    - name: Build Docker image
+      run: docker build -t etl-ubuntu-2604 -f .devcontainer/ubuntu-26.04/Dockerfile .
+
     - name: Build
       run: |
-        export CC=gcc
-        export CXX=g++
-        cmake -DNO_STL=OFF -DETL_USE_TYPE_TRAITS_BUILTINS=OFF -DETL_USER_DEFINED_TYPE_TRAITS=OFF -DETL_FORCE_TEST_CPP03_IMPLEMENTATION=ON -DETL_CXX_STANDARD=26 ./test/syntax_check
-        gcc --version
-        make -j "$(getconf _NPROCESSORS_ONLN)"
+        docker run --rm --user root -v ${{ github.workspace }}:/workspaces/etl etl-ubuntu-2604 bash -c "\
+          cd /workspaces/etl && \
+          export CC=gcc && \
+          export CXX=g++ && \
+          cmake -DNO_STL=OFF -DETL_USE_TYPE_TRAITS_BUILTINS=OFF -DETL_USER_DEFINED_TYPE_TRAITS=OFF -DETL_FORCE_TEST_CPP03_IMPLEMENTATION=ON -DETL_CXX_STANDARD=26 ./test/syntax_check && \
+          gcc --version && \
+          make -j \$(getconf _NPROCESSORS_ONLN)"
 
   build-gcc-cpp26-linux-No-STL-Force-CPP03:
     name: Syntax Check - GCC C++26 Linux No STL Force C++03
-    if: false # enabled when ubuntu-26.04 is available in github
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-26.04]
+    runs-on: ubuntu-24.04
 
     steps:
     - uses: actions/checkout@v4
 
+    - name: Build Docker image
+      run: docker build -t etl-ubuntu-2604 -f .devcontainer/ubuntu-26.04/Dockerfile .
+
     - name: Build
       run: |
-        export CC=gcc
-        export CXX=g++
-        cmake -DNO_STL=ON -DETL_USE_TYPE_TRAITS_BUILTINS=OFF -DETL_USER_DEFINED_TYPE_TRAITS=OFF -DETL_FORCE_TEST_CPP03_IMPLEMENTATION=ON -DETL_CXX_STANDARD=26 ./test/syntax_check
-        gcc --version
-        make -j "$(getconf _NPROCESSORS_ONLN)"
+        docker run --rm --user root -v ${{ github.workspace }}:/workspaces/etl etl-ubuntu-2604 bash -c "\
+          cd /workspaces/etl && \
+          export CC=gcc && \
+          export CXX=g++ && \
+          cmake -DNO_STL=ON -DETL_USE_TYPE_TRAITS_BUILTINS=OFF -DETL_USER_DEFINED_TYPE_TRAITS=OFF -DETL_FORCE_TEST_CPP03_IMPLEMENTATION=ON -DETL_CXX_STANDARD=26 ./test/syntax_check && \
+          gcc --version && \
+          make -j \$(getconf _NPROCESSORS_ONLN)"

--- a/include/etl/tuple.h
+++ b/include/etl/tuple.h
@@ -1181,7 +1181,7 @@ namespace etl
 namespace std
 {
   #if ETL_NOT_USING_STL                                                                                                       \
-    && !((defined(ETL_DEVELOPMENT_OS_APPLE) || (ETL_COMPILER_FULL_VERSION >= 190000) && (ETL_COMPILER_FULL_VERSION < 220000)) \
+    && !((defined(ETL_DEVELOPMENT_OS_APPLE) || (ETL_COMPILER_FULL_VERSION >= 190000) && (ETL_COMPILER_FULL_VERSION < 210000)) \
          && defined(ETL_COMPILER_CLANG))
   template <typename T>
   struct tuple_size;

--- a/test/syntax_check/CMakeLists.txt
+++ b/test/syntax_check/CMakeLists.txt
@@ -27,6 +27,10 @@ if (ETL_FORCE_TEST_CPP03_IMPLEMENTATION)
 	add_definitions(-DETL_FORCE_TEST_CPP03_IMPLEMENTATION)
 endif()
 
+# Override the compile rule to use -fsyntax-only instead of -c,
+# since this project only checks syntax and doesn't produce object files.
+set(CMAKE_CXX_COMPILE_OBJECT "<CMAKE_CXX_COMPILER> <DEFINES> <INCLUDES> <FLAGS> -fsyntax-only <SOURCE>")
+
 add_library(tests OBJECT)
 target_compile_definitions(tests PRIVATE __STDC_LIMIT_MACROS __STDC_CONSTANT_MACROS __STDC_FORMAT_MACROS)
 target_include_directories(tests PRIVATE "")
@@ -38,7 +42,6 @@ set_target_properties(tests PROPERTIES
 if (CMAKE_CXX_COMPILER_ID MATCHES "GNU")
 target_compile_options(tests
 	    PRIVATE
-		-fsyntax-only
 		-pedantic-errors
 		-Werror
 		-Wextra-semi
@@ -47,7 +50,6 @@ endif ()
 if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 target_compile_options(tests
 	    PRIVATE
-		-fsyntax-only
 		-pedantic-errors
 		-Werror
 		-Wextra-semi


### PR DESCRIPTION
Ubuntu 26.04 is not available in github workflows directly and won't be soon. But ubuntu-26.04 is available as docker container. So use it for running C++26 workflows which were disabled previously.