### PR TITLE
Only enable the assign and insert member functions for class ivector<…

### DIFF
--- a/include/etl/private/ivectorpointer.h
+++ b/include/etl/private/ivectorpointer.h
@@ -70,6 +70,13 @@ namespace etl
 
     typedef pvoidvector base_t;
 
+    template <typename TIterator>
+    struct is_compatible_iterator
+      : etl::integral_constant<bool, etl::is_pointer<typename etl::iterator_traits<TIterator>::value_type>::value
+                                       && etl::is_convertible<typename etl::iterator_traits<TIterator>::value_type, value_type>::value>
+    {
+    };
+
   public:
 
     //*********************************************************************
@@ -320,10 +327,7 @@ namespace etl
     ///\param last  The iterator to the last element + 1.
     //*********************************************************************
     template <typename TIterator>
-    typename etl::enable_if< etl::is_pointer<typename etl::iterator_traits<TIterator>::value_type>::value
-                               && etl::is_convertible<typename etl::iterator_traits<TIterator>::value_type, value_type>::value,
-                             void>::type
-      assign(TIterator first, TIterator last)
+    typename etl::enable_if< is_compatible_iterator<TIterator>::value, void>::type assign(TIterator first, TIterator last)
     {
       base_t::assign(first, last);
     }
@@ -444,10 +448,7 @@ namespace etl
     ///\param last     The last + 1 element to add.
     //*********************************************************************
     template <typename TIterator>
-    typename etl::enable_if< etl::is_pointer<typename etl::iterator_traits<TIterator>::value_type>::value
-                               && etl::is_convertible<typename etl::iterator_traits<TIterator>::value_type, value_type>::value,
-                             void>::type
-      insert(const_iterator position, TIterator first, TIterator last)
+    typename etl::enable_if< is_compatible_iterator<TIterator>::value, void>::type insert(const_iterator position, TIterator first, TIterator last)
     {
       base_t::insert(base_t::iterator(position), first, last);
     }
@@ -578,6 +579,13 @@ namespace etl
   private:
 
     typedef pvoidvector base_t;
+
+    template <typename TIterator>
+    struct is_compatible_iterator
+      : etl::integral_constant<bool, etl::is_pointer<typename etl::iterator_traits<TIterator>::value_type>::value
+                                       && etl::is_convertible<typename etl::iterator_traits<TIterator>::value_type, value_type>::value>
+    {
+    };
 
   public:
 
@@ -829,10 +837,7 @@ namespace etl
     ///\param last  The iterator to the last element + 1.
     //*********************************************************************
     template <typename TIterator>
-    typename etl::enable_if< etl::is_pointer<typename etl::iterator_traits<TIterator>::value_type>::value
-                               && etl::is_convertible<typename etl::iterator_traits<TIterator>::value_type, value_type>::value,
-                             void>::type
-      assign(TIterator first, TIterator last)
+    typename etl::enable_if< is_compatible_iterator<TIterator>::value, void>::type assign(TIterator first, TIterator last)
     {
       base_t::assign(first, last);
     }
@@ -911,10 +916,7 @@ namespace etl
     ///\param last     The last + 1 element to add.
     //*********************************************************************
     template <typename TIterator>
-    typename etl::enable_if< etl::is_pointer<typename etl::iterator_traits<TIterator>::value_type>::value
-                               && etl::is_convertible<typename etl::iterator_traits<TIterator>::value_type, value_type>::value,
-                             void>::type
-      insert(const_iterator position, TIterator first, TIterator last)
+    typename etl::enable_if< is_compatible_iterator<TIterator>::value, void>::type insert(const_iterator position, TIterator first, TIterator last)
     {
       base_t::insert(base_t::iterator(position), first, last);
     }

--- a/include/etl/private/ivectorpointer.h
+++ b/include/etl/private/ivectorpointer.h
@@ -320,7 +320,12 @@ namespace etl
     ///\param last  The iterator to the last element + 1.
     //*********************************************************************
     template <typename TIterator>
-    void assign(TIterator first, TIterator last)
+    typename etl::enable_if<
+      etl::is_pointer<typename etl::iterator_traits<TIterator>::value_type>::value
+        && etl::is_same<typename etl::remove_cv<typename etl::remove_pointer<typename etl::iterator_traits<TIterator>::value_type>::type>::type,
+                        T>::value,
+      void>::type
+      assign(TIterator first, TIterator last)
     {
       base_t::assign(first, last);
     }
@@ -440,8 +445,13 @@ namespace etl
     ///\param first    The first element to add.
     ///\param last     The last + 1 element to add.
     //*********************************************************************
-    template <class TIterator>
-    void insert(const_iterator position, TIterator first, TIterator last)
+    template <typename TIterator>
+    typename etl::enable_if<
+      etl::is_pointer<typename etl::iterator_traits<TIterator>::value_type>::value
+        && etl::is_same<typename etl::remove_cv<typename etl::remove_pointer<typename etl::iterator_traits<TIterator>::value_type>::type>::type,
+                        T>::value,
+      void>::type
+      insert(const_iterator position, TIterator first, TIterator last)
     {
       base_t::insert(base_t::iterator(position), first, last);
     }
@@ -823,7 +833,12 @@ namespace etl
     ///\param last  The iterator to the last element + 1.
     //*********************************************************************
     template <typename TIterator>
-    void assign(TIterator first, TIterator last)
+    typename etl::enable_if<
+      etl::is_pointer<typename etl::iterator_traits<TIterator>::value_type>::value
+        && etl::is_same<typename etl::remove_cv<typename etl::remove_pointer<typename etl::iterator_traits<TIterator>::value_type>::type>::type,
+                        T>::value,
+      void>::type
+      assign(TIterator first, TIterator last)
     {
       base_t::assign(first, last);
     }
@@ -901,9 +916,16 @@ namespace etl
     ///\param first    The first element to add.
     ///\param last     The last + 1 element to add.
     //*********************************************************************
-    template <class TIterator>
-    void insert(const_iterator position, TIterator first, TIterator last)
+    template <typename TIterator>
+    typename etl::enable_if<
+      etl::is_pointer<typename etl::iterator_traits<TIterator>::value_type>::value
+        && etl::is_same<typename etl::remove_cv<typename etl::remove_pointer<typename etl::iterator_traits<TIterator>::value_type>::type>::type,
+                        T>::value,
+      void>::type
+      insert(const_iterator position, TIterator first, TIterator last)
     {
+      ETL_STATIC_ASSERT(etl::is_pointer<typename etl::iterator_traits<TIterator>::value_type>::value, "TIterator must dereference to a pointer type");
+
       base_t::insert(base_t::iterator(position), first, last);
     }
 

--- a/include/etl/private/ivectorpointer.h
+++ b/include/etl/private/ivectorpointer.h
@@ -320,10 +320,9 @@ namespace etl
     ///\param last  The iterator to the last element + 1.
     //*********************************************************************
     template <typename TIterator>
-    typename etl::enable_if<
-      etl::is_pointer<typename etl::iterator_traits<TIterator>::value_type>::value
-      && etl::is_convertible<typename etl::iterator_traits<TIterator>::value_type, value_type>::value,
-      void>::type
+    typename etl::enable_if< etl::is_pointer<typename etl::iterator_traits<TIterator>::value_type>::value
+                               && etl::is_convertible<typename etl::iterator_traits<TIterator>::value_type, value_type>::value,
+                             void>::type
       assign(TIterator first, TIterator last)
     {
       base_t::assign(first, last);
@@ -445,10 +444,9 @@ namespace etl
     ///\param last     The last + 1 element to add.
     //*********************************************************************
     template <typename TIterator>
-    typename etl::enable_if<
-      etl::is_pointer<typename etl::iterator_traits<TIterator>::value_type>::value
-      && etl::is_convertible<typename etl::iterator_traits<TIterator>::value_type, value_type>::value,
-      void>::type
+    typename etl::enable_if< etl::is_pointer<typename etl::iterator_traits<TIterator>::value_type>::value
+                               && etl::is_convertible<typename etl::iterator_traits<TIterator>::value_type, value_type>::value,
+                             void>::type
       insert(const_iterator position, TIterator first, TIterator last)
     {
       base_t::insert(base_t::iterator(position), first, last);
@@ -831,10 +829,9 @@ namespace etl
     ///\param last  The iterator to the last element + 1.
     //*********************************************************************
     template <typename TIterator>
-    typename etl::enable_if<
-      etl::is_pointer<typename etl::iterator_traits<TIterator>::value_type>::value
-      && etl::is_convertible<typename etl::iterator_traits<TIterator>::value_type, value_type>::value,
-      void>::type
+    typename etl::enable_if< etl::is_pointer<typename etl::iterator_traits<TIterator>::value_type>::value
+                               && etl::is_convertible<typename etl::iterator_traits<TIterator>::value_type, value_type>::value,
+                             void>::type
       assign(TIterator first, TIterator last)
     {
       base_t::assign(first, last);
@@ -914,10 +911,9 @@ namespace etl
     ///\param last     The last + 1 element to add.
     //*********************************************************************
     template <typename TIterator>
-    typename etl::enable_if<
-      etl::is_pointer<typename etl::iterator_traits<TIterator>::value_type>::value
-      && etl::is_convertible<typename etl::iterator_traits<TIterator>::value_type, value_type>::value,
-      void>::type
+    typename etl::enable_if< etl::is_pointer<typename etl::iterator_traits<TIterator>::value_type>::value
+                               && etl::is_convertible<typename etl::iterator_traits<TIterator>::value_type, value_type>::value,
+                             void>::type
       insert(const_iterator position, TIterator first, TIterator last)
     {
       base_t::insert(base_t::iterator(position), first, last);

--- a/include/etl/private/ivectorpointer.h
+++ b/include/etl/private/ivectorpointer.h
@@ -322,8 +322,7 @@ namespace etl
     template <typename TIterator>
     typename etl::enable_if<
       etl::is_pointer<typename etl::iterator_traits<TIterator>::value_type>::value
-        && etl::is_same<typename etl::remove_cv<typename etl::remove_pointer<typename etl::iterator_traits<TIterator>::value_type>::type>::type,
-                        T>::value,
+      && etl::is_convertible<typename etl::iterator_traits<TIterator>::value_type, value_type>::value,
       void>::type
       assign(TIterator first, TIterator last)
     {
@@ -448,8 +447,7 @@ namespace etl
     template <typename TIterator>
     typename etl::enable_if<
       etl::is_pointer<typename etl::iterator_traits<TIterator>::value_type>::value
-        && etl::is_same<typename etl::remove_cv<typename etl::remove_pointer<typename etl::iterator_traits<TIterator>::value_type>::type>::type,
-                        T>::value,
+      && etl::is_convertible<typename etl::iterator_traits<TIterator>::value_type, value_type>::value,
       void>::type
       insert(const_iterator position, TIterator first, TIterator last)
     {
@@ -835,8 +833,7 @@ namespace etl
     template <typename TIterator>
     typename etl::enable_if<
       etl::is_pointer<typename etl::iterator_traits<TIterator>::value_type>::value
-        && etl::is_same<typename etl::remove_cv<typename etl::remove_pointer<typename etl::iterator_traits<TIterator>::value_type>::type>::type,
-                        T>::value,
+      && etl::is_convertible<typename etl::iterator_traits<TIterator>::value_type, value_type>::value,
       void>::type
       assign(TIterator first, TIterator last)
     {
@@ -919,13 +916,10 @@ namespace etl
     template <typename TIterator>
     typename etl::enable_if<
       etl::is_pointer<typename etl::iterator_traits<TIterator>::value_type>::value
-        && etl::is_same<typename etl::remove_cv<typename etl::remove_pointer<typename etl::iterator_traits<TIterator>::value_type>::type>::type,
-                        T>::value,
+      && etl::is_convertible<typename etl::iterator_traits<TIterator>::value_type, value_type>::value,
       void>::type
       insert(const_iterator position, TIterator first, TIterator last)
     {
-      ETL_STATIC_ASSERT(etl::is_pointer<typename etl::iterator_traits<TIterator>::value_type>::value, "TIterator must dereference to a pointer type");
-
       base_t::insert(base_t::iterator(position), first, last);
     }
 

--- a/test/test_vector.cpp
+++ b/test/test_vector.cpp
@@ -1685,20 +1685,33 @@ namespace
     }
 
     //*************************************************************************
-    // TEST_FIXTURE(SetupFixture, test_issue_1464_etl_vector_insert_allows_inserting_an_incompatible_type)
-    //{
-    //  // Uncomment the code below to trigger the compile time error
+    template <typename TContainer, typename TIterator, typename = void>
+    struct is_assign_callable : std::false_type {};
 
-    //  struct SomeStruct
-    //  {
-    //    int foo;
-    //  };
+    template <typename TContainer, typename TIterator>
+    struct is_assign_callable<TContainer, TIterator, std::void_t<decltype(std::declval<TContainer&>().assign(std::declval<TIterator>(), std::declval<TIterator>()))>> : std::true_type {};
 
-    //  etl::vector<SomeStruct, 4> myStructs{{1}, {2}, {3}, {4}};
+    template <typename TContainer, typename TIterator1, typename TIterator2, typename = void>
+    struct is_insert_callable : std::false_type {};
 
-    //  etl::vector<SomeStruct *, 4> structPointers;
-    //  structPointers.insert(structPointers.end(), myStructs.begin(), myStructs.end());
-    //  structPointers.assign(myStructs.begin(), myStructs.end());
-    //}
+    template <typename TContainer, typename TIterator1, typename TIterator2>
+    struct is_insert_callable<TContainer, TIterator1, TIterator2, std::void_t<decltype(std::declval<TContainer&>().insert(std::declval<TIterator1>(), std::declval<TIterator2>(), std::declval<TIterator2>()))>> : std::true_type {};
+    TEST_FIXTURE(SetupFixture, test_issue_1464_etl_vector_insert_allows_inserting_an_incompatible_type)
+    {
+      struct SomeStruct
+      {
+        int foo;
+      };
+
+      using ContainerType = etl::vector<SomeStruct*, 4>;
+      using Iterator1Type = etl::vector<SomeStruct*, 4>::iterator;
+      using Iterator2Type = etl::vector<SomeStruct, 4>::const_iterator;
+
+      constexpr bool can_assign = is_assign_callable<ContainerType, Iterator2Type>::value;
+      CHECK_FALSE(can_assign);
+
+      constexpr bool can_insert = is_insert_callable<ContainerType, Iterator1Type, Iterator2Type>::value;
+      CHECK_FALSE(can_insert);
+    }
   }
 } // namespace

--- a/test/test_vector.cpp
+++ b/test/test_vector.cpp
@@ -1686,16 +1686,29 @@ namespace
 
     //*************************************************************************
     template <typename TContainer, typename TIterator, typename = void>
-    struct is_assign_callable : std::false_type {};
+    struct is_assign_callable : std::false_type
+    {
+    };
 
     template <typename TContainer, typename TIterator>
-    struct is_assign_callable<TContainer, TIterator, std::void_t<decltype(std::declval<TContainer&>().assign(std::declval<TIterator>(), std::declval<TIterator>()))>> : std::true_type {};
+    struct is_assign_callable<TContainer, TIterator,
+                              std::void_t<decltype(std::declval<TContainer&>().assign(std::declval<TIterator>(), std::declval<TIterator>()))>>
+      : std::true_type
+    {
+    };
 
     template <typename TContainer, typename TIterator1, typename TIterator2, typename = void>
-    struct is_insert_callable : std::false_type {};
+    struct is_insert_callable : std::false_type
+    {
+    };
 
     template <typename TContainer, typename TIterator1, typename TIterator2>
-    struct is_insert_callable<TContainer, TIterator1, TIterator2, std::void_t<decltype(std::declval<TContainer&>().insert(std::declval<TIterator1>(), std::declval<TIterator2>(), std::declval<TIterator2>()))>> : std::true_type {};
+    struct is_insert_callable<
+      TContainer, TIterator1, TIterator2,
+      std::void_t<decltype(std::declval<TContainer&>().insert(std::declval<TIterator1>(), std::declval<TIterator2>(), std::declval<TIterator2>()))>>
+      : std::true_type
+    {
+    };
     TEST_FIXTURE(SetupFixture, test_issue_1464_etl_vector_insert_allows_inserting_an_incompatible_type)
     {
       struct SomeStruct

--- a/test/test_vector.cpp
+++ b/test/test_vector.cpp
@@ -1683,5 +1683,22 @@ namespace
       CHECK(etl_data2.size() == swap_other_data.size());
       CHECK(etl_data2.max_size() == other_size);
     }
+
+    //*************************************************************************
+    // TEST_FIXTURE(SetupFixture, test_issue_1464_etl_vector_insert_allows_inserting_an_incompatible_type)
+    //{
+    //  // Uncomment the code below to trigger the compile time error
+
+    //  struct SomeStruct
+    //  {
+    //    int foo;
+    //  };
+
+    //  etl::vector<SomeStruct, 4> myStructs{{1}, {2}, {3}, {4}};
+
+    //  etl::vector<SomeStruct *, 4> structPointers;
+    //  structPointers.insert(structPointers.end(), myStructs.begin(), myStructs.end());
+    //  structPointers.assign(myStructs.begin(), myStructs.end());
+    //}
   }
 } // namespace

--- a/test/test_vector.cpp
+++ b/test/test_vector.cpp
@@ -1692,7 +1692,7 @@ namespace
 
     template <typename TContainer, typename TIterator>
     struct is_assign_callable<TContainer, TIterator,
-                              std::void_t<decltype(std::declval<TContainer&>().assign(std::declval<TIterator>(), std::declval<TIterator>()))>>
+                              etl::void_t<decltype(std::declval<TContainer&>().assign(std::declval<TIterator>(), std::declval<TIterator>()))>>
       : std::true_type
     {
     };
@@ -1705,7 +1705,7 @@ namespace
     template <typename TContainer, typename TIterator1, typename TIterator2>
     struct is_insert_callable<
       TContainer, TIterator1, TIterator2,
-      std::void_t<decltype(std::declval<TContainer&>().insert(std::declval<TIterator1>(), std::declval<TIterator2>(), std::declval<TIterator2>()))>>
+      etl::void_t<decltype(std::declval<TContainer&>().insert(std::declval<TIterator1>(), std::declval<TIterator2>(), std::declval<TIterator2>()))>>
       : std::true_type
     {
     };


### PR DESCRIPTION
Only enable the `assign` and `insert` member functions for `class ivector<T*>` & `class ivector<const T*>` when the `value_type` the iterator references is a pointer to `T`.

Fixes #1464 