### PR TITLE
Remove dead code

### DIFF
--- a/include/etl/algorithm.h
+++ b/include/etl/algorithm.h
@@ -91,26 +91,6 @@ namespace etl
   template <typename TIterator, typename TCompare>
   ETL_CONSTEXPR14 void insertion_sort(TIterator first, TIterator last, TCompare compare);
 
-  class algorithm_exception : public etl::exception
-  {
-  public:
-
-    algorithm_exception(string_type reason_, string_type file_name_, numeric_type line_number_)
-      : exception(reason_, file_name_, line_number_)
-    {
-    }
-  };
-
-  class algorithm_error : public algorithm_exception
-  {
-  public:
-
-    algorithm_error(string_type file_name_, numeric_type line_number_)
-      : algorithm_exception(ETL_ERROR_TEXT("algorithm:error", ETL_ALGORITHM_FILE_ID"A"), file_name_, line_number_)
-    {
-    }
-  };
-
 } // namespace etl
 
 //*****************************************************************************

--- a/include/etl/basic_string.h
+++ b/include/etl/basic_string.h
@@ -95,20 +95,6 @@ namespace etl
 
   //***************************************************************************
   ///\ingroup string
-  /// String empty exception.
-  //***************************************************************************
-  class string_empty : public etl::string_exception
-  {
-  public:
-
-    string_empty(string_type file_name_, numeric_type line_number_)
-      : string_exception(ETL_ERROR_TEXT("string:empty", ETL_BASIC_STRING_FILE_ID"A"), file_name_, line_number_)
-    {
-    }
-  };
-
-  //***************************************************************************
-  ///\ingroup string
   /// String out of bounds exception.
   //***************************************************************************
   class string_out_of_bounds : public etl::string_exception
@@ -2742,6 +2728,7 @@ namespace etl
                                iterator>::type
       copy_characters(TIterator1 from, size_t n, iterator to)
     {
+#include "etl/private/diagnostic_stringop_overflow_push.h"
       size_t count = 0;
 
       while (count != n)
@@ -2750,6 +2737,7 @@ namespace etl
         ++count;
       }
 
+#include "etl/private/diagnostic_pop.h"
       return to;
     }
 
@@ -3217,8 +3205,6 @@ namespace etl
   }
 #endif
 } // namespace etl
-
-#undef ETL_USING_WCHAR_T_H
 
 #include "private/minmax_pop.h"
 

--- a/include/etl/callback_timer.h
+++ b/include/etl/callback_timer.h
@@ -629,7 +629,6 @@ namespace etl
       timer_list(timer_data* ptimers_)
         : head(etl::timer::id::NO_TIMER)
         , tail(etl::timer::id::NO_TIMER)
-        , current(etl::timer::id::NO_TIMER)
         , ptimers(ptimers_)
       {
       }
@@ -758,22 +757,13 @@ namespace etl
       //*******************************
       etl::timer::id::type begin()
       {
-        current = head;
-        return current;
-      }
-
-      //*******************************
-      etl::timer::id::type previous(etl::timer::id::type last)
-      {
-        current = ptimers[last].previous;
-        return current;
+        return head;
       }
 
       //*******************************
       etl::timer::id::type next(etl::timer::id::type last)
       {
-        current = ptimers[last].next;
-        return current;
+        return ptimers[last].next;
       }
 
       //*******************************
@@ -788,16 +778,14 @@ namespace etl
           timer.next        = etl::timer::id::NO_TIMER;
         }
 
-        head    = etl::timer::id::NO_TIMER;
-        tail    = etl::timer::id::NO_TIMER;
-        current = etl::timer::id::NO_TIMER;
+        head = etl::timer::id::NO_TIMER;
+        tail = etl::timer::id::NO_TIMER;
       }
 
     private:
 
       etl::timer::id::type head;
       etl::timer::id::type tail;
-      etl::timer::id::type current;
 
       timer_data* const ptimers;
     };

--- a/include/etl/callback_timer_atomic.h
+++ b/include/etl/callback_timer_atomic.h
@@ -487,7 +487,6 @@ namespace etl
       timer_list(timer_data* ptimers_)
         : head(etl::timer::id::NO_TIMER)
         , tail(etl::timer::id::NO_TIMER)
-        , current(etl::timer::id::NO_TIMER)
         , ptimers(ptimers_)
       {
       }
@@ -616,22 +615,13 @@ namespace etl
       //*******************************
       etl::timer::id::type begin()
       {
-        current = head;
-        return current;
-      }
-
-      //*******************************
-      etl::timer::id::type previous(etl::timer::id::type last)
-      {
-        current = ptimers[last].previous;
-        return current;
+        return head;
       }
 
       //*******************************
       etl::timer::id::type next(etl::timer::id::type last)
       {
-        current = ptimers[last].next;
-        return current;
+        return ptimers[last].next;
       }
 
       //*******************************
@@ -646,16 +636,14 @@ namespace etl
           timer.next        = etl::timer::id::NO_TIMER;
         }
 
-        head    = etl::timer::id::NO_TIMER;
-        tail    = etl::timer::id::NO_TIMER;
-        current = etl::timer::id::NO_TIMER;
+        head = etl::timer::id::NO_TIMER;
+        tail = etl::timer::id::NO_TIMER;
       }
 
     private:
 
       etl::timer::id::type head;
       etl::timer::id::type tail;
-      etl::timer::id::type current;
 
       timer_data* const ptimers;
     };

--- a/include/etl/callback_timer_interrupt.h
+++ b/include/etl/callback_timer_interrupt.h
@@ -487,7 +487,6 @@ namespace etl
       timer_list(timer_data* ptimers_)
         : head(etl::timer::id::NO_TIMER)
         , tail(etl::timer::id::NO_TIMER)
-        , current(etl::timer::id::NO_TIMER)
         , ptimers(ptimers_)
       {
       }
@@ -616,22 +615,13 @@ namespace etl
       //*******************************
       etl::timer::id::type begin()
       {
-        current = head;
-        return current;
-      }
-
-      //*******************************
-      etl::timer::id::type previous(etl::timer::id::type last)
-      {
-        current = ptimers[last].previous;
-        return current;
+        return head;
       }
 
       //*******************************
       etl::timer::id::type next(etl::timer::id::type last)
       {
-        current = ptimers[last].next;
-        return current;
+        return ptimers[last].next;
       }
 
       //*******************************
@@ -646,16 +636,14 @@ namespace etl
           timer.next        = etl::timer::id::NO_TIMER;
         }
 
-        head    = etl::timer::id::NO_TIMER;
-        tail    = etl::timer::id::NO_TIMER;
-        current = etl::timer::id::NO_TIMER;
+        head = etl::timer::id::NO_TIMER;
+        tail = etl::timer::id::NO_TIMER;
       }
 
     private:
 
       etl::timer::id::type head;
       etl::timer::id::type tail;
-      etl::timer::id::type current;
 
       timer_data* const ptimers;
     };

--- a/include/etl/callback_timer_locked.h
+++ b/include/etl/callback_timer_locked.h
@@ -460,7 +460,6 @@ namespace etl
       timer_list(timer_data* ptimers_)
         : head(etl::timer::id::NO_TIMER)
         , tail(etl::timer::id::NO_TIMER)
-        , current(etl::timer::id::NO_TIMER)
         , ptimers(ptimers_)
       {
       }
@@ -589,22 +588,13 @@ namespace etl
       //*******************************
       etl::timer::id::type begin()
       {
-        current = head;
-        return current;
-      }
-
-      //*******************************
-      etl::timer::id::type previous(etl::timer::id::type last)
-      {
-        current = ptimers[last].previous;
-        return current;
+        return head;
       }
 
       //*******************************
       etl::timer::id::type next(etl::timer::id::type last)
       {
-        current = ptimers[last].next;
-        return current;
+        return ptimers[last].next;
       }
 
       //*******************************
@@ -619,16 +609,14 @@ namespace etl
           timer.next        = etl::timer::id::NO_TIMER;
         }
 
-        head    = etl::timer::id::NO_TIMER;
-        tail    = etl::timer::id::NO_TIMER;
-        current = etl::timer::id::NO_TIMER;
+        head = etl::timer::id::NO_TIMER;
+        tail = etl::timer::id::NO_TIMER;
       }
 
     private:
 
       etl::timer::id::type head;
       etl::timer::id::type tail;
-      etl::timer::id::type current;
 
       timer_data* const ptimers;
     };

--- a/include/etl/deque.h
+++ b/include/etl/deque.h
@@ -463,19 +463,6 @@ namespace etl
     private:
 
       //***************************************************
-      difference_type distance(difference_type firstIndex, difference_type index_) const
-      {
-        if (index_ < firstIndex)
-        {
-          return static_cast<difference_type>(p_deque->Buffer_Size) + index_ - firstIndex;
-        }
-        else
-        {
-          return index_ - firstIndex;
-        }
-      }
-
-      //***************************************************
       iterator(difference_type index_, ideque& the_deque, pointer p_buffer_)
         : index(index_)
         , p_deque(&the_deque)
@@ -720,19 +707,6 @@ namespace etl
       }
 
     private:
-
-      //***************************************************
-      difference_type distance(difference_type firstIndex, difference_type index_) const
-      {
-        if (index_ < firstIndex)
-        {
-          return static_cast<difference_type>(p_deque->Buffer_Size) + index_ - firstIndex;
-        }
-        else
-        {
-          return index_ - firstIndex;
-        }
-      }
 
       //***************************************************
       const_iterator(difference_type index_, ideque& the_deque, pointer p_buffer_)

--- a/include/etl/flat_map.h
+++ b/include/etl/flat_map.h
@@ -100,26 +100,6 @@ namespace etl
 
   private:
 
-    //*********************************************************************
-    /// How to compare elements and keys.
-    //*********************************************************************
-    class compare
-    {
-    public:
-
-      bool operator()(const value_type& element, key_type key) const
-      {
-        return comp(element.first, key);
-      }
-
-      bool operator()(key_type key, const value_type& element) const
-      {
-        return comp(key, element.first);
-      }
-
-      key_compare comp;
-    };
-
   public:
 
     //*********************************************************************

--- a/include/etl/memory.h
+++ b/include/etl/memory.h
@@ -795,12 +795,8 @@ namespace etl
   template <typename TInputIterator, typename TSize, typename TOutputIterator>
   TOutputIterator uninitialized_move_n(TInputIterator i_begin, TSize n, TOutputIterator o_begin)
   {
-      // Move not supported. Defer to copy.
-  #if ETL_USING_CPP11
-    return std::uninitialized_copy_n(i_begin, n, o_begin);
-  #else
+    // Move not supported. Defer to copy.
     return etl::uninitialized_copy_n(i_begin, n, o_begin);
-  #endif
   }
 
   //*****************************************************************************
@@ -814,12 +810,8 @@ namespace etl
   {
     count += TCounter(n);
 
-      // Move not supported. Defer to copy.
-  #if ETL_USING_CPP11
-    return std::uninitialized_copy_n(i_begin, n, o_begin);
-  #else
+    // Move not supported. Defer to copy.
     return etl::uninitialized_copy_n(i_begin, n, o_begin);
-  #endif
   }
 #endif
 
@@ -2643,6 +2635,14 @@ namespace etl
     {
       *p++ = 0;
     }
+
+    // Prevent the compiler from optimising away the volatile stores
+    // as dead stores (observed with GCC -O3 in C++23 mode).
+#if defined(ETL_COMPILER_GCC) || defined(ETL_COMPILER_CLANG)
+    __asm__ __volatile__("" : : : "memory");
+#elif defined(ETL_COMPILER_MICROSOFT)
+    _ReadWriteBarrier();
+#endif
   }
 
   //*****************************************************************************

--- a/include/etl/message_timer.h
+++ b/include/etl/message_timer.h
@@ -157,7 +157,6 @@ namespace etl
       list(etl::message_timer_data* ptimers_)
         : head(etl::timer::id::NO_TIMER)
         , tail(etl::timer::id::NO_TIMER)
-        , current(etl::timer::id::NO_TIMER)
         , ptimers(ptimers_)
       {
       }
@@ -286,22 +285,13 @@ namespace etl
       //*******************************
       etl::timer::id::type begin()
       {
-        current = head;
-        return current;
-      }
-
-      //*******************************
-      etl::timer::id::type previous(etl::timer::id::type last)
-      {
-        current = ptimers[last].previous;
-        return current;
+        return head;
       }
 
       //*******************************
       etl::timer::id::type next(etl::timer::id::type last)
       {
-        current = ptimers[last].next;
-        return current;
+        return ptimers[last].next;
       }
 
       //*******************************
@@ -316,16 +306,14 @@ namespace etl
           timer.next                     = etl::timer::id::NO_TIMER;
         }
 
-        head    = etl::timer::id::NO_TIMER;
-        tail    = etl::timer::id::NO_TIMER;
-        current = etl::timer::id::NO_TIMER;
+        head = etl::timer::id::NO_TIMER;
+        tail = etl::timer::id::NO_TIMER;
       }
 
     private:
 
       etl::timer::id::type head;
       etl::timer::id::type tail;
-      etl::timer::id::type current;
 
       etl::message_timer_data* const ptimers;
     };

--- a/include/etl/message_timer_atomic.h
+++ b/include/etl/message_timer_atomic.h
@@ -466,7 +466,6 @@ namespace etl
       timer_list(timer_data* ptimers_)
         : head(etl::timer::id::NO_TIMER)
         , tail(etl::timer::id::NO_TIMER)
-        , current(etl::timer::id::NO_TIMER)
         , ptimers(ptimers_)
       {
       }
@@ -595,22 +594,13 @@ namespace etl
       //*******************************
       etl::timer::id::type begin()
       {
-        current = head;
-        return current;
-      }
-
-      //*******************************
-      etl::timer::id::type previous(etl::timer::id::type last)
-      {
-        current = ptimers[last].previous;
-        return current;
+        return head;
       }
 
       //*******************************
       etl::timer::id::type next(etl::timer::id::type last)
       {
-        current = ptimers[last].next;
-        return current;
+        return ptimers[last].next;
       }
 
       //*******************************
@@ -625,16 +615,14 @@ namespace etl
           timer.next        = etl::timer::id::NO_TIMER;
         }
 
-        head    = etl::timer::id::NO_TIMER;
-        tail    = etl::timer::id::NO_TIMER;
-        current = etl::timer::id::NO_TIMER;
+        head = etl::timer::id::NO_TIMER;
+        tail = etl::timer::id::NO_TIMER;
       }
 
     private:
 
       etl::timer::id::type head;
       etl::timer::id::type tail;
-      etl::timer::id::type current;
 
       timer_data* const ptimers;
     };

--- a/include/etl/message_timer_interrupt.h
+++ b/include/etl/message_timer_interrupt.h
@@ -472,7 +472,6 @@ namespace etl
       timer_list(timer_data* ptimers_)
         : head(etl::timer::id::NO_TIMER)
         , tail(etl::timer::id::NO_TIMER)
-        , current(etl::timer::id::NO_TIMER)
         , ptimers(ptimers_)
       {
       }
@@ -601,22 +600,13 @@ namespace etl
       //*******************************
       etl::timer::id::type begin()
       {
-        current = head;
-        return current;
-      }
-
-      //*******************************
-      etl::timer::id::type previous(etl::timer::id::type last)
-      {
-        current = ptimers[last].previous;
-        return current;
+        return head;
       }
 
       //*******************************
       etl::timer::id::type next(etl::timer::id::type last)
       {
-        current = ptimers[last].next;
-        return current;
+        return ptimers[last].next;
       }
 
       //*******************************
@@ -631,16 +621,14 @@ namespace etl
           timer.next        = etl::timer::id::NO_TIMER;
         }
 
-        head    = etl::timer::id::NO_TIMER;
-        tail    = etl::timer::id::NO_TIMER;
-        current = etl::timer::id::NO_TIMER;
+        head = etl::timer::id::NO_TIMER;
+        tail = etl::timer::id::NO_TIMER;
       }
 
     private:
 
       etl::timer::id::type head;
       etl::timer::id::type tail;
-      etl::timer::id::type current;
 
       timer_data* const ptimers;
     };

--- a/include/etl/message_timer_locked.h
+++ b/include/etl/message_timer_locked.h
@@ -480,7 +480,6 @@ namespace etl
       timer_list(timer_data* ptimers_)
         : head(etl::timer::id::NO_TIMER)
         , tail(etl::timer::id::NO_TIMER)
-        , current(etl::timer::id::NO_TIMER)
         , ptimers(ptimers_)
       {
       }
@@ -609,22 +608,13 @@ namespace etl
       //*******************************
       etl::timer::id::type begin()
       {
-        current = head;
-        return current;
-      }
-
-      //*******************************
-      etl::timer::id::type previous(etl::timer::id::type last)
-      {
-        current = ptimers[last].previous;
-        return current;
+        return head;
       }
 
       //*******************************
       etl::timer::id::type next(etl::timer::id::type last)
       {
-        current = ptimers[last].next;
-        return current;
+        return ptimers[last].next;
       }
 
       //*******************************
@@ -639,16 +629,14 @@ namespace etl
           timer.next        = etl::timer::id::NO_TIMER;
         }
 
-        head    = etl::timer::id::NO_TIMER;
-        tail    = etl::timer::id::NO_TIMER;
-        current = etl::timer::id::NO_TIMER;
+        head = etl::timer::id::NO_TIMER;
+        tail = etl::timer::id::NO_TIMER;
       }
 
     private:
 
       etl::timer::id::type head;
       etl::timer::id::type tail;
-      etl::timer::id::type current;
 
       timer_data* const ptimers;
     };

--- a/include/etl/ranges.h
+++ b/include/etl/ranges.h
@@ -3639,20 +3639,6 @@ namespace etl
     template <class... Ranges>
     concat_view(Ranges&&...) -> concat_view<views::all_t<Ranges>...>;
 
-    struct concat_range_adapter_closure : public range_adapter_closure<concat_range_adapter_closure>
-    {
-      template <typename... Ranges>
-      using target_view_type = concat_view<Ranges...>;
-
-      constexpr concat_range_adapter_closure() = default;
-
-      template <typename... Ranges>
-      constexpr auto operator()(Ranges&&... r) const
-      {
-        return concat_view(views::all(etl::forward<Ranges>(r))...);
-      }
-    };
-
     namespace views
     {
       namespace private_views

--- a/include/etl/vector.h
+++ b/include/etl/vector.h
@@ -1126,17 +1126,6 @@ namespace etl
   private:
 
     //*********************************************************************
-    /// Create a new element with a default value at the back.
-    //*********************************************************************
-    void create_back()
-    {
-      etl::create_value_at(p_end);
-      ETL_INCREMENT_DEBUG_COUNT;
-
-      ++p_end;
-    }
-
-    //*********************************************************************
     /// Create a new element with a value at the back
     //*********************************************************************
     void create_back(const_reference value)

--- a/test/test_memory.cpp
+++ b/test/test_memory.cpp
@@ -2980,5 +2980,31 @@ namespace
       CHECK_EQUAL(0, relocatable_t::destructor_count);
     }
 #endif
+
+    //*************************************************************************
+    TEST(test_wipe_on_destruct)
+    {
+      struct Data : public etl::wipe_on_destruct<Data>
+      {
+        uint32_t d1;
+        uint32_t d2;
+        char     d3;
+      };
+
+      alignas(Data) unsigned char buffer[sizeof(Data)] = {0};
+
+      // Construct a Data object in the buffer with known non-zero values.
+      Data* p = new (buffer) Data();
+      p->d1   = 0x12345678UL;
+      p->d2   = 0xAABBCCDDUL;
+      p->d3   = char(0xEE);
+
+      // Destroy the object; wipe_on_destruct should zero the memory.
+      p->~Data();
+
+      // Verify the memory occupied by the object has been cleared.
+      unsigned char zeroes[sizeof(Data)] = {0};
+      CHECK(memcmp(buffer, zeroes, sizeof(Data)) == 0);
+    }
   }
 } // namespace

--- a/test/test_ranges.cpp
+++ b/test/test_ranges.cpp
@@ -3385,6 +3385,42 @@ namespace
     }
 
     //*************************************************************************
+    TEST(test_ranges_keys_view_alias)
+    {
+      std::vector<std::pair<int, double>> v = {{10, 1.1}, {20, 2.2}, {30, 3.3}};
+
+      using range_t = etl::ranges::views::all_t<decltype(v)&>;
+      etl::ranges::keys_view<range_t> kv(etl::ranges::views::all(v));
+
+      auto it = kv.begin();
+      CHECK_EQUAL(10, *it);
+      ++it;
+      CHECK_EQUAL(20, *it);
+      ++it;
+      CHECK_EQUAL(30, *it);
+      ++it;
+      CHECK(it == kv.end());
+    }
+
+    //*************************************************************************
+    TEST(test_ranges_values_view_alias)
+    {
+      std::vector<std::pair<int, double>> v = {{10, 1.1}, {20, 2.2}, {30, 3.3}};
+
+      using range_t = etl::ranges::views::all_t<decltype(v)&>;
+      etl::ranges::values_view<range_t> vv(etl::ranges::views::all(v));
+
+      auto it = vv.begin();
+      CHECK_CLOSE(1.1, *it, 0.001);
+      ++it;
+      CHECK_CLOSE(2.2, *it, 0.001);
+      ++it;
+      CHECK_CLOSE(3.3, *it, 0.001);
+      ++it;
+      CHECK(it == vv.end());
+    }
+
+    //*************************************************************************
     TEST(test_ranges_views_keys)
     {
       std::vector<std::pair<int, double>> v = {{10, 1.1}, {20, 2.2}, {30, 3.3}};


### PR DESCRIPTION
Removing private class members, code unused by ETL in "private"
namespaces, code unreachable via preprocessor guards (C++11 inside
C++03).

For code still to be kept, even though unused at first sight, add
tests.

Note: Based on development branch, to prevent conflicts.