### PR TITLE
 Add more constexpr to constructors

### DIFF
--- a/include/etl/cyclic_value.h
+++ b/include/etl/cyclic_value.h
@@ -65,7 +65,7 @@ namespace etl
     /// Default constructor.
     /// The initial value is set to the first value.
     //*************************************************************************
-    cyclic_value()
+    ETL_CONSTEXPR cyclic_value()
       : value(First)
     {
     }
@@ -75,7 +75,7 @@ namespace etl
     /// Set to an initial value.
     /// Clamped to the range.
     //*************************************************************************
-    explicit cyclic_value(T initial)
+    ETL_CONSTEXPR14 explicit cyclic_value(T initial)
     {
       set(initial);
     }
@@ -83,7 +83,7 @@ namespace etl
     //*************************************************************************
     /// Copy constructor.
     //*************************************************************************
-    cyclic_value(const cyclic_value<T, First, Last>& other)
+    ETL_CONSTEXPR cyclic_value(const cyclic_value<T, First, Last>& other)
       : value(other.value)
     {
     }
@@ -91,7 +91,7 @@ namespace etl
     //*************************************************************************
     /// Assignment operator.
     //*************************************************************************
-    cyclic_value& operator=(const cyclic_value<T, First, Last>& other)
+    ETL_CONSTEXPR14 cyclic_value& operator=(const cyclic_value<T, First, Last>& other)
     {
       value = other.value;
 
@@ -103,7 +103,7 @@ namespace etl
     /// Truncates to the First/Last range.
     ///\param value The value.
     //*************************************************************************
-    void set(T value_)
+    ETL_CONSTEXPR14 void set(T value_)
     {
       value = etl::clamp(value_, First, Last);
     }
@@ -111,7 +111,7 @@ namespace etl
     //*************************************************************************
     /// Resets the value to the first in the range.
     //*************************************************************************
-    void to_first()
+    ETL_CONSTEXPR14 void to_first()
     {
       value = First;
     }
@@ -119,7 +119,7 @@ namespace etl
     //*************************************************************************
     /// Resets the value to the last in the range.
     //*************************************************************************
-    void to_last()
+    ETL_CONSTEXPR14 void to_last()
     {
       value = Last;
     }
@@ -128,7 +128,7 @@ namespace etl
     /// Advances to value by a number of steps.
     ///\param n The number of steps to advance.
     //*************************************************************************
-    void advance(int n)
+    ETL_CONSTEXPR14 void advance(int n)
     {
       if (n > 0)
       {
@@ -150,7 +150,7 @@ namespace etl
     /// Conversion operator.
     /// \return The value of the underlying type.
     //*************************************************************************
-    operator T()
+    ETL_CONSTEXPR14 operator T()
     {
       return value;
     }
@@ -159,7 +159,7 @@ namespace etl
     /// Const conversion operator.
     /// \return The value of the underlying type.
     //*************************************************************************
-    operator const T() const
+    ETL_CONSTEXPR operator const T() const
     {
       return value;
     }
@@ -167,7 +167,7 @@ namespace etl
     //*************************************************************************
     /// ++ operator.
     //*************************************************************************
-    cyclic_value& operator++()
+    ETL_CONSTEXPR14 cyclic_value& operator++()
     {
       if (value >= Last) ETL_UNLIKELY
       {
@@ -184,7 +184,7 @@ namespace etl
     //*************************************************************************
     /// ++ operator.
     //*************************************************************************
-    cyclic_value operator++(int)
+    ETL_CONSTEXPR14 cyclic_value operator++(int)
     {
       cyclic_value temp(*this);
 
@@ -196,7 +196,7 @@ namespace etl
     //*************************************************************************
     /// -- operator.
     //*************************************************************************
-    cyclic_value& operator--()
+    ETL_CONSTEXPR14 cyclic_value& operator--()
     {
       if (value <= First) ETL_UNLIKELY
       {
@@ -213,7 +213,7 @@ namespace etl
     //*************************************************************************
     /// -- operator.
     //*************************************************************************
-    cyclic_value operator--(int)
+    ETL_CONSTEXPR14 cyclic_value operator--(int)
     {
       cyclic_value temp(*this);
 
@@ -225,7 +225,7 @@ namespace etl
     //*************************************************************************
     /// = operator.
     //*************************************************************************
-    cyclic_value& operator=(T t)
+    ETL_CONSTEXPR14 cyclic_value& operator=(T t)
     {
       set(t);
       return *this;
@@ -235,7 +235,7 @@ namespace etl
     /// = operator.
     //*************************************************************************
     template <const T FIRST2, const T LAST2>
-    cyclic_value& operator=(const cyclic_value<T, FIRST2, LAST2>& other)
+    ETL_CONSTEXPR14 cyclic_value& operator=(const cyclic_value<T, FIRST2, LAST2>& other)
     {
       set(other.get());
       return *this;
@@ -244,7 +244,7 @@ namespace etl
     //*************************************************************************
     /// Gets the value.
     //*************************************************************************
-    T get() const
+    ETL_CONSTEXPR T get() const
     {
       return value;
     }
@@ -286,7 +286,7 @@ namespace etl
     //*************************************************************************
     /// Operator ==.
     //*************************************************************************
-    friend bool operator==(const cyclic_value<T, First, Last>& lhs, const cyclic_value<T, First, Last>& rhs)
+    friend ETL_CONSTEXPR bool operator==(const cyclic_value<T, First, Last>& lhs, const cyclic_value<T, First, Last>& rhs)
     {
       return lhs.value == rhs.value;
     }
@@ -294,7 +294,7 @@ namespace etl
     //*************************************************************************
     /// Operator !=.
     //*************************************************************************
-    friend bool operator!=(const cyclic_value<T, First, Last>& lhs, const cyclic_value<T, First, Last>& rhs)
+    friend ETL_CONSTEXPR bool operator!=(const cyclic_value<T, First, Last>& lhs, const cyclic_value<T, First, Last>& rhs)
     {
       return !(lhs == rhs);
     }
@@ -322,7 +322,7 @@ namespace etl
     /// Sets 'first' and 'last' to the template parameter values.
     /// The initial value is set to the first value.
     //*************************************************************************
-    cyclic_value()
+    ETL_CONSTEXPR cyclic_value()
       : value(First)
       , first_value(First)
       , last_value(Last)
@@ -335,7 +335,7 @@ namespace etl
     ///\param first The first value in the range.
     ///\param last  The last value in the range.
     //*************************************************************************
-    cyclic_value(T first_, T last_)
+    ETL_CONSTEXPR cyclic_value(T first_, T last_)
       : value(first_)
       , first_value(first_)
       , last_value(last_)
@@ -349,7 +349,7 @@ namespace etl
     ///\param first The first value in the range.
     ///\param last  The last value in the range.
     //*************************************************************************
-    cyclic_value(T first_, T last_, T initial)
+    ETL_CONSTEXPR14 cyclic_value(T first_, T last_, T initial)
       : first_value(first_)
       , last_value(last_)
     {
@@ -359,7 +359,7 @@ namespace etl
     //*************************************************************************
     /// Copy constructor.
     //*************************************************************************
-    cyclic_value(const cyclic_value& other)
+    ETL_CONSTEXPR cyclic_value(const cyclic_value& other)
       : value(other.value)
       , first_value(other.first_value)
       , last_value(other.last_value)
@@ -372,7 +372,7 @@ namespace etl
     ///\param first The first value in the range.
     ///\param last  The last value in the range.
     //*************************************************************************
-    void set(T first_, T last_)
+    ETL_CONSTEXPR14 void set(T first_, T last_)
     {
       first_value = first_;
       last_value  = last_;
@@ -383,7 +383,7 @@ namespace etl
     /// Sets the value.
     ///\param value The value.
     //*************************************************************************
-    void set(T value_)
+    ETL_CONSTEXPR14 void set(T value_)
     {
       value = etl::clamp(value_, first_value, last_value);
     }
@@ -391,7 +391,7 @@ namespace etl
     //*************************************************************************
     /// Resets the value to the first in the range.
     //*************************************************************************
-    void to_first()
+    ETL_CONSTEXPR14 void to_first()
     {
       value = first_value;
     }
@@ -399,7 +399,7 @@ namespace etl
     //*************************************************************************
     /// Resets the value to the last in the range.
     //*************************************************************************
-    void to_last()
+    ETL_CONSTEXPR14 void to_last()
     {
       value = last_value;
     }
@@ -408,7 +408,7 @@ namespace etl
     /// Advances to value by a number of steps.
     ///\param n The number of steps to advance.
     //*************************************************************************
-    void advance(int n)
+    ETL_CONSTEXPR14 void advance(int n)
     {
       if (n > 0)
       {
@@ -430,7 +430,7 @@ namespace etl
     /// Conversion operator.
     /// \return The value of the underlying type.
     //*************************************************************************
-    operator T()
+    ETL_CONSTEXPR14 operator T()
     {
       return value;
     }
@@ -439,7 +439,7 @@ namespace etl
     /// Const conversion operator.
     /// \return The value of the underlying type.
     //*************************************************************************
-    operator const T() const
+    ETL_CONSTEXPR operator const T() const
     {
       return value;
     }
@@ -447,7 +447,7 @@ namespace etl
     //*************************************************************************
     /// ++ operator.
     //*************************************************************************
-    cyclic_value& operator++()
+    ETL_CONSTEXPR14 cyclic_value& operator++()
     {
       if (value >= last_value)
       {
@@ -464,7 +464,7 @@ namespace etl
     //*************************************************************************
     /// ++ operator.
     //*************************************************************************
-    cyclic_value operator++(int)
+    ETL_CONSTEXPR14 cyclic_value operator++(int)
     {
       cyclic_value temp(*this);
 
@@ -476,7 +476,7 @@ namespace etl
     //*************************************************************************
     /// -- operator.
     //*************************************************************************
-    cyclic_value& operator--()
+    ETL_CONSTEXPR14 cyclic_value& operator--()
     {
       if (value <= first_value)
       {
@@ -493,7 +493,7 @@ namespace etl
     //*************************************************************************
     /// -- operator.
     //*************************************************************************
-    cyclic_value operator--(int)
+    ETL_CONSTEXPR14 cyclic_value operator--(int)
     {
       cyclic_value temp(*this);
 
@@ -505,7 +505,7 @@ namespace etl
     //*************************************************************************
     /// = operator.
     //*************************************************************************
-    cyclic_value& operator=(T t)
+    ETL_CONSTEXPR14 cyclic_value& operator=(T t)
     {
       set(t);
       return *this;
@@ -514,7 +514,7 @@ namespace etl
     //*************************************************************************
     /// = operator.
     //*************************************************************************
-    cyclic_value& operator=(const cyclic_value& other)
+    ETL_CONSTEXPR14 cyclic_value& operator=(const cyclic_value& other)
     {
       value       = other.value;
       first_value = other.first_value;
@@ -525,7 +525,7 @@ namespace etl
     //*************************************************************************
     /// Gets the value.
     //*************************************************************************
-    T get() const
+    ETL_CONSTEXPR T get() const
     {
       return value;
     }
@@ -533,7 +533,7 @@ namespace etl
     //*************************************************************************
     /// Gets the first value.
     //*************************************************************************
-    T first() const
+    ETL_CONSTEXPR T first() const
     {
       return first_value;
     }
@@ -541,7 +541,7 @@ namespace etl
     //*************************************************************************
     /// Gets the last value.
     //*************************************************************************
-    T last() const
+    ETL_CONSTEXPR T last() const
     {
       return last_value;
     }
@@ -569,7 +569,7 @@ namespace etl
     //*************************************************************************
     /// Operator ==.
     //*************************************************************************
-    friend bool operator==(const cyclic_value<T, First, Last>& lhs, const cyclic_value<T, First, Last>& rhs)
+    friend ETL_CONSTEXPR bool operator==(const cyclic_value<T, First, Last>& lhs, const cyclic_value<T, First, Last>& rhs)
     {
       return (lhs.value == rhs.value) && (lhs.first_value == rhs.first_value) && (lhs.last_value == rhs.last_value);
     }
@@ -577,7 +577,7 @@ namespace etl
     //*************************************************************************
     /// Operator !=.
     //*************************************************************************
-    friend bool operator!=(const cyclic_value<T, First, Last>& lhs, const cyclic_value<T, First, Last>& rhs)
+    friend ETL_CONSTEXPR bool operator!=(const cyclic_value<T, First, Last>& lhs, const cyclic_value<T, First, Last>& rhs)
     {
       return !(lhs == rhs);
     }

--- a/include/etl/fixed_iterator.h
+++ b/include/etl/fixed_iterator.h
@@ -108,7 +108,7 @@ namespace etl
     //***************************************************************************
     /// Dereference operator.
     //***************************************************************************
-    ETL_CONSTEXPR14 typename etl::iterator_traits<TIterator>::value_type operator*()
+    ETL_CONSTEXPR14 typename etl::iterator_traits<TIterator>::reference operator*()
     {
       return *it;
     }
@@ -116,7 +116,7 @@ namespace etl
     //***************************************************************************
     /// Dereference operator.
     //***************************************************************************
-    ETL_CONSTEXPR const typename etl::iterator_traits<TIterator>::value_type operator*() const
+    ETL_CONSTEXPR typename etl::iterator_traits<TIterator>::reference operator*() const
     {
       return *it;
     }

--- a/include/etl/fixed_iterator.h
+++ b/include/etl/fixed_iterator.h
@@ -263,7 +263,7 @@ namespace etl
   /// Inequality operator. iterator == fixed_iterator.
   //*****************************************************************************
   template <typename TIterator>
-  ETL_CONSTEXPR bool operator!=(TIterator& lhs, const etl::fixed_iterator<TIterator>& rhs)
+  ETL_CONSTEXPR bool operator!=(TIterator lhs, const etl::fixed_iterator<TIterator>& rhs)
   {
     return !(lhs == rhs);
   }

--- a/include/etl/fixed_iterator.h
+++ b/include/etl/fixed_iterator.h
@@ -52,7 +52,7 @@ namespace etl
     //***************************************************************************
     /// Default constructor.
     //***************************************************************************
-    fixed_iterator()
+    ETL_CONSTEXPR fixed_iterator()
       : it(TIterator())
     {
     }
@@ -60,7 +60,7 @@ namespace etl
     //***************************************************************************
     /// Construct from iterator.
     //***************************************************************************
-    fixed_iterator(TIterator it_)
+    ETL_CONSTEXPR fixed_iterator(TIterator it_)
       : it(it_)
     {
     }
@@ -68,7 +68,7 @@ namespace etl
     //***************************************************************************
     /// Copy constructor
     //***************************************************************************
-    fixed_iterator(const fixed_iterator& other)
+    ETL_CONSTEXPR fixed_iterator(const fixed_iterator& other)
       : it(other.it)
     {
     }
@@ -76,7 +76,7 @@ namespace etl
     //***************************************************************************
     /// Increment (Does nothing).
     //***************************************************************************
-    fixed_iterator& operator++()
+    ETL_CONSTEXPR14 fixed_iterator& operator++()
     {
       return *this;
     }
@@ -84,7 +84,7 @@ namespace etl
     //***************************************************************************
     /// Increment (Does nothing).
     //***************************************************************************
-    fixed_iterator operator++(int)
+    ETL_CONSTEXPR14 fixed_iterator operator++(int)
     {
       return *this;
     }
@@ -92,7 +92,7 @@ namespace etl
     //***************************************************************************
     /// Decrement (Does nothing).
     //***************************************************************************
-    fixed_iterator& operator--()
+    ETL_CONSTEXPR14 fixed_iterator& operator--()
     {
       return *this;
     }
@@ -100,7 +100,7 @@ namespace etl
     //***************************************************************************
     /// Decrement (Does nothing).
     //***************************************************************************
-    fixed_iterator operator--(int)
+    ETL_CONSTEXPR14 fixed_iterator operator--(int)
     {
       return *this;
     }
@@ -108,7 +108,7 @@ namespace etl
     //***************************************************************************
     /// Dereference operator.
     //***************************************************************************
-    typename etl::iterator_traits<TIterator>::value_type operator*()
+    ETL_CONSTEXPR14 typename etl::iterator_traits<TIterator>::value_type operator*()
     {
       return *it;
     }
@@ -116,7 +116,7 @@ namespace etl
     //***************************************************************************
     /// Dereference operator.
     //***************************************************************************
-    const typename etl::iterator_traits<TIterator>::value_type operator*() const
+    ETL_CONSTEXPR const typename etl::iterator_traits<TIterator>::value_type operator*() const
     {
       return *it;
     }
@@ -124,7 +124,7 @@ namespace etl
     //***************************************************************************
     /// -> operator.
     //***************************************************************************
-    TIterator operator->()
+    ETL_CONSTEXPR14 TIterator operator->()
     {
       return it;
     }
@@ -132,7 +132,7 @@ namespace etl
     //***************************************************************************
     /// -> operator.
     //***************************************************************************
-    const TIterator operator->() const
+    ETL_CONSTEXPR const TIterator operator->() const
     {
       return it;
     }
@@ -140,7 +140,7 @@ namespace etl
     //***************************************************************************
     /// Conversion operator.
     //***************************************************************************
-    operator TIterator() const
+    ETL_CONSTEXPR operator TIterator() const
     {
       return it;
     }
@@ -148,7 +148,7 @@ namespace etl
     //***************************************************************************
     /// += operator.
     //***************************************************************************
-    fixed_iterator& operator+=(typename etl::iterator_traits<TIterator>::difference_type /*offset*/)
+    ETL_CONSTEXPR14 fixed_iterator& operator+=(typename etl::iterator_traits<TIterator>::difference_type /*offset*/)
     {
       return *this;
     }
@@ -156,7 +156,7 @@ namespace etl
     //***************************************************************************
     /// -= operator.
     //***************************************************************************
-    fixed_iterator& operator-=(typename etl::iterator_traits<TIterator>::difference_type /*offset*/)
+    ETL_CONSTEXPR14 fixed_iterator& operator-=(typename etl::iterator_traits<TIterator>::difference_type /*offset*/)
     {
       return *this;
     }
@@ -164,7 +164,7 @@ namespace etl
     //***************************************************************************
     /// Assignment from iterator.
     //***************************************************************************
-    fixed_iterator& operator=(TIterator new_it)
+    ETL_CONSTEXPR14 fixed_iterator& operator=(TIterator new_it)
     {
       it = new_it;
       return *this;
@@ -173,7 +173,7 @@ namespace etl
     //***************************************************************************
     /// Assignment from fixed_iterator.
     //***************************************************************************
-    fixed_iterator& operator=(fixed_iterator other)
+    ETL_CONSTEXPR14 fixed_iterator& operator=(fixed_iterator other)
     {
       it = other.it;
       return *this;
@@ -188,7 +188,8 @@ namespace etl
   /// + difference operator.
   //*****************************************************************************
   template <typename TIterator>
-  etl::fixed_iterator<TIterator>& operator+(etl::fixed_iterator<TIterator>& lhs, typename etl::iterator_traits<TIterator>::difference_type /*rhs*/)
+  ETL_CONSTEXPR14 etl::fixed_iterator<TIterator>& operator+(etl::fixed_iterator<TIterator>& lhs,
+                                                      typename etl::iterator_traits<TIterator>::difference_type /*rhs*/)
   {
     return lhs;
   }
@@ -197,7 +198,8 @@ namespace etl
   /// - difference operator.
   //*****************************************************************************
   template <typename TIterator>
-  etl::fixed_iterator<TIterator>& operator-(etl::fixed_iterator<TIterator>& lhs, typename etl::iterator_traits<TIterator>::difference_type /*rhs*/)
+  ETL_CONSTEXPR14 etl::fixed_iterator<TIterator>& operator-(etl::fixed_iterator<TIterator>& lhs,
+                                                      typename etl::iterator_traits<TIterator>::difference_type /*rhs*/)
   {
     return lhs;
   }
@@ -206,8 +208,8 @@ namespace etl
   /// - fixed_iterator operator.
   //*****************************************************************************
   template <typename TIterator>
-  typename etl::iterator_traits<TIterator>::difference_type operator-(const etl::fixed_iterator<TIterator>& lhs,
-                                                                      const etl::fixed_iterator<TIterator>& rhs)
+  ETL_CONSTEXPR typename etl::iterator_traits<TIterator>::difference_type operator-(const etl::fixed_iterator<TIterator>& lhs,
+                                                                                const etl::fixed_iterator<TIterator>& rhs)
   {
     return TIterator(lhs) - TIterator(rhs);
   }
@@ -216,7 +218,7 @@ namespace etl
   /// Equality operator. fixed_iterator == fixed_iterator.
   //*****************************************************************************
   template <typename TIterator>
-  bool operator==(const etl::fixed_iterator<TIterator>& lhs, const etl::fixed_iterator<TIterator>& rhs)
+  ETL_CONSTEXPR bool operator==(const etl::fixed_iterator<TIterator>& lhs, const etl::fixed_iterator<TIterator>& rhs)
   {
     return TIterator(lhs) == TIterator(rhs);
   }
@@ -225,7 +227,7 @@ namespace etl
   /// Equality operator. fixed_iterator == iterator.
   //*****************************************************************************
   template <typename TIterator>
-  bool operator==(const etl::fixed_iterator<TIterator>& lhs, TIterator rhs)
+  ETL_CONSTEXPR bool operator==(const etl::fixed_iterator<TIterator>& lhs, TIterator rhs)
   {
     return TIterator(lhs) == rhs;
   }
@@ -234,7 +236,7 @@ namespace etl
   /// Equality operator. iterator == fixed_iterator.
   //*****************************************************************************
   template <typename TIterator>
-  bool operator==(TIterator lhs, const etl::fixed_iterator<TIterator>& rhs)
+  ETL_CONSTEXPR bool operator==(TIterator lhs, const etl::fixed_iterator<TIterator>& rhs)
   {
     return lhs == TIterator(rhs);
   }
@@ -243,7 +245,7 @@ namespace etl
   /// Inequality operator. fixed_iterator == fixed_iterator.
   //*****************************************************************************
   template <typename TIterator>
-  bool operator!=(const etl::fixed_iterator<TIterator>& lhs, const etl::fixed_iterator<TIterator>& rhs)
+  ETL_CONSTEXPR bool operator!=(const etl::fixed_iterator<TIterator>& lhs, const etl::fixed_iterator<TIterator>& rhs)
   {
     return !(lhs == rhs);
   }
@@ -252,7 +254,7 @@ namespace etl
   /// Inequality operator. fixed_iterator == iterator.
   //*****************************************************************************
   template <typename TIterator>
-  bool operator!=(const etl::fixed_iterator<TIterator>& lhs, TIterator rhs)
+  ETL_CONSTEXPR bool operator!=(const etl::fixed_iterator<TIterator>& lhs, TIterator rhs)
   {
     return !(lhs == rhs);
   }
@@ -261,7 +263,7 @@ namespace etl
   /// Inequality operator. iterator == fixed_iterator.
   //*****************************************************************************
   template <typename TIterator>
-  bool operator!=(TIterator& lhs, const etl::fixed_iterator<TIterator>& rhs)
+  ETL_CONSTEXPR bool operator!=(TIterator& lhs, const etl::fixed_iterator<TIterator>& rhs)
   {
     return !(lhs == rhs);
   }

--- a/include/etl/functional.h
+++ b/include/etl/functional.h
@@ -363,25 +363,25 @@ namespace etl
 
   public:
 
-    binder1st(const TFunction& f, const typename TFunction::first_argument_type& v)
+    ETL_CONSTEXPR binder1st(const TFunction& f, const typename TFunction::first_argument_type& v)
       : operation(f)
       , value(v)
     {
     }
 
-    typename TFunction::result_type operator()(typename TFunction::second_argument_type& x) const
+    ETL_CONSTEXPR typename TFunction::result_type operator()(typename TFunction::second_argument_type& x) const
     {
       return operation(value, x);
     }
 
-    typename TFunction::result_type operator()(const typename TFunction::second_argument_type& x) const
+    ETL_CONSTEXPR typename TFunction::result_type operator()(const typename TFunction::second_argument_type& x) const
     {
       return operation(value, x);
     }
   };
 
   template <typename F, typename T>
-  binder1st<F> bind1st(const F& f, const T& x)
+  ETL_CONSTEXPR binder1st<F> bind1st(const F& f, const T& x)
   {
     return binder1st<F>(f, x);
   }
@@ -397,25 +397,25 @@ namespace etl
 
   public:
 
-    binder2nd(const TFunction& f, const typename TFunction::second_argument_type& v)
+    ETL_CONSTEXPR binder2nd(const TFunction& f, const typename TFunction::second_argument_type& v)
       : operation(f)
       , value(v)
     {
     }
 
-    typename TFunction::result_type operator()(typename TFunction::first_argument_type& x) const
+    ETL_CONSTEXPR typename TFunction::result_type operator()(typename TFunction::first_argument_type& x) const
     {
       return operation(x, value);
     }
 
-    typename TFunction::result_type operator()(const typename TFunction::first_argument_type& x) const
+    ETL_CONSTEXPR typename TFunction::result_type operator()(const typename TFunction::first_argument_type& x) const
     {
       return operation(x, value);
     }
   };
 
   template <typename F, typename T>
-  binder2nd<F> bind2nd(const F& f, const T& x)
+  ETL_CONSTEXPR binder2nd<F> bind2nd(const F& f, const T& x)
   {
     return binder2nd<F>(f, x);
   }

--- a/include/etl/invert.h
+++ b/include/etl/invert.h
@@ -48,7 +48,7 @@ namespace etl
     //*****************************************************************
     // Constructor.
     //*****************************************************************
-    invert()
+    ETL_CONSTEXPR invert()
       : offset(TInput(0))
       , minuend((etl::numeric_limits<TInput>::is_signed) ? TInput(0) : etl::numeric_limits<TInput>::max())
     {
@@ -57,7 +57,7 @@ namespace etl
     //*****************************************************************
     // Constructor.
     //*****************************************************************
-    invert(TInput offset_, TInput minuend_)
+    ETL_CONSTEXPR invert(TInput offset_, TInput minuend_)
       : offset(offset_)
       , minuend(minuend_)
     {
@@ -66,7 +66,7 @@ namespace etl
     //*****************************************************************
     // operator ()
     //*****************************************************************
-    TInput operator()(TInput value) const
+    ETL_CONSTEXPR TInput operator()(TInput value) const
     {
       return minuend - (value - offset);
     }

--- a/include/etl/iterator.h
+++ b/include/etl/iterator.h
@@ -576,13 +576,13 @@ namespace etl
       return move_iterator(current - n);
     }
 
-    ETL_CONSTEXPR14 move_iterator operator+=(difference_type n)
+    ETL_CONSTEXPR14 move_iterator& operator+=(difference_type n)
     {
       current += n;
       return *this;
     }
 
-    ETL_CONSTEXPR14 move_iterator operator-=(difference_type n)
+    ETL_CONSTEXPR14 move_iterator& operator-=(difference_type n)
     {
       current -= n;
       return *this;

--- a/include/etl/iterator.h
+++ b/include/etl/iterator.h
@@ -502,90 +502,90 @@ namespace etl
     typedef TIterator                                              pointer;
     typedef value_type&&                                           reference;
 
-    move_iterator() {}
+    ETL_CONSTEXPR move_iterator() {}
 
-    explicit move_iterator(TIterator itr)
+    ETL_CONSTEXPR explicit move_iterator(TIterator itr)
       : current(itr)
     {
     }
 
     template <typename U>
-    move_iterator(const move_iterator<U>& itr)
+    ETL_CONSTEXPR move_iterator(const move_iterator<U>& itr)
       : current(itr.base())
     {
     }
 
     template <typename U>
-    move_iterator& operator=(const move_iterator<U>& itr)
+    ETL_CONSTEXPR14 move_iterator& operator=(const move_iterator<U>& itr)
     {
       current = itr.current;
       return *this;
     }
 
-    iterator_type base() const
+    ETL_CONSTEXPR iterator_type base() const
     {
       return current;
     }
 
-    pointer operator->() const
+    ETL_CONSTEXPR pointer operator->() const
     {
       return current;
     }
 
-    reference operator*() const
+    ETL_CONSTEXPR reference operator*() const
     {
       return etl::move(*current);
     }
 
-    move_iterator& operator++()
+    ETL_CONSTEXPR14 move_iterator& operator++()
     {
       ++current;
       return *this;
     }
 
-    move_iterator& operator--()
+    ETL_CONSTEXPR14 move_iterator& operator--()
     {
       --current;
       return *this;
     }
 
-    move_iterator operator++(int)
+    ETL_CONSTEXPR14 move_iterator operator++(int)
     {
       move_iterator temp = *this;
       ++current;
       return temp;
     }
 
-    move_iterator operator--(int)
+    ETL_CONSTEXPR14 move_iterator operator--(int)
     {
       move_iterator temp = *this;
       --current;
       return temp;
     }
 
-    move_iterator operator+(difference_type n) const
+    ETL_CONSTEXPR move_iterator operator+(difference_type n) const
     {
       return move_iterator(current + n);
     }
 
-    move_iterator operator-(difference_type n) const
+    ETL_CONSTEXPR move_iterator operator-(difference_type n) const
     {
       return move_iterator(current - n);
     }
 
-    move_iterator operator+=(difference_type n)
+    ETL_CONSTEXPR14 move_iterator operator+=(difference_type n)
     {
       current += n;
       return *this;
     }
 
-    move_iterator operator-=(difference_type n)
+    ETL_CONSTEXPR14 move_iterator operator-=(difference_type n)
     {
       current -= n;
       return *this;
     }
 
-    reference operator[](difference_type n) const
+    ETL_CONSTEXPR reference operator[](difference_type n) const
     {
       return etl::move(current[n]);
     }
@@ -596,55 +596,55 @@ namespace etl
   };
 
   template <typename TIterator>
-  bool operator==(const etl::move_iterator<TIterator>& lhs, const etl::move_iterator<TIterator>& rhs)
+  ETL_CONSTEXPR bool operator==(const etl::move_iterator<TIterator>& lhs, const etl::move_iterator<TIterator>& rhs)
   {
     return lhs.base() == rhs.base();
   }
 
   template <typename TIterator>
-  bool operator!=(const etl::move_iterator<TIterator>& lhs, const etl::move_iterator<TIterator>& rhs)
+  ETL_CONSTEXPR bool operator!=(const etl::move_iterator<TIterator>& lhs, const etl::move_iterator<TIterator>& rhs)
   {
     return !(lhs == rhs);
   }
 
   template <typename TIterator>
-  bool operator<(const etl::move_iterator<TIterator>& lhs, const etl::move_iterator<TIterator>& rhs)
+  ETL_CONSTEXPR bool operator<(const etl::move_iterator<TIterator>& lhs, const etl::move_iterator<TIterator>& rhs)
   {
     return lhs.base() < rhs.base();
   }
 
   template <typename TIterator>
-  bool operator<=(const etl::move_iterator<TIterator>& lhs, const etl::move_iterator<TIterator>& rhs)
+  ETL_CONSTEXPR bool operator<=(const etl::move_iterator<TIterator>& lhs, const etl::move_iterator<TIterator>& rhs)
   {
     return !(rhs < lhs);
   }
 
   template <typename TIterator>
-  bool operator>(const etl::move_iterator<TIterator>& lhs, const etl::move_iterator<TIterator>& rhs)
+  ETL_CONSTEXPR bool operator>(const etl::move_iterator<TIterator>& lhs, const etl::move_iterator<TIterator>& rhs)
   {
     return (rhs < lhs);
   }
 
   template <typename TIterator>
-  bool operator>=(const etl::move_iterator<TIterator>& lhs, const etl::move_iterator<TIterator>& rhs)
+  ETL_CONSTEXPR bool operator>=(const etl::move_iterator<TIterator>& lhs, const etl::move_iterator<TIterator>& rhs)
   {
     return !(lhs < rhs);
   }
 
   template <typename TIterator>
-  move_iterator<TIterator> operator+(typename move_iterator<TIterator>::difference_type n, const move_iterator<TIterator>& rhs)
+  ETL_CONSTEXPR move_iterator<TIterator> operator+(typename move_iterator<TIterator>::difference_type n, const move_iterator<TIterator>& rhs)
   {
     return rhs + n;
   }
 
   template <typename TIterator1, typename TIterator2 >
-  auto operator-(const move_iterator<TIterator1>& lhs, const move_iterator<TIterator2>& rhs) -> decltype(lhs.base() - rhs.base())
+  ETL_CONSTEXPR auto operator-(const move_iterator<TIterator1>& lhs, const move_iterator<TIterator2>& rhs) -> decltype(lhs.base() - rhs.base())
   {
     return lhs.base() - rhs.base();
   }
 
   template <typename TIterator>
-  etl::move_iterator<TIterator> make_move_iterator(TIterator itr)
+  ETL_CONSTEXPR etl::move_iterator<TIterator> make_move_iterator(TIterator itr)
   {
     return etl::move_iterator<TIterator>(itr);
   }

--- a/include/etl/iterator.h
+++ b/include/etl/iterator.h
@@ -502,7 +502,10 @@ namespace etl
     typedef TIterator                                              pointer;
     typedef value_type&&                                           reference;
 
-    ETL_CONSTEXPR move_iterator() {}
+    ETL_CONSTEXPR move_iterator()
+      : current()
+    {
+    }
 
     ETL_CONSTEXPR explicit move_iterator(TIterator itr)
       : current(itr)

--- a/include/etl/memory.h
+++ b/include/etl/memory.h
@@ -1916,7 +1916,7 @@ namespace etl
 
     //*********************************
     template <typename U>
-    default_delete(const default_delete<U>&) ETL_NOEXCEPT
+    ETL_CONSTEXPR default_delete(const default_delete<U>&) ETL_NOEXCEPT
     {
     }
 
@@ -1943,7 +1943,7 @@ namespace etl
 
     //*********************************
     template <typename U>
-    default_delete(const default_delete<U>&) ETL_NOEXCEPT
+    ETL_CONSTEXPR default_delete(const default_delete<U>&) ETL_NOEXCEPT
     {
     }
 

--- a/include/etl/pseudo_moving_average.h
+++ b/include/etl/pseudo_moving_average.h
@@ -127,7 +127,7 @@ namespace etl
     /// Constructor
     /// \param initial_value The initial value for the average.
     //*************************************************************************
-    pseudo_moving_average(const T initial_value)
+    ETL_CONSTEXPR pseudo_moving_average(const T initial_value)
       : average(initial_value * SCALE)
     {
     }
@@ -208,7 +208,7 @@ namespace etl
     /// Constructor
     /// \param initial_value The initial value for the average.
     //*************************************************************************
-    pseudo_moving_average(const T initial_value, const size_t sample_size)
+    ETL_CONSTEXPR pseudo_moving_average(const T initial_value, const size_t sample_size)
       : average(initial_value * SCALE)
       , samples(sample_t(sample_size))
     {
@@ -292,7 +292,7 @@ namespace etl
     /// Constructor
     /// \param initial_value The initial value for the average.
     //*************************************************************************
-    pseudo_moving_average(const T initial_value)
+    ETL_CONSTEXPR pseudo_moving_average(const T initial_value)
       : reciprocal_samples_plus_1(T(1.0) / T(SAMPLE_SIZE_ + 1U))
       , average(initial_value)
     {
@@ -363,7 +363,7 @@ namespace etl
     /// Constructor
     /// \param initial_value The initial value for the average.
     //*************************************************************************
-    pseudo_moving_average(const T initial_value, const size_t sample_size)
+    ETL_CONSTEXPR pseudo_moving_average(const T initial_value, const size_t sample_size)
       : reciprocal_samples_plus_1(T(1.0) / T(sample_size + 1U))
       , average(initial_value)
     {

--- a/include/etl/rescale.h
+++ b/include/etl/rescale.h
@@ -51,7 +51,7 @@ namespace etl
     //*****************************************************************
     /// Constructor.
     //*****************************************************************
-    rescale(TInput input_min_value_, TInput input_max_value_, TOutput output_min_value_, TOutput output_max_value_)
+    ETL_CONSTEXPR rescale(TInput input_min_value_, TInput input_max_value_, TOutput output_min_value_, TOutput output_max_value_)
       : input_min_value(input_min_value_)
       , output_min_value(output_min_value_)
       , output_max_value(output_max_value_)
@@ -62,7 +62,7 @@ namespace etl
     //*****************************************************************
     /// operator ()
     //*****************************************************************
-    TOutput operator()(TInput value) const
+    ETL_CONSTEXPR TOutput operator()(TInput value) const
     {
       return TOutput(((value - input_min_value) * multiplier)) + output_min_value;
     }

--- a/include/etl/threshold.h
+++ b/include/etl/threshold.h
@@ -50,7 +50,7 @@ namespace etl
     //*****************************************************************
     // Constructor.
     //*****************************************************************
-    threshold(TInput threshold_value_, TInput true_value_, TInput false_value_, TCompare compare_ = TCompare())
+    ETL_CONSTEXPR threshold(TInput threshold_value_, TInput true_value_, TInput false_value_, TCompare compare_ = TCompare())
       : threshold_value(threshold_value_)
       , true_value(true_value_)
       , false_value(false_value_)
@@ -61,7 +61,7 @@ namespace etl
     //*****************************************************************
     // operator ()
     //*****************************************************************
-    TInput operator()(TInput value) const
+    ETL_CONSTEXPR TInput operator()(TInput value) const
     {
       return compare(value, threshold_value) ? true_value : false_value;
     }

--- a/include/etl/utility.h
+++ b/include/etl/utility.h
@@ -228,7 +228,7 @@ namespace etl
     }
 
     /// Copy constructor
-    pair(const pair<T1, T2>& other)
+    ETL_CONSTEXPR pair(const pair<T1, T2>& other)
       : first(other.first)
       , second(other.second)
     {
@@ -254,16 +254,16 @@ namespace etl
 
     /// Constructing from std::pair
     template <typename U1, typename U2>
-    pair(const std::pair<U1, U2>& other)
+    ETL_CONSTEXPR pair(const std::pair<U1, U2>& other)
       : first(other.first)
       , second(other.second)
     {
     }
 
   #if ETL_USING_CPP11
-    /// Constructing to etl::pair
+    /// Constructing from std::pair (move)
     template <typename U1, typename U2>
-    pair(std::pair<U1, U2>&& other)
+    ETL_CONSTEXPR pair(std::pair<U1, U2>&& other)
       : first(etl::forward<U1>(other.first))
       , second(etl::forward<U2>(other.second))
     {
@@ -892,13 +892,13 @@ namespace etl
   template <typename T>
   struct coordinate_2d
   {
-    coordinate_2d()
+    ETL_CONSTEXPR coordinate_2d()
       : x(T(0))
       , y(T(0))
     {
     }
 
-    coordinate_2d(T x_, T y_)
+    ETL_CONSTEXPR coordinate_2d(T x_, T y_)
       : x(x_)
       , y(y_)
     {

--- a/test/test_cyclic_value.cpp
+++ b/test/test_cyclic_value.cpp
@@ -492,5 +492,33 @@ namespace
       CHECK(data1 == compare2);
       CHECK(data2 == compare1);
     }
+
+#if ETL_USING_CPP14
+    //*************************************************************************
+    TEST(test_cyclic_value_constexpr_ctor)
+    {
+      constexpr etl::cyclic_value<int, 0, 9> cv;
+      static_assert(cv.get() == 0, "constexpr default ctor");
+      CHECK(true);
+    }
+
+    //*************************************************************************
+    TEST(test_cyclic_value_constexpr_ctor_with_range)
+    {
+      constexpr etl::cyclic_value<int> cv(0, 9);
+      static_assert(cv.first() == 0, "constexpr range ctor first");
+      static_assert(cv.last() == 9, "constexpr range ctor last");
+      CHECK(true);
+    }
+
+    //*************************************************************************
+    TEST(test_cyclic_value_constexpr_copy_ctor)
+    {
+      constexpr etl::cyclic_value<int, 0, 9> cv1;
+      constexpr etl::cyclic_value<int, 0, 9> cv2(cv1);
+      static_assert(cv2.get() == 0, "constexpr copy ctor");
+      CHECK(true);
+    }
+#endif
   }
 } // namespace

--- a/test/test_fixed_iterator.cpp
+++ b/test/test_fixed_iterator.cpp
@@ -229,6 +229,22 @@ namespace
       CHECK(fi1 != fi3);
     }
 
+    //*************************************************************************
+    TEST(test_dereference_write_through)
+    {
+      int                       value = 42;
+      etl::fixed_iterator<int*> fi(&value);
+
+      // Writing through the dereferenced iterator should modify the underlying value.
+      *fi = 99;
+      CHECK_EQUAL(99, value);
+
+      // Increment does nothing, so writing again still targets the same location.
+      ++fi;
+      *fi = 123;
+      CHECK_EQUAL(123, value);
+    }
+
 #if ETL_USING_CPP14
     //*************************************************************************
     TEST(test_fixed_iterator_constexpr_ctor)

--- a/test/test_fixed_iterator.cpp
+++ b/test/test_fixed_iterator.cpp
@@ -228,5 +228,26 @@ namespace
       CHECK(fi1 == fi2);
       CHECK(fi1 != fi3);
     }
+
+#if ETL_USING_CPP14
+    //*************************************************************************
+    TEST(test_fixed_iterator_constexpr_ctor)
+    {
+      static constexpr int                      data[] = {1, 2, 3};
+      constexpr etl::fixed_iterator<const int*> fi(&data[1]);
+      static_assert(*fi == 2, "constexpr ctor and deref");
+      CHECK(true);
+    }
+
+    //*************************************************************************
+    TEST(test_fixed_iterator_constexpr_copy_ctor)
+    {
+      static constexpr int                      data[] = {1, 2, 3};
+      constexpr etl::fixed_iterator<const int*> fi1(&data[0]);
+      constexpr etl::fixed_iterator<const int*> fi2(fi1);
+      static_assert(*fi2 == 1, "constexpr copy ctor");
+      CHECK(true);
+    }
+#endif
   }
 } // namespace

--- a/test/test_functional.cpp
+++ b/test/test_functional.cpp
@@ -591,5 +591,47 @@ namespace
       CHECK(!result_equal);
     }
 #endif
+
+#if ETL_USING_CPP14
+    //*************************************************************************
+    TEST(test_binder1st_constexpr)
+    {
+      struct plus_op
+      {
+        typedef int first_argument_type;
+        typedef int second_argument_type;
+        typedef int result_type;
+        ETL_CONSTEXPR int operator()(int a, int b) const
+        {
+          return a + b;
+        }
+      };
+
+      constexpr plus_op                 op;
+      constexpr etl::binder1st<plus_op> b = etl::bind1st(op, 10);
+      static_assert(b(5) == 15, "constexpr bind1st");
+      CHECK(true);
+    }
+
+    //*************************************************************************
+    TEST(test_binder2nd_constexpr)
+    {
+      struct plus_op
+      {
+        typedef int first_argument_type;
+        typedef int second_argument_type;
+        typedef int result_type;
+        ETL_CONSTEXPR int operator()(int a, int b) const
+        {
+          return a + b;
+        }
+      };
+
+      constexpr plus_op                 op;
+      constexpr etl::binder2nd<plus_op> b = etl::bind2nd(op, 10);
+      static_assert(b(5) == 15, "constexpr bind2nd");
+      CHECK(true);
+    }
+#endif
   }
 } // namespace

--- a/test/test_invert.cpp
+++ b/test/test_invert.cpp
@@ -112,5 +112,15 @@ namespace
       bool isEqual = std::equal(output2.begin(), output2.end(), result2b.begin(), Compare());
       CHECK(isEqual);
     }
+
+#if ETL_USING_CPP14
+    //*************************************************************************
+    TEST(test_invert_constexpr)
+    {
+      constexpr etl::invert<int> inv(0, 255);
+      static_assert(inv(100) == 155, "constexpr invert");
+      CHECK(true);
+    }
+#endif
   }
 } // namespace

--- a/test/test_iterator.cpp
+++ b/test/test_iterator.cpp
@@ -551,6 +551,28 @@ namespace
     }
 
     //*************************************************************************
+    TEST(test_move_iterator_compound_assignment_returns_reference)
+    {
+      int data[] = {10, 20, 30, 40, 50};
+
+      etl::move_iterator<int*> mitr(&data[0]);
+
+      // operator+= must return a reference to *this
+      etl::move_iterator<int*>& ref_plus = (mitr += 2);
+      CHECK_EQUAL(&mitr, &ref_plus);
+      CHECK_EQUAL(30, *mitr);
+
+      // operator-= must return a reference to *this
+      etl::move_iterator<int*>& ref_minus = (mitr -= 1);
+      CHECK_EQUAL(&mitr, &ref_minus);
+      CHECK_EQUAL(20, *mitr);
+
+      // Chaining should work
+      (mitr += 1) += 1;
+      CHECK_EQUAL(40, *mitr);
+    }
+
+    //*************************************************************************
     TEST(test_move_iterator_subtraction)
     {
       Item list[] = {Item("1"), Item("2"), Item("3")};

--- a/test/test_iterator.cpp
+++ b/test/test_iterator.cpp
@@ -1409,5 +1409,27 @@ namespace
     }
 
 #endif
+
+#if ETL_USING_CPP14
+    //*************************************************************************
+    TEST(test_move_iterator_constexpr_ctor)
+    {
+      static constexpr int                     data[] = {10, 20, 30};
+      constexpr etl::move_iterator<const int*> mi(&data[0]);
+      static_assert(mi.base() == &data[0], "constexpr ctor");
+      CHECK(true);
+    }
+
+    //*************************************************************************
+    TEST(test_move_iterator_constexpr_operators)
+    {
+      static constexpr int                     data[] = {10, 20, 30};
+      constexpr etl::move_iterator<const int*> mi1(&data[0]);
+      constexpr etl::move_iterator<const int*> mi2(&data[1]);
+      static_assert(mi1 != mi2, "constexpr operator!=");
+      static_assert(mi1 < mi2, "constexpr operator<");
+      CHECK(true);
+    }
+#endif
   }
 } // namespace

--- a/test/test_memory.cpp
+++ b/test/test_memory.cpp
@@ -3006,5 +3006,17 @@ namespace
       unsigned char zeroes[sizeof(Data)] = {0};
       CHECK(memcmp(buffer, zeroes, sizeof(Data)) == 0);
     }
+
+#if ETL_USING_CPP14
+    //*************************************************************************
+    TEST(test_default_delete_constexpr_copy_ctor)
+    {
+      constexpr etl::default_delete<int> d1;
+      constexpr etl::default_delete<int> d2(d1);
+      (void)d2;
+      static_assert(sizeof(d2) > 0, "constexpr default_delete copy ctor");
+      CHECK(true);
+    }
+#endif
   }
 } // namespace

--- a/test/test_pseudo_moving_average.cpp
+++ b/test/test_pseudo_moving_average.cpp
@@ -344,5 +344,15 @@ namespace
 
       CHECK_CLOSE(2.82, cma.value(), 0.01);
     }
+
+#if ETL_USING_CPP14
+    //*************************************************************************
+    TEST(test_pseudo_moving_average_constexpr_ctor)
+    {
+      constexpr etl::pseudo_moving_average<int, 4> pma(0);
+      static_assert(sizeof(pma) > 0, "constexpr ctor");
+      CHECK(true);
+    }
+#endif
   }
 } // namespace

--- a/test/test_rescale.cpp
+++ b/test/test_rescale.cpp
@@ -84,5 +84,15 @@ namespace
       bool isEqual = std::equal(output2.begin(), output2.end(), result2.begin(), Compare());
       CHECK(isEqual);
     }
+
+#if ETL_USING_CPP14
+    //*************************************************************************
+    TEST(test_rescale_constexpr)
+    {
+      constexpr etl::rescale<int, int> rs(0, 100, 0, 1000);
+      static_assert(rs(50) == 500, "constexpr rescale");
+      CHECK(true);
+    }
+#endif
   }
 } // namespace

--- a/test/test_threshold.cpp
+++ b/test/test_threshold.cpp
@@ -115,5 +115,16 @@ namespace
       bool isEqual = std::equal(output2.begin(), output2.end(), result2b.begin(), Compare());
       CHECK(isEqual);
     }
+
+#if ETL_USING_CPP14
+    //*************************************************************************
+    TEST(test_threshold_constexpr)
+    {
+      constexpr etl::threshold<int> th(50, 1, 0);
+      static_assert(th(40) == 1, "constexpr threshold below");
+      static_assert(th(60) == 0, "constexpr threshold above");
+      CHECK(true);
+    }
+#endif
   }
 } // namespace

--- a/test/test_utility.cpp
+++ b/test/test_utility.cpp
@@ -1093,5 +1093,29 @@ namespace
 
       CHECK_FALSE(pw1 == pw2); // This would FAIL with the old < > based comparison
     }
+
+#if ETL_USING_CPP14
+    //*************************************************************************
+    TEST(test_pair_constexpr_copy_ctor)
+    {
+      constexpr etl::pair<int, int> p1(1, 2);
+      constexpr etl::pair<int, int> p2(p1);
+      static_assert(p2.first == 1, "constexpr pair copy ctor first");
+      static_assert(p2.second == 2, "constexpr pair copy ctor second");
+      CHECK(true);
+    }
+
+    //*************************************************************************
+    TEST(test_coordinate_2d_constexpr_ctors)
+    {
+      constexpr etl::coordinate_2d<int> c1;
+      constexpr etl::coordinate_2d<int> c2(3, 4);
+      static_assert(c1.x == 0, "constexpr default ctor x");
+      static_assert(c1.y == 0, "constexpr default ctor y");
+      static_assert(c2.x == 3, "constexpr value ctor x");
+      static_assert(c2.y == 4, "constexpr value ctor y");
+      CHECK(true);
+    }
+#endif
   }
 } // namespace


### PR DESCRIPTION
While we are at it, fix 2 issues:

    Adjust operator!=() in fixed_iterator.h
    Instead of taking an iterator by reference, take it by value as
    done in the other operators and overloads.

    Initialize move_iterator() current member
    Prevent indeterminate values