### PR TITLE
Add etl::infinite_loop

### DIFF
--- a/docs/utilities/infinite-loop.md
+++ b/docs/utilities/infinite-loop.md
@@ -1,0 +1,39 @@
+---
+title: "infinite_loop"
+---
+
+{{< callout type="info">}}
+  Header: `infinite_loop.h`
+{{< /callout >}}
+
+A portable infinite loop that will not be optimised away by the compiler.
+
+Before C++26, an empty infinite loop without side effects is considered undefined behaviour and may
+be optimised away. This utility uses a compiler memory barrier to prevent that optimisation.
+
+See [P2809R1](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2023/p2809r1.html) for background.
+
+## Function
+
+```cpp
+[[noreturn]] inline void etl::infinite_loop()
+```
+
+**Description**
+Enters an infinite loop that is guaranteed not to be removed by the compiler.
+
+On GCC and Clang this is achieved with an inline assembly memory clobber.
+On MSVC this uses `_ReadWriteBarrier()`.
+
+## Example
+
+```cpp
+#include <etl/infinite_loop.h>
+
+int main()
+{
+  // Initialise hardware...
+
+  etl::infinite_loop();
+}
+```

--- a/include/etl/infinite_loop.h
+++ b/include/etl/infinite_loop.h
@@ -1,0 +1,65 @@
+///\file
+
+/******************************************************************************
+The MIT License(MIT)
+
+Embedded Template Library.
+https://github.com/ETLCPP/etl
+https://www.etlcpp.com
+
+Copyright(c) 2026 BMW AG
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files(the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions :
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+******************************************************************************/
+
+#ifndef ETL_INFINITE_LOOP_INCLUDED
+#define ETL_INFINITE_LOOP_INCLUDED
+
+#include "platform.h"
+
+namespace etl
+{
+  //*****************************************************************************
+  /// An infinite loop that will not be optimised out
+  ///
+  /// Before C++26, an empty infinite loop without side effects is considered
+  /// undefined behavior, and may be optimised away by the compiler.
+  ///
+  /// See also
+  /// https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2023/p2809r1.html
+  //*****************************************************************************
+  ETL_NORETURN
+  inline void infinite_loop()
+  {
+    while (true)
+    {
+#if ETL_NOT_USING_CPP26
+  #if defined(ETL_COMPILER_GCC) || defined(ETL_COMPILER_CLANG)
+      __asm__ __volatile__("" : : : "memory");
+  #elif defined(ETL_COMPILER_MICROSOFT)
+      _ReadWriteBarrier();
+  #else
+    #error "Infinite loop not supported for this compiler and platform"
+  #endif
+#endif
+    }
+  }
+} // namespace etl
+
+#endif

--- a/test/syntax_check/CMakeLists.txt
+++ b/test/syntax_check/CMakeLists.txt
@@ -243,6 +243,7 @@ target_sources(tests PRIVATE
 		imemory_block_allocator.h.t.cpp
 		index_of_type.h.t.cpp
 		indirect_vector.h.t.cpp
+		infinite_loop.h.t.cpp
 		initializer_list.h.t.cpp
 		inplace_function.h.t.cpp
 		instance_count.h.t.cpp

--- a/test/syntax_check/infinite_loop.h.t.cpp
+++ b/test/syntax_check/infinite_loop.h.t.cpp
@@ -1,0 +1,29 @@
+/******************************************************************************
+The MIT License(MIT)
+
+Embedded Template Library.
+https://github.com/ETLCPP/etl
+https://www.etlcpp.com
+
+Copyright(c) 2026 BMW AG
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files(the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions :
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+******************************************************************************/
+
+#include <etl/infinite_loop.h>


### PR DESCRIPTION
Enters an infinite loop that is guaranteed not to be removed by the compiler. Relevant before C++26, see
https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2023/p2809r1.html

On GCC and Clang this is achieved with an inline assembly memory clobber.
On MSVC this uses `_ReadWriteBarrier()`.
