### PR TITLE
ranges: Fix confict with Zephyr preprocessor definition

### DIFF
--- a/include/etl/ranges.h
+++ b/include/etl/ranges.h
@@ -2975,7 +2975,7 @@ namespace etl
         iterator() = default;
 
         iterator(const_iterator_type current, const_iterator_type segment_end, bool is_end)
-          : _current(current)
+          : _cur(current)
           , _segment_end(segment_end)
           , _is_end(is_end || (current == segment_end))
         {
@@ -2983,18 +2983,18 @@ namespace etl
 
         reference operator*() const
         {
-          return *_current;
+          return *_cur;
         }
 
         pointer operator->() const
         {
-          return &(*_current);
+          return &(*_cur);
         }
 
         iterator& operator++()
         {
-          ++_current;
-          if (_current == _segment_end)
+          ++_cur;
+          if (_cur == _segment_end)
           {
             _is_end = true;
           }
@@ -3018,7 +3018,7 @@ namespace etl
           {
             return false;
           }
-          return _current == other._current;
+          return _cur == other._cur;
         }
 
         constexpr bool operator!=(const iterator& other) const
@@ -3028,7 +3028,7 @@ namespace etl
 
       private:
 
-        const_iterator_type _current{};
+        const_iterator_type _cur{};
         const_iterator_type _segment_end{};
         bool                _is_end = true;
       };
@@ -3379,7 +3379,7 @@ namespace etl
       concat_iterator(size_t index, concat_view<Ranges...>& view, iterator_variant_type current)
         : _ranges_index{index}
         , _view(view)
-        , _current(current)
+        , _cur(current)
       {
       }
 
@@ -3387,7 +3387,7 @@ namespace etl
 
       constexpr reference operator*() const
       {
-        return _view.get_value(_ranges_index, _current);
+        return _view.get_value(_ranges_index, _cur);
       }
 
       constexpr decltype(auto) operator[](difference_type pos) const
@@ -3397,14 +3397,14 @@ namespace etl
         {
           for (difference_type i = 0; i < pos; ++i)
           {
-            tmp._view.advance(tmp._ranges_index, tmp._current, 1);
+            tmp._view.advance(tmp._ranges_index, tmp._cur, 1);
           }
         }
         if (pos < 0)
         {
           for (difference_type i = 0; i < -pos; ++i)
           {
-            tmp._view.advance(tmp._ranges_index, tmp._current, -1);
+            tmp._view.advance(tmp._ranges_index, tmp._cur, -1);
           }
         }
         return *tmp;
@@ -3412,27 +3412,27 @@ namespace etl
 
       constexpr concat_iterator& operator++()
       {
-        _view.advance(_ranges_index, _current, 1);
+        _view.advance(_ranges_index, _cur, 1);
         return *this;
       }
 
       constexpr concat_iterator operator++(int)
       {
         auto result = *this;
-        _view.advance(_ranges_index, _current, 1);
+        _view.advance(_ranges_index, _cur, 1);
         return result;
       }
 
       constexpr concat_iterator& operator--()
       {
-        _view.advance(_ranges_index, _current, -1);
+        _view.advance(_ranges_index, _cur, -1);
         return *this;
       }
 
       constexpr concat_iterator operator--(int)
       {
         auto result = *this;
-        _view.advance(_ranges_index, _current, -1);
+        _view.advance(_ranges_index, _cur, -1);
         return result;
       }
 
@@ -3440,7 +3440,7 @@ namespace etl
       {
         for (difference_type i = 0; i < n; ++i)
         {
-          _view.advance(_ranges_index, _current, 1);
+          _view.advance(_ranges_index, _cur, 1);
         }
         return *this;
       }
@@ -3449,7 +3449,7 @@ namespace etl
       {
         for (difference_type i = 0; i < n; ++i)
         {
-          _view.advance(_ranges_index, _current, -1);
+          _view.advance(_ranges_index, _cur, -1);
         }
         return *this;
       }
@@ -3457,12 +3457,12 @@ namespace etl
       friend constexpr bool operator==(const concat_iterator<Ranges...>& x, etl::default_sentinel_t)
       {
         return x._ranges_index == x._view.number_of_ranges - 1
-               && etl::get<x._view.number_of_ranges - 1>(x._current) == etl::get<x._view.number_of_ranges - 1>(x._view).end();
+               && etl::get<x._view.number_of_ranges - 1>(x._cur) == etl::get<x._view.number_of_ranges - 1>(x._view).end();
       }
 
       friend constexpr bool operator==(const concat_iterator<Ranges...>& x, const concat_iterator<Ranges...>& y)
       {
-        return x._ranges_index == y._ranges_index && x._current.index() == y._current.index() && x._current == y._current;
+        return x._ranges_index == y._ranges_index && x._cur.index() == y._cur.index() && x._cur == y._cur;
       }
 
       friend constexpr bool operator!=(const concat_iterator<Ranges...>& x, etl::default_sentinel_t)
@@ -3479,7 +3479,7 @@ namespace etl
 
       size_t                        _ranges_index;
       const concat_view<Ranges...>& _view;
-      iterator_variant_type         _current;
+      iterator_variant_type         _cur;
     };
 
     template <class... Ranges>
@@ -5746,7 +5746,7 @@ namespace etl
       using iterator_category = ETL_OR_STD::forward_iterator_tag;
 
       constexpr cartesian_product_iterator(iterators_type current, iterators_type begins, iterators_type ends, bool is_end = false)
-        : _current(current)
+        : _cur(current)
         , _begins(begins)
         , _ends(ends)
         , _is_end(is_end)
@@ -5799,7 +5799,7 @@ namespace etl
       template <size_t I>
       constexpr etl::enable_if_t<(I > 0)> increment_at()
       {
-        auto& it = etl::get<I>(_current);
+        auto& it = etl::get<I>(_cur);
         ++it;
         if (it == etl::get<I>(_ends))
         {
@@ -5811,7 +5811,7 @@ namespace etl
       template <size_t I>
       constexpr etl::enable_if_t<(I == 0)> increment_at()
       {
-        auto& it = etl::get<0>(_current);
+        auto& it = etl::get<0>(_cur);
         ++it;
         if (it == etl::get<0>(_ends))
         {
@@ -5822,16 +5822,16 @@ namespace etl
       template <size_t... Is>
       constexpr value_type deref(etl::index_sequence<Is...>) const
       {
-        return value_type(*etl::get<Is>(_current)...);
+        return value_type(*etl::get<Is>(_cur)...);
       }
 
       template <size_t... Is>
       constexpr bool all_equal(const cartesian_product_iterator& other, etl::index_sequence<Is...>) const
       {
-        return ((etl::get<Is>(_current) == etl::get<Is>(other._current)) && ...);
+        return ((etl::get<Is>(_cur) == etl::get<Is>(other._cur)) && ...);
       }
 
-      iterators_type _current;
+      iterators_type _cur;
       iterators_type _begins;
       iterators_type _ends;
       bool           _is_end;


### PR DESCRIPTION
Classic naming pollution through the preprocessor! 

Zephyr defines the `_current` as a preprocessor macro (https://github.com/zephyrproject-rtos/zephyr/blob/f0ce29dd53bc4d4271bd13113691807cd55ea55f/include/zephyr/kernel_structs.h#L256). In the `etl/ranges.h` file, the `_current` is used as a member in various places. This causes a conflict and prevents the code from compiling.
This commit fixes this issue by renaming all members named `_current` to `_cur`.

I understand that this is not an issue of ETL, but Zephyr, so feel free to reject this PR unconditionally :D 