### PR TITLE
Fix using libc++

### DIFF
--- a/.github/workflows/clang-c++11.yml
+++ b/.github/workflows/clang-c++11.yml
@@ -30,6 +30,35 @@ jobs:
     - name: Run tests
       run: ./test/etl_tests -v
 
+  build-clang-cpp11-linux-stl-libcxx:
+    name: Clang C++11 Linux - STL - libc++
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-22.04]
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install libc++
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libc++-dev libc++abi-dev
+
+    - name: Build
+      run: |
+        export CC=clang
+        export CXX=clang++
+        export CXXFLAGS="-stdlib=libc++"
+        export LDFLAGS="-stdlib=libc++"
+        export ASAN_OPTIONS=alloc_dealloc_mismatch=0,detect_leaks=0
+        cmake -D BUILD_TESTS=ON -DNO_STL=OFF -DETL_USE_TYPE_TRAITS_BUILTINS=OFF -DETL_USER_DEFINED_TYPE_TRAITS=OFF -DETL_FORCE_TEST_CPP03_IMPLEMENTATION=OFF -DETL_CXX_STANDARD=11 ./
+        clang --version
+        make -j "$(getconf _NPROCESSORS_ONLN)"
+
+    - name: Run tests
+      run: ./test/etl_tests -v
+
   build-clang-cpp11-linux-no-stl:
     name: Clang C++11 Linux - No STL
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/clang-c++14.yml
+++ b/.github/workflows/clang-c++14.yml
@@ -30,6 +30,35 @@ jobs:
     - name: Run tests
       run: ./test/etl_tests -v
 
+  build-clang-cpp14-linux-stl-libcxx:
+    name: Clang C++14 Linux - STL - libc++
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-22.04]
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install libc++
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libc++-dev libc++abi-dev
+
+    - name: Build
+      run: |
+        export CC=clang
+        export CXX=clang++
+        export CXXFLAGS="-stdlib=libc++"
+        export LDFLAGS="-stdlib=libc++"
+        export ASAN_OPTIONS=alloc_dealloc_mismatch=0,detect_leaks=0
+        cmake -D BUILD_TESTS=ON -DNO_STL=OFF -DETL_USE_TYPE_TRAITS_BUILTINS=OFF -DETL_USER_DEFINED_TYPE_TRAITS=OFF -DETL_FORCE_TEST_CPP03_IMPLEMENTATION=OFF -DETL_CXX_STANDARD=14 ./
+        clang --version
+        make -j "$(getconf _NPROCESSORS_ONLN)"
+
+    - name: Run tests
+      run: ./test/etl_tests -v
+
   build-clang-cpp14-linux-no-stl:
     name: Clang C++14 Linux - No STL
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/clang-c++17.yml
+++ b/.github/workflows/clang-c++17.yml
@@ -30,6 +30,35 @@ jobs:
     - name: Run tests
       run: ./test/etl_tests -v
 
+  build-clang-cpp17-linux-stl-libcxx:
+    name: Clang C++17 Linux - STL - libc++
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-22.04]
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install libc++
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libc++-dev libc++abi-dev
+
+    - name: Build
+      run: |
+        export CC=clang
+        export CXX=clang++
+        export CXXFLAGS="-stdlib=libc++"
+        export LDFLAGS="-stdlib=libc++"
+        export ASAN_OPTIONS=alloc_dealloc_mismatch=0,detect_leaks=0
+        cmake -D BUILD_TESTS=ON -DNO_STL=OFF -DETL_USE_TYPE_TRAITS_BUILTINS=OFF -DETL_USER_DEFINED_TYPE_TRAITS=OFF -DETL_FORCE_TEST_CPP03_IMPLEMENTATION=OFF -DETL_CXX_STANDARD=17 ./
+        clang --version
+        make -j "$(getconf _NPROCESSORS_ONLN)"
+
+    - name: Run tests
+      run: ./test/etl_tests -v
+
   build-clang-cpp17-linux-no-stl:
     name: Clang C++17 Linux - No STL
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/clang-c++20.yml
+++ b/.github/workflows/clang-c++20.yml
@@ -8,6 +8,40 @@ on:
 
 jobs:
 
+  build-clang-cpp20-linux-stl-libcxx:
+    name: Clang C++20 Linux - STL - libc++
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-22.04]
+
+    steps:
+    - uses: actions/checkout@v4
+
+    # Temporary fix. See https://github.com/actions/runner-images/issues/8659
+    - name: Install newer Clang
+      run: |
+        wget https://apt.llvm.org/llvm.sh
+        chmod +x ./llvm.sh
+        sudo ./llvm.sh 17
+
+    - name: Install libc++
+      run: sudo apt-get install -y libc++-17-dev libc++abi-17-dev
+
+    - name: Build
+      run: |
+        export CC=clang-17
+        export CXX=clang++-17
+        export CXXFLAGS="-stdlib=libc++"
+        export LDFLAGS="-stdlib=libc++"
+        export ASAN_OPTIONS=alloc_dealloc_mismatch=0,detect_leaks=0
+        cmake -D BUILD_TESTS=ON -DNO_STL=OFF -DETL_USE_TYPE_TRAITS_BUILTINS=OFF -DETL_USER_DEFINED_TYPE_TRAITS=OFF -DETL_FORCE_TEST_CPP03_IMPLEMENTATION=OFF -DETL_CXX_STANDARD=20 ./
+        clang-17 --version
+        make -j "$(getconf _NPROCESSORS_ONLN)"
+
+    - name: Run tests
+      run: ./test/etl_tests -v
+
   build-clang-cpp20-linux-no-stl:
     name: Clang C++20 Linux - No STL
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/clang-c++23.yml
+++ b/.github/workflows/clang-c++23.yml
@@ -8,6 +8,35 @@ on:
 
 jobs:
 
+  build-clang-cpp23-linux-stl-libcxx:
+    name: Clang C++23 Linux - STL - libc++
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-24.04]
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install libc++
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libc++-dev libc++abi-dev
+
+    - name: Build
+      run: |
+        export CC=clang
+        export CXX=clang++
+        export CXXFLAGS="-stdlib=libc++"
+        export LDFLAGS="-stdlib=libc++"
+        export ASAN_OPTIONS=alloc_dealloc_mismatch=0,detect_leaks=0
+        cmake -D BUILD_TESTS=ON -DNO_STL=OFF -DETL_USE_TYPE_TRAITS_BUILTINS=OFF -DETL_USER_DEFINED_TYPE_TRAITS=OFF -DETL_FORCE_TEST_CPP03_IMPLEMENTATION=OFF -DETL_CXX_STANDARD=23 -DETL_OPTIMISATION=-O3 ./
+        clang --version
+        make -j "$(getconf _NPROCESSORS_ONLN)"
+
+    - name: Run tests
+      run: ./test/etl_tests -v
+
   build-clang-cpp23-linux-no-stl:
     name: Clang C++23 Linux - No STL
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/clang-c++26.yml
+++ b/.github/workflows/clang-c++26.yml
@@ -8,6 +8,31 @@ on:
 
 jobs:
 
+  build-clang-cpp26-linux-stl-libcxx:
+    name: Clang C++26 Linux - STL - libc++
+    runs-on: ubuntu-24.04
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Build Docker image
+      run: docker build -t etl-ubuntu-2604 -f .devcontainer/ubuntu-26.04/Dockerfile .
+
+    - name: Build and run tests
+      run: |
+        docker run --rm --user root -v ${{ github.workspace }}:/workspaces/etl etl-ubuntu-2604 bash -c "\
+          cd /workspaces/etl && \
+          apt-get update && apt-get install -y libc++-dev libc++abi-dev && \
+          export CC=clang && \
+          export CXX=clang++ && \
+          export CXXFLAGS=-stdlib=libc++ && \
+          export LDFLAGS=-stdlib=libc++ && \
+          export ASAN_OPTIONS=alloc_dealloc_mismatch=0,detect_leaks=0 && \
+          cmake -DBUILD_TESTS=ON -DNO_STL=OFF -DETL_USE_TYPE_TRAITS_BUILTINS=OFF -DETL_USER_DEFINED_TYPE_TRAITS=OFF -DETL_FORCE_TEST_CPP03_IMPLEMENTATION=OFF -DETL_CXX_STANDARD=26 ./ && \
+          clang --version && \
+          make -j \$(getconf _NPROCESSORS_ONLN) && \
+          ./test/etl_tests -v"
+
   build-clang-cpp26-linux-stl:
     name: Clang C++26 Linux - STL
     runs-on: ubuntu-24.04

--- a/include/etl/tuple.h
+++ b/include/etl/tuple.h
@@ -1180,7 +1180,11 @@ namespace etl
 
 namespace std
 {
-  #if ETL_NOT_USING_STL                                                                                                       \
+  // libc++ already declares std::tuple_size / std::tuple_element in its inline
+  // namespace (std::__1), so re-declaring them here would make the name
+  // ambiguous. Detect libc++ via _LIBCPP_VERSION and skip the forward
+  // declarations in that case, even when not using the STL.
+  #if ETL_NOT_USING_STL && !defined(_LIBCPP_VERSION)                                                                          \
     && !((defined(ETL_DEVELOPMENT_OS_APPLE) || (ETL_COMPILER_FULL_VERSION >= 190000) && (ETL_COMPILER_FULL_VERSION < 210000)) \
          && defined(ETL_COMPILER_CLANG))
   template <typename T>


### PR DESCRIPTION
Before, libstdc++ was used in both gcc and clang builds.

Fix includes an adjustment to consider in NO_STL case.

Now build with libc++ in separate github workflows with clang.