### PR TITLE
Fix etl::bitset single-element from_string shift on empty string

### DIFF
--- a/include/etl/private/bitset_new.h
+++ b/include/etl/private/bitset_new.h
@@ -311,6 +311,11 @@ namespace etl
         // Build from the string.
         string_length = etl::min(active_bits, string_length);
 
+        if (string_length == 0U)
+        {
+          return;
+        }
+
         element_type mask = element_type(element_type(1) << (string_length - 1U));
 
         for (size_t i = 0U; i < string_length; ++i)
@@ -338,6 +343,11 @@ namespace etl
 
         // Build from the string.
         string_length = etl::min(active_bits, string_length);
+
+        if (string_length == 0U)
+        {
+          return;
+        }
 
         element_type mask = element_type(element_type(1) << (string_length - 1U));
 
@@ -367,6 +377,11 @@ namespace etl
         // Build from the string.
         string_length = etl::min(active_bits, string_length);
 
+        if (string_length == 0U)
+        {
+          return;
+        }
+
         element_type mask = element_type(element_type(1) << (string_length - 1U));
 
         for (size_t i = 0U; i < string_length; ++i)
@@ -394,6 +409,11 @@ namespace etl
 
         // Build from the string.
         string_length = etl::min(active_bits, string_length);
+
+        if (string_length == 0U)
+        {
+          return;
+        }
 
         element_type mask = element_type(element_type(1) << (string_length - 1U));
 

--- a/test/test_bitset_new_explicit_single_element_type.cpp
+++ b/test/test_bitset_new_explicit_single_element_type.cpp
@@ -399,6 +399,22 @@ namespace
     }
 
     //*************************************************************************
+    // Empty strings exercise the string_length == 0 path in from_string,
+    // which must not shift by (0 - 1U).
+    TEST(test_construct_from_empty_string)
+    {
+      etl::bitset<64, uint64_t> data_char("");
+      etl::bitset<64, uint64_t> data_wchar(L"");
+      etl::bitset<64, uint64_t> data_u16(u"");
+      etl::bitset<64, uint64_t> data_u32(U"");
+
+      CHECK_EQUAL(0U, data_char.count());
+      CHECK_EQUAL(0U, data_wchar.count());
+      CHECK_EQUAL(0U, data_u16.count());
+      CHECK_EQUAL(0U, data_u32.count());
+    }
+
+    //*************************************************************************
     TEST(test_construct_from_excess_string)
     {
       std::bitset<64>           compare("110001001000110100010101100111001100010010001101000101011001111100001");


### PR DESCRIPTION
The single-element from_string overloads (char, wchar_t, char16_t, char32_t) computed element_type(1) << (string_length - 1U) before the copy loop. For an empty string, or when active_bits is 0, string_length is 0, so the shift count underflows to SIZE_MAX. Shifting by more than the element width is undefined behaviour, which also breaks constexpr evaluation.

Guard the mask with a zero-length check so the shift is only performed when string_length > 0. The multi-element from_string overloads were already safe.

Add test_construct_from_empty_string regression test.