### PR TITLE
Update operator[] docs for map class

### DIFF
--- a/docs/containers/maps/map.md
+++ b/docs/containers/maps/map.md
@@ -96,10 +96,9 @@ If assert or exceptions are not enabled then undefined behaviour occurs.
 
 ```cpp
 TMapped& operator[](key_parameter_t key)
-const TMapped& operator[](key_parameter_t key) const
 ```
 **Description**  
-Returns a reference or const reference to the indexed element.
+Returns a reference to the indexed element.
 If the key does not exist then one is created using the default constructor.  
 If the map is full then asserts an `etl::map_full`. If asserts or exceptions are not enabled then undefined behaviour occurs.
 

--- a/docs/utilities/bit-stream-reader.md
+++ b/docs/utilities/bit-stream-reader.md
@@ -3,11 +3,11 @@ title: "bit_stream_reader"
 ---
 
 {{< callout type="info">}}
-  Header: `bit_stream_reader.h`  
+  Header: `bit_stream.h`  
   Since: `TBC`  
 {{< /callout >}}
 
-A binary streaming utility that allows values to be read from an array of char or unsigned char using custom bits widths for efficient packing. Values may be streamed in either msb or lsb format.  
+A binary streaming utility that allows values to be read from an array of char or unsigned char using custom bits widths for efficient packing. The bit order (MSB or LSB first) and the byte order (endianness) can be configured independently.  
 
 Read functions come in both checked and unchecked forms.  
 - Unchecked reads return a value of the specified type.  
@@ -36,38 +36,42 @@ const_iterator const char*
 ## Member functions
 
 ```cpp
-bit_stream_reader(etl::span<char> span, etl::endian stream_endianness)
+bit_stream_reader(etl::span<char> span, etl::bit_order bit_order, etl::endian byte_order = etl::endian::big)
 ```
 **Parameters**  
 `span` A `char` span of the read buffer.  
-`stream_endianness` The endianness of the stream. `etl::endian::little` or `etl::endian::big`.  
+`bit_order` The bit order of the stream. `etl::bit_order::msb_first` (MSB first) or `etl::bit_order::lsb_first` (LSB first).  
+`byte_order` The byte order (endianness) of the stream. `etl::endian::big` or `etl::endian::little`. Defaults to `etl::endian::big`.  
 
 ---
 
 ```cpp
-bit_stream_reader(etl::span<unsigned char> span, etl::endian stream_endianness)
+bit_stream_reader(etl::span<unsigned char> span, etl::bit_order bit_order, etl::endian byte_order = etl::endian::big)
 ```
 **Parameters**  
 `span` `An unsigned char span` of the read buffer.  
-`stream_endianness` The endianness of the stream. `etl::endian::little` or `etl::endian::big`.  
+`bit_order` The bit order of the stream. `etl::bit_order::msb_first` (MSB first) or `etl::bit_order::lsb_first` (LSB first).  
+`byte_order` The byte order (endianness) of the stream. `etl::endian::big` or `etl::endian::little`. Defaults to `etl::endian::big`.  
 
 ---
 
 ```cpp
-bit_stream_reader(void* begin, void* end, etl::endian stream_endianness)
+bit_stream_reader(const void* begin, const void* end, etl::bit_order bit_order, etl::endian byte_order = etl::endian::big)
 ```
-`begin` A pointer to the beginning of the read buffer.  
-`end` A pointer to the beginning of the read buffer.  
-`stream_endianness` The endianness of the stream. `etl::endian::little` or `etl::endian::big`.  
+`begin` A const pointer to the beginning of the read buffer.  
+`end` A const pointer to the end of the read buffer.  
+`bit_order` The bit order of the stream. `etl::bit_order::msb_first` (MSB first) or `etl::bit_order::lsb_first` (LSB first).  
+`byte_order` The byte order (endianness) of the stream. `etl::endian::big` or `etl::endian::little`. Defaults to `etl::endian::big`.  
 
 ---
 
 ```cpp
-bit_stream_reader(void* begin, size_t length, etl::endian stream_endianness)
+bit_stream_reader(const void* begin, size_t length, etl::bit_order bit_order, etl::endian byte_order = etl::endian::big)
 ```
-`begin` A pointer to the beginning of the read buffer.  
+`begin` A const pointer to the beginning of the read buffer.  
 `length` The length, in char, of the read buffer.  
-`stream_endianness` The endianness of the stream. `etl::endian::little` or `etl::endian::big`.  
+`bit_order` The bit order of the stream. `etl::bit_order::msb_first` (MSB first) or `etl::bit_order::lsb_first` (LSB first).  
+`byte_order` The byte order (endianness) of the stream. `etl::endian::big` or `etl::endian::little`. Defaults to `etl::endian::big`.  
 
 ---
 

--- a/docs/utilities/bit-stream-writer.md
+++ b/docs/utilities/bit-stream-writer.md
@@ -3,11 +3,11 @@ title: "bit_stream_writer"
 ---
 
 {{< callout type="info">}}
-  Header: `bit_stream_writer.h`  
+  Header: `bit_stream.h`  
   Since: `TBC`  
 {{< /callout >}}
 
-A binary streaming utility that allows values to be written to an array of char or unsigned char using custom bits widths for efficient packing. Values may be streamed in either msb or lsb format.
+A binary streaming utility that allows values to be written to an array of char or unsigned char using custom bits widths for efficient packing. The bit order (MSB or LSB first) and the byte order (endianness) can be configured independently.
 
 Write functions come in both checked and unchecked forms.
 - Unchecked writes return `void`.
@@ -38,51 +38,56 @@ callback_type           etl::delegate<void(callback_parameter_type)>
 
 ## Member functions
 ```cpp
-bit_stream_writer(etl::span<char> span, etl::endian stream_endianness, callback_type callback = callback_type())
+bit_stream_writer(etl::span<char> span, etl::bit_order bit_order, callback_type callback = callback_type(), etl::endian byte_order = etl::endian::big)
 ```
 **Description**  
 Construct from span.  
 **Parameters**  
-`span` A char span of the read buffer.  
-`stream_endianness` The endianness of the stream. `etl::endian::little` or `etl::endian::big`.   
-`callback` An optional callback.
+`span` A char span of the write buffer.  
+`bit_order` The bit order of the stream. `etl::bit_order::msb_first` (MSB first) or `etl::bit_order::lsb_first` (LSB first).  
+`callback` An optional callback.  
+`byte_order` The byte order (endianness) of the stream. `etl::endian::big` or `etl::endian::little`. Defaults to `etl::endian::big`.
 
 ---
 
 ```cpp
-bit_stream_writer(etl::span<unsigned char> span, etl::endian stream_endianness, callback_type callback = callback_type())
+bit_stream_writer(etl::span<unsigned char> span, etl::bit_order bit_order, callback_type callback = callback_type(), etl::endian byte_order = etl::endian::big)
 ```
 **Description**  
 Construct from span.  
 **Parameters**  
-`span` A char span of the read buffer.  
-`stream_endianness` The endianness of the stream. etl::endian::little or etl::endian::big.  
-`callback` An optional callback.
+`span` An unsigned char span of the write buffer.  
+`bit_order` The bit order of the stream. `etl::bit_order::msb_first` (MSB first) or `etl::bit_order::lsb_first` (LSB first).  
+`callback` An optional callback.  
+`byte_order` The byte order (endianness) of the stream. `etl::endian::big` or `etl::endian::little`. Defaults to `etl::endian::big`.
 
 ---
 
 ```cpp
-bit_stream_writer(void* begin, void* end, etl::endian stream_endianness, callback_type callback = callback_type())
+bit_stream_writer(void* begin, void* end, etl::bit_order bit_order, callback_type callback = callback_type(), etl::endian byte_order = etl::endian::big)
 ```
 **Description**  
 Construct from range.  
 **Parameters**  
-`begin` A pointer to the beginning of the read buffer.  
-`end` A pointer to the beginning of the read buffer.  
-`stream_endianness` The endianness of the stream. `etl::endian::little` or `etl::endian::big`.  
-`callback` An optional callback.
+`begin` A pointer to the beginning of the write buffer.  
+`end` A pointer to the end of the write buffer.  
+`bit_order` The bit order of the stream. `etl::bit_order::msb_first` (MSB first) or `etl::bit_order::lsb_first` (LSB first).  
+`callback` An optional callback.  
+`byte_order` The byte order (endianness) of the stream. `etl::endian::big` or `etl::endian::little`. Defaults to `etl::endian::big`.
 
 ---
 
 ```cpp
-bit_stream_writer(void* begin, size_t length_chars, etl::endian stream_endianness, callback_type callback = callback_type())
+bit_stream_writer(void* begin, size_t length_chars, etl::bit_order bit_order, callback_type callback = callback_type(), etl::endian byte_order = etl::endian::big)
 ```
 **Description**  
 Construct from begin and length.  
 **Parameters**  
-`begin` A pointer to the beginning of the read buffer.  
-`length` The length, in char, of the read buffer.  
-`stream_endianness` The endianness of the stream. `etl::endian::little` or `etl::endian::big`.  
+`begin` A pointer to the beginning of the write buffer.  
+`length` The length, in char, of the write buffer.  
+`bit_order` The bit order of the stream. `etl::bit_order::msb_first` (MSB first) or `etl::bit_order::lsb_first` (LSB first).  
+`callback` An optional callback.  
+`byte_order` The byte order (endianness) of the stream. `etl::endian::big` or `etl::endian::little`. Defaults to `etl::endian::big`.  
 
 ---
 

--- a/docs/utilities/byte-stream-reader.md
+++ b/docs/utilities/byte-stream-reader.md
@@ -3,7 +3,7 @@ title: "byte_stream_reader"
 ---
 
 {{< callout type="info">}}
-  Header: `byte_stream_reader.h`  
+  Header: `byte_stream.h`  
   From: `20.17.0`  
 {{< /callout >}}
 

--- a/docs/utilities/byte-stream-writer.md
+++ b/docs/utilities/byte-stream-writer.md
@@ -3,7 +3,7 @@ title: "byte_stream_writer"
 ---
 
 {{< callout type="info">}}
-  Header: `byte_stream_writer.h`  
+  Header: `byte_stream.h`  
   From: `20.17.0`  
 {{< /callout >}}
 

--- a/docs/utilities/constant.md
+++ b/docs/utilities/constant.md
@@ -3,7 +3,7 @@ title: "constant"
 ---
 
 {{< callout type="info">}}
-  Header: `constants.h`  
+  Header: `constant.h`  
   Since: `TBC`  
 {{< /callout >}}
 

--- a/docs/utilities/endian.md
+++ b/docs/utilities/endian.md
@@ -3,7 +3,7 @@ title: "endian"
 ---
 
 {{< callout type="info">}}
-  Header: `endian.h`  
+  Header: `endianness.h`  
   Since: `TBC`  
 {{< /callout >}}
 

--- a/include/etl/bit_stream.h
+++ b/include/etl/bit_stream.h
@@ -31,6 +31,7 @@ SOFTWARE.
 #include "binary.h"
 #include "delegate.h"
 #include "endianness.h"
+#include "enum_type.h"
 #include "error_handler.h"
 #include "exception.h"
 #include "integral_limits.h"
@@ -48,6 +49,26 @@ SOFTWARE.
 
 namespace etl
 {
+  //***************************************************************************
+  /// Describes the order in which the bits of a value are written to, or read
+  /// from, a bit stream.
+  /// This is deliberately a distinct type from etl::endian (which describes
+  /// byte order) so that bit order cannot be confused with byte order.
+  //***************************************************************************
+  struct bit_order
+  {
+    enum enum_type
+    {
+      lsb_first, ///< Least significant bit first.
+      msb_first  ///< Most significant bit first.
+    };
+
+    ETL_DECLARE_ENUM_TYPE(bit_order, int)
+    ETL_ENUM_TYPE(lsb_first, "lsb_first")
+    ETL_ENUM_TYPE(msb_first, "msb_first")
+    ETL_END_ENUM_TYPE
+  };
+
   //***************************************************************************
   /// Encodes and decodes bitstreams.
   /// Data must be stored in the stream in network order.
@@ -349,7 +370,8 @@ namespace etl
             uint32_t mask = ((1U << mask_width) - 1U) << nbits;
             // uint32_t mask = ((uint32_t(1U) << mask_width) - 1U) << nbits;
 
-            // Move chunk to lowest char bits.
+            // Normalise the chunk to the low bits (>> nbits), then left-align
+            // it within the bits still free in the current char.
             // Chunks are never larger than one char.
             uint32_t chunk = ((value & mask) >> nbits) << (bits_available_in_char - mask_width);
 
@@ -383,7 +405,8 @@ namespace etl
             nbits -= mask_width;
             uint64_t mask = ((uint64_t(1U) << mask_width) - 1U) << nbits;
 
-            // Move chunk to lowest char bits.
+            // Normalise the chunk to the low bits (>> nbits), then left-align
+            // it within the bits still free in the current char.
             // Chunks are never larger than one char.
             uint64_t chunk = ((value & mask) >> nbits) << (bits_available_in_char - mask_width);
 
@@ -535,10 +558,12 @@ namespace etl
     /// Construct from span.
     //***************************************************************************
     template <size_t Length>
-    bit_stream_writer(const etl::span<char, Length>& span_, etl::endian stream_endianness_, callback_type callback_ = callback_type())
+    bit_stream_writer(const etl::span<char, Length>& span_, etl::bit_order bit_order_, callback_type callback_ = callback_type(),
+                      etl::endian byte_order_ = etl::endian::big)
       : pdata(span_.begin())
       , length_chars(span_.size_bytes())
-      , stream_endianness(stream_endianness_)
+      , bit_order(bit_order_)
+      , byte_order(byte_order_)
       , callback(callback_)
     {
       restart();
@@ -548,10 +573,12 @@ namespace etl
     /// Construct from span.
     //***************************************************************************
     template <size_t Length>
-    bit_stream_writer(const etl::span<unsigned char, Length>& span_, etl::endian stream_endianness_, callback_type callback_ = callback_type())
+    bit_stream_writer(const etl::span<unsigned char, Length>& span_, etl::bit_order bit_order_, callback_type callback_ = callback_type(),
+                      etl::endian byte_order_ = etl::endian::big)
       : pdata(reinterpret_cast<char*>(span_.begin()))
       , length_chars(span_.size_bytes())
-      , stream_endianness(stream_endianness_)
+      , bit_order(bit_order_)
+      , byte_order(byte_order_)
       , callback(callback_)
     {
       restart();
@@ -560,10 +587,12 @@ namespace etl
     //***************************************************************************
     /// Construct from range.
     //***************************************************************************
-    bit_stream_writer(void* begin_, void* end_, etl::endian stream_endianness_, callback_type callback_ = callback_type())
+    bit_stream_writer(void* begin_, void* end_, etl::bit_order bit_order_, callback_type callback_ = callback_type(),
+                      etl::endian byte_order_ = etl::endian::big)
       : pdata(reinterpret_cast<char*>(begin_))
       , length_chars(static_cast<size_t>(etl::distance(reinterpret_cast<unsigned char*>(begin_), reinterpret_cast<unsigned char*>(end_))))
-      , stream_endianness(stream_endianness_)
+      , bit_order(bit_order_)
+      , byte_order(byte_order_)
       , callback(callback_)
     {
       restart();
@@ -572,10 +601,12 @@ namespace etl
     //***************************************************************************
     /// Construct from begin and length.
     //***************************************************************************
-    bit_stream_writer(void* begin_, size_t length_chars_, etl::endian stream_endianness_, callback_type callback_ = callback_type())
+    bit_stream_writer(void* begin_, size_t length_chars_, etl::bit_order bit_order_, callback_type callback_ = callback_type(),
+                      etl::endian byte_order_ = etl::endian::big)
       : pdata(reinterpret_cast<char*>(begin_))
       , length_chars(length_chars_)
-      , stream_endianness(stream_endianness_)
+      , bit_order(bit_order_)
+      , byte_order(byte_order_)
       , callback(callback_)
     {
       restart();
@@ -883,10 +914,17 @@ namespace etl
     template <typename T>
     void write_data(T value, uint_least8_t nbits)
     {
-      // Make sure that we are not writing more bits than should be available.
-      nbits = (nbits > (CHAR_BIT * sizeof(T))) ? (CHAR_BIT * sizeof(T)) : nbits;
+      ETL_ASSERT(nbits <= (CHAR_BIT * sizeof(T)), ETL_ERROR_GENERIC("bit_stream_writer::write_data: nbits too large"));
 
-      if (stream_endianness == etl::endian::little)
+      // Apply the byte order (endianness).
+      // Only meaningful when writing the full width of the type.
+      if ((byte_order == etl::endian::little) && (nbits == (CHAR_BIT * sizeof(T))))
+      {
+        value = etl::reverse_bytes(value);
+      }
+
+      // Apply the bit order.
+      if (bit_order == etl::bit_order::lsb_first)
       {
         value = etl::reverse_bits(value);
         value = value >> ((CHAR_BIT * sizeof(T)) - nbits);
@@ -899,7 +937,8 @@ namespace etl
         nbits -= mask_width;
         T mask = ((T(1U) << mask_width) - 1U) << nbits;
 
-        // Move chunk to lowest char bits.
+        // Normalise the chunk to the low bits (>> nbits), then left-align
+        // it within the bits still free in the current char.
         // Chunks are never larger than one char.
         T chunk = ((value & mask) >> nbits) << (bits_available_in_char - mask_width);
 
@@ -968,15 +1007,16 @@ namespace etl
       bits_available -= nbits;
     }
 
-    char* const       pdata;                  ///< The start of the bitstream buffer.
-    const size_t      length_chars;           ///< The length of the bitstream buffer.
-    const etl::endian stream_endianness;      ///< The endianness of the stream data.
-    unsigned char     bits_available_in_char; ///< The number of available bits in
-                                              ///< the current char.
-    size_t char_index;                        ///< The index of the current char in the bitstream buffer.
-    size_t bits_available;                    ///< The number of bits still available in the
-                                              ///< bitstream buffer.
-    callback_type callback;                   ///< An optional callback on every filled byte in buffer.
+    char* const          pdata;                  ///< The start of the bitstream buffer.
+    const size_t         length_chars;           ///< The length of the bitstream buffer.
+    const etl::bit_order bit_order;              ///< The bit order of the stream data (MSB or LSB first).
+    const etl::endian    byte_order;             ///< The byte order (endianness) of the stream data.
+    unsigned char        bits_available_in_char; ///< The number of available bits in
+                                                 ///< the current char.
+    size_t char_index;                           ///< The index of the current char in the bitstream buffer.
+    size_t bits_available;                       ///< The number of bits still available in the
+                                                 ///< bitstream buffer.
+    callback_type callback;                      ///< An optional callback on every filled byte in buffer.
   };
 
   //***************************************************************************
@@ -1035,10 +1075,11 @@ namespace etl
     /// Construct from span.
     //***************************************************************************
     template <size_t Length>
-    bit_stream_reader(const etl::span<char, Length>& span_, etl::endian stream_endianness_)
+    bit_stream_reader(const etl::span<char, Length>& span_, etl::bit_order bit_order_, etl::endian byte_order_ = etl::endian::big)
       : pdata(span_.begin())
       , length_chars(span_.size_bytes())
-      , stream_endianness(stream_endianness_)
+      , bit_order(bit_order_)
+      , byte_order(byte_order_)
     {
       restart();
     }
@@ -1047,10 +1088,11 @@ namespace etl
     /// Construct from span.
     //***************************************************************************
     template <size_t Length>
-    bit_stream_reader(const etl::span<unsigned char, Length>& span_, etl::endian stream_endianness_)
+    bit_stream_reader(const etl::span<unsigned char, Length>& span_, etl::bit_order bit_order_, etl::endian byte_order_ = etl::endian::big)
       : pdata(reinterpret_cast<const char*>(span_.begin()))
       , length_chars(span_.size_bytes())
-      , stream_endianness(stream_endianness_)
+      , bit_order(bit_order_)
+      , byte_order(byte_order_)
     {
       restart();
     }
@@ -1059,10 +1101,11 @@ namespace etl
     /// Construct from span.
     //***************************************************************************
     template <size_t Length>
-    bit_stream_reader(const etl::span<const char, Length>& span_, etl::endian stream_endianness_)
+    bit_stream_reader(const etl::span<const char, Length>& span_, etl::bit_order bit_order_, etl::endian byte_order_ = etl::endian::big)
       : pdata(span_.begin())
       , length_chars(span_.size_bytes())
-      , stream_endianness(stream_endianness_)
+      , bit_order(bit_order_)
+      , byte_order(byte_order_)
     {
       restart();
     }
@@ -1071,10 +1114,11 @@ namespace etl
     /// Construct from span.
     //***************************************************************************
     template <size_t Length>
-    bit_stream_reader(const etl::span<const unsigned char, Length>& span_, etl::endian stream_endianness_)
+    bit_stream_reader(const etl::span<const unsigned char, Length>& span_, etl::bit_order bit_order_, etl::endian byte_order_ = etl::endian::big)
       : pdata(reinterpret_cast<const char*>(span_.begin()))
       , length_chars(span_.size_bytes())
-      , stream_endianness(stream_endianness_)
+      , bit_order(bit_order_)
+      , byte_order(byte_order_)
     {
       restart();
     }
@@ -1082,10 +1126,11 @@ namespace etl
     //***************************************************************************
     /// Construct from range.
     //***************************************************************************
-    bit_stream_reader(const void* begin_, const void* end_, etl::endian stream_endianness_)
+    bit_stream_reader(const void* begin_, const void* end_, etl::bit_order bit_order_, etl::endian byte_order_ = etl::endian::big)
       : pdata(reinterpret_cast<const char*>(begin_))
       , length_chars(static_cast<size_t>(etl::distance(reinterpret_cast<const char*>(begin_), reinterpret_cast<const char*>(end_))))
-      , stream_endianness(stream_endianness_)
+      , bit_order(bit_order_)
+      , byte_order(byte_order_)
     {
       restart();
     }
@@ -1093,10 +1138,11 @@ namespace etl
     //***************************************************************************
     /// Construct from begin and length.
     //***************************************************************************
-    bit_stream_reader(const void* begin_, size_t length_, etl::endian stream_endianness_)
+    bit_stream_reader(const void* begin_, size_t length_, etl::bit_order bit_order_, etl::endian byte_order_ = etl::endian::big)
       : pdata(reinterpret_cast<const char*>(begin_))
       , length_chars(length_)
-      , stream_endianness(stream_endianness_)
+      , bit_order(bit_order_)
+      , byte_order(byte_order_)
     {
       restart();
     }
@@ -1259,8 +1305,7 @@ namespace etl
     template <typename T>
     T read_value(uint_least8_t nbits, bool is_signed)
     {
-      // Make sure that we are not reading more bits than should be available.
-      nbits = (nbits > (CHAR_BIT * sizeof(T))) ? (CHAR_BIT * sizeof(T)) : nbits;
+      ETL_ASSERT(nbits <= (CHAR_BIT * sizeof(T)), ETL_ERROR_GENERIC("bit_stream_reader::read_value: nbits too large"));
 
       T             value = 0;
       uint_least8_t bits  = nbits;
@@ -1276,10 +1321,17 @@ namespace etl
         value |= static_cast<T>(chunk << nbits);
       }
 
-      if (stream_endianness == etl::endian::little)
+      if (bit_order == etl::bit_order::lsb_first)
       {
         value = value << ((CHAR_BIT * sizeof(T)) - bits);
         value = etl::reverse_bits(value);
+      }
+
+      // Apply the byte order (endianness).
+      // Only meaningful when reading the full width of the type.
+      if ((byte_order == etl::endian::little) && (bits == (CHAR_BIT * sizeof(T))))
+      {
+        value = etl::reverse_bytes(value);
       }
 
       if (is_signed && (bits != (CHAR_BIT * sizeof(T))))
@@ -1345,14 +1397,15 @@ namespace etl
       bits_available -= nbits;
     }
 
-    const char*       pdata;                  ///< The start of the bitstream buffer.
-    size_t            length_chars;           ///< The length, in char, of the bitstream buffer.
-    const etl::endian stream_endianness;      ///< The endianness of the stream data.
-    unsigned char     bits_available_in_char; ///< The number of available bits in
-                                              ///< the current char.
-    size_t char_index;                        ///< The index of the char in the bitstream buffer.
-    size_t bits_available;                    ///< The number of bits still available in the
-                                              ///< bitstream buffer.
+    const char*          pdata;                  ///< The start of the bitstream buffer.
+    size_t               length_chars;           ///< The length, in char, of the bitstream buffer.
+    const etl::bit_order bit_order;              ///< The bit order of the stream data (MSB or LSB first).
+    const etl::endian    byte_order;             ///< The byte order (endianness) of the stream data.
+    unsigned char        bits_available_in_char; ///< The number of available bits in
+                                                 ///< the current char.
+    size_t char_index;                           ///< The index of the char in the bitstream buffer.
+    size_t bits_available;                       ///< The number of bits still available in the
+                                                 ///< bitstream buffer.
   };
 
   //***************************************************************************

--- a/test/test_bit_stream_reader_big_endian.cpp
+++ b/test/test_bit_stream_reader_big_endian.cpp
@@ -99,7 +99,7 @@ namespace
     {
       char storage = 0x5AU;
 
-      etl::bit_stream_reader bit_stream(&storage, 1, etl::endian::big);
+      etl::bit_stream_reader bit_stream(&storage, 1, etl::bit_order::msb_first);
 
       CHECK_EQUAL(1U, bit_stream.size_bytes());
 
@@ -154,7 +154,7 @@ namespace
     {
       char storage = 0x5AU;
 
-      etl::bit_stream_reader bit_stream(&storage, 1, etl::endian::big);
+      etl::bit_stream_reader bit_stream(&storage, 1, etl::bit_order::msb_first);
 
       CHECK_EQUAL(1U, bit_stream.size_bytes());
 
@@ -210,7 +210,7 @@ namespace
       std::array<char, 4U>   storage  = {char(0x01), char(0x5A), char(0xA5), char(0xFF)};
       std::array<int8_t, 4U> expected = {int8_t(0x01), int8_t(0x5A), int8_t(0xA5), int8_t(0xFF)};
 
-      etl::bit_stream_reader bit_stream(storage.data(), storage.size(), etl::endian::big);
+      etl::bit_stream_reader bit_stream(storage.data(), storage.size(), etl::bit_order::msb_first);
 
       CHECK_EQUAL(storage.size(), bit_stream.size_bytes());
 
@@ -246,7 +246,7 @@ namespace
       std::array<char, 4U>   storage  = {char(0x01), char(0x5A), char(0xA5), char(0xFF)};
       std::array<int8_t, 4U> expected = {int8_t(0x01), int8_t(0x5A), int8_t(0xA5), int8_t(0xFF)};
 
-      etl::bit_stream_reader bit_stream(storage.data(), storage.size(), etl::endian::big);
+      etl::bit_stream_reader bit_stream(storage.data(), storage.size(), etl::bit_order::msb_first);
 
       CHECK_EQUAL(storage.size(), bit_stream.size_bytes());
 
@@ -282,7 +282,7 @@ namespace
       std::array<char, 4U>   storage  = {char(0x01), char(0x5A), char(0xA5), char(0xFF)};
       std::array<int8_t, 4U> expected = {int8_t(0x01), int8_t(0x5A), int8_t(0xA5), int8_t(0xFF)};
 
-      etl::bit_stream_reader bit_stream(storage.data(), storage.size(), etl::endian::big);
+      etl::bit_stream_reader bit_stream(storage.data(), storage.size(), etl::bit_order::msb_first);
 
       CHECK_EQUAL(storage.size(), bit_stream.size_bytes());
 
@@ -307,7 +307,7 @@ namespace
       std::array<char, 3U>   storage  = {char(0x0E), char(0x8B), char(0xF0)};
       std::array<int8_t, 4U> expected = {int8_t(0x01), int8_t(0xFA), int8_t(0x05), int8_t(0xFF)};
 
-      etl::bit_stream_reader bit_stream(storage.data(), storage.size(), etl::endian::big);
+      etl::bit_stream_reader bit_stream(storage.data(), storage.size(), etl::bit_order::msb_first);
 
       CHECK_EQUAL(storage.size(), bit_stream.size_bytes());
 
@@ -343,7 +343,7 @@ namespace
       std::array<char, 3U>   storage  = {char(0x0E), char(0x8B), char(0xF0)};
       std::array<int8_t, 4U> expected = {int8_t(0x01), int8_t(0xFA), int8_t(0x05), int8_t(0xFF)};
 
-      etl::bit_stream_reader bit_stream(storage.data(), storage.size(), etl::endian::big);
+      etl::bit_stream_reader bit_stream(storage.data(), storage.size(), etl::bit_order::msb_first);
 
       CHECK_EQUAL(storage.size(), bit_stream.size_bytes());
 
@@ -377,7 +377,7 @@ namespace
       std::array<char, 3U>   storage  = {char(0x0E), char(0x8B), char(0xF0)};
       std::array<int8_t, 4U> expected = {int8_t(0x01), int8_t(0xFA), int8_t(0x05), int8_t(0xFF)};
 
-      etl::bit_stream_reader bit_stream(storage.data(), storage.size(), etl::endian::big);
+      etl::bit_stream_reader bit_stream(storage.data(), storage.size(), etl::bit_order::msb_first);
 
       CHECK_EQUAL(storage.size(), bit_stream.size_bytes());
 
@@ -413,7 +413,7 @@ namespace
       std::array<char, 3U>   storage  = {char(0x0E), char(0x8B), char(0xF0)};
       std::array<int8_t, 4U> expected = {int8_t(0x01), int8_t(0xFA), int8_t(0x05), int8_t(0xFF)};
 
-      etl::bit_stream_reader bit_stream(storage.data(), storage.size(), etl::endian::big);
+      etl::bit_stream_reader bit_stream(storage.data(), storage.size(), etl::bit_order::msb_first);
 
       CHECK_EQUAL(storage.size(), bit_stream.size_bytes());
 
@@ -438,7 +438,7 @@ namespace
       std::array<char, 4U>    storage  = {char(0x01), char(0x5A), char(0xA5), char(0xFF)};
       std::array<uint8_t, 4U> expected = {uint8_t(0x01), uint8_t(0x5A), uint8_t(0xA5), uint8_t(0xFF)};
 
-      etl::bit_stream_reader bit_stream(storage.data(), storage.size(), etl::endian::big);
+      etl::bit_stream_reader bit_stream(storage.data(), storage.size(), etl::bit_order::msb_first);
 
       CHECK_EQUAL(storage.size(), bit_stream.size_bytes());
 
@@ -474,7 +474,7 @@ namespace
       std::array<char, 3U> storage  = {char(0x0E), char(0x8B), char(0xF0)};
       std::array<char, 4U> expected = {uint8_t(0x01), uint8_t(0x1A), uint8_t(0x05), uint8_t(0x1F)};
 
-      etl::bit_stream_reader bit_stream(storage.data(), storage.size(), etl::endian::big);
+      etl::bit_stream_reader bit_stream(storage.data(), storage.size(), etl::bit_order::msb_first);
 
       CHECK_EQUAL(storage.size(), bit_stream.size_bytes());
 
@@ -510,7 +510,7 @@ namespace
       std::array<char, 8U>    storage  = {char(0x00), char(0x01), char(0xA5), char(0x5A), char(0x5A), char(0xA5), char(0xFF), char(0xFF)};
       std::array<int16_t, 4U> expected = {int16_t(0x0001), int16_t(0xA55A), int16_t(0x5AA5), int16_t(0xFFFF)};
 
-      etl::bit_stream_reader bit_stream(storage.data(), storage.size(), etl::endian::big);
+      etl::bit_stream_reader bit_stream(storage.data(), storage.size(), etl::bit_order::msb_first);
 
       CHECK_EQUAL(storage.size(), bit_stream.size_bytes());
 
@@ -546,7 +546,7 @@ namespace
       std::array<char, 5U>    storage  = {char(0x00), char(0x55), char(0xAA), char(0x97), char(0xFF)};
       std::array<int16_t, 4U> expected = {int16_t(0x0001), int16_t(0x015A), int16_t(0xFEA5), int16_t(0xFFFF)};
 
-      etl::bit_stream_reader bit_stream(storage.data(), storage.size(), etl::endian::big);
+      etl::bit_stream_reader bit_stream(storage.data(), storage.size(), etl::bit_order::msb_first);
 
       CHECK_EQUAL(storage.size(), bit_stream.size_bytes());
 
@@ -582,7 +582,7 @@ namespace
       std::array<char, 8U>     storage  = {char(0x00), char(0x01), char(0xA5), char(0x5A), char(0x5A), char(0xA5), char(0xFF), char(0xFF)};
       std::array<uint16_t, 4U> expected = {uint16_t(0x0001), uint16_t(0xA55A), uint16_t(0x5AA5), uint16_t(0xFFFF)};
 
-      etl::bit_stream_reader bit_stream(storage.data(), storage.size(), etl::endian::big);
+      etl::bit_stream_reader bit_stream(storage.data(), storage.size(), etl::bit_order::msb_first);
 
       CHECK_EQUAL(storage.size(), bit_stream.size_bytes());
 
@@ -618,7 +618,7 @@ namespace
       std::array<char, 5U>     storage  = {char(0x00), char(0x55), char(0xAA), char(0x97), char(0xFF)};
       std::array<uint16_t, 4U> expected = {uint16_t(0x0001), uint16_t(0x015A), uint16_t(0x02A5), uint16_t(0x03FF)};
 
-      etl::bit_stream_reader bit_stream(storage.data(), storage.size(), etl::endian::big);
+      etl::bit_stream_reader bit_stream(storage.data(), storage.size(), etl::bit_order::msb_first);
 
       CHECK_EQUAL(storage.size(), bit_stream.size_bytes());
 
@@ -655,7 +655,7 @@ namespace
                                           char(0x5A), char(0xA5), char(0x5A), char(0xA5), char(0xFF), char(0xFF), char(0xFF), char(0xFF)};
       std::array<int32_t, 4U> expected = {int32_t(0x00000001), int32_t(0xA55AA55A), int32_t(0x5AA55AA5), int32_t(0xFFFFFFFF)};
 
-      etl::bit_stream_reader bit_stream(storage.data(), storage.size(), etl::endian::big);
+      etl::bit_stream_reader bit_stream(storage.data(), storage.size(), etl::bit_order::msb_first);
 
       CHECK_EQUAL(storage.size(), bit_stream.size_bytes());
 
@@ -692,7 +692,7 @@ namespace
                                           char(0x56), char(0xA9), char(0x7F), char(0xFF), char(0xFF)};
       std::array<int32_t, 4U> expected = {int32_t(0x00000001), int32_t(0x001AA55A), int32_t(0xFFE55AA5), int32_t(0xFFFFFFFF)};
 
-      etl::bit_stream_reader bit_stream(storage.data(), storage.size(), etl::endian::big);
+      etl::bit_stream_reader bit_stream(storage.data(), storage.size(), etl::bit_order::msb_first);
 
       CHECK_EQUAL(storage.size(), bit_stream.size_bytes());
 
@@ -729,7 +729,7 @@ namespace
                                            char(0x5A), char(0xA5), char(0x5A), char(0xA5), char(0xFF), char(0xFF), char(0xFF), char(0xFF)};
       std::array<uint32_t, 4U> expected = {uint32_t(0x00000001), uint32_t(0xA55AA55A), uint32_t(0x5AA55AA5), uint32_t(0xFFFFFFFF)};
 
-      etl::bit_stream_reader bit_stream(storage.data(), storage.size(), etl::endian::big);
+      etl::bit_stream_reader bit_stream(storage.data(), storage.size(), etl::bit_order::msb_first);
 
       CHECK_EQUAL(storage.size(), bit_stream.size_bytes());
 
@@ -766,7 +766,7 @@ namespace
                                            char(0x56), char(0xA9), char(0x7F), char(0xFF), char(0xFF)};
       std::array<uint32_t, 4U> expected = {uint32_t(0x00000001), uint32_t(0x001AA55A), uint32_t(0x00255AA5), uint32_t(0x003FFFFF)};
 
-      etl::bit_stream_reader bit_stream(storage.data(), storage.size(), etl::endian::big);
+      etl::bit_stream_reader bit_stream(storage.data(), storage.size(), etl::bit_order::msb_first);
 
       CHECK_EQUAL(storage.size(), bit_stream.size_bytes());
 
@@ -806,7 +806,7 @@ namespace
       std::array<int64_t, 4U> expected = {int64_t(0x0000000000000001), int64_t(0xA55AA55AA55AA55A), int64_t(0x5AA55AA55AA55AA5),
                                           int64_t(0xFFFFFFFFFFFFFFFF)};
 
-      etl::bit_stream_reader bit_stream(storage.data(), storage.size(), etl::endian::big);
+      etl::bit_stream_reader bit_stream(storage.data(), storage.size(), etl::bit_order::msb_first);
 
       CHECK_EQUAL(storage.size(), bit_stream.size_bytes());
 
@@ -845,7 +845,7 @@ namespace
       std::array<int64_t, 4U> expected = {int64_t(0x0000000000000001), int64_t(0x0000255AA55AA55A), int64_t(0xFFFFDAA55AA55AA5),
                                           int64_t(0xFFFFFFFFFFFFFFFF)};
 
-      etl::bit_stream_reader bit_stream(storage.data(), storage.size(), etl::endian::big);
+      etl::bit_stream_reader bit_stream(storage.data(), storage.size(), etl::bit_order::msb_first);
 
       CHECK_EQUAL(storage.size(), bit_stream.size_bytes());
 
@@ -885,7 +885,7 @@ namespace
       std::array<uint64_t, 4U> expected = {uint64_t(0x0000000000000001), uint64_t(0xA55AA55AA55AA55A), uint64_t(0x5AA55AA55AA55AA5),
                                            uint64_t(0xFFFFFFFFFFFFFFFF)};
 
-      etl::bit_stream_reader bit_stream(storage.data(), storage.size(), etl::endian::big);
+      etl::bit_stream_reader bit_stream(storage.data(), storage.size(), etl::bit_order::msb_first);
 
       CHECK_EQUAL(storage.size(), bit_stream.size_bytes());
 
@@ -924,7 +924,7 @@ namespace
       std::array<uint64_t, 4U> expected = {uint64_t(0x0000000000000001), uint64_t(0x0000255AA55AA55A), uint64_t(0x00005AA55AA55AA5),
                                            uint64_t(0x00007FFFFFFFFFFF)};
 
-      etl::bit_stream_reader bit_stream(storage.data(), storage.size(), etl::endian::big);
+      etl::bit_stream_reader bit_stream(storage.data(), storage.size(), etl::bit_order::msb_first);
 
       CHECK_EQUAL(storage.size(), bit_stream.size_bytes());
 
@@ -967,7 +967,7 @@ namespace
       std::array<char, 14U> storage = {char(0x5A), char(0x12), char(0x34), char(0x89), char(0xAB), char(0xCD), char(0xEF),
                                        char(0xFE), char(0xDC), char(0xBA), char(0x98), char(0x56), char(0x78), char(0xA5)};
 
-      etl::bit_stream_reader bit_stream(storage.data(), storage.size(), etl::endian::big);
+      etl::bit_stream_reader bit_stream(storage.data(), storage.size(), etl::bit_order::msb_first);
 
       CHECK_EQUAL(storage.size(), bit_stream.size_bytes());
 
@@ -1009,7 +1009,7 @@ namespace
       std::array<char, 11U> storage = {char(0x6A), char(0x46), char(0x8A), char(0xF3), char(0x7B), char(0xDB),
                                        char(0x97), char(0x53), char(0x19), char(0xE1), char(0x28)};
 
-      etl::bit_stream_reader bit_stream(storage.data(), storage.size(), etl::endian::big);
+      etl::bit_stream_reader bit_stream(storage.data(), storage.size(), etl::bit_order::msb_first);
 
       CHECK_EQUAL(storage.size(), bit_stream.size_bytes());
 
@@ -1053,7 +1053,7 @@ namespace
 
       auto storage_span = etl::span<char, etl::dynamic_extent>(storage.data(), storage.size());
 
-      etl::bit_stream_reader bit_stream(storage_span, etl::endian::big);
+      etl::bit_stream_reader bit_stream(storage_span, etl::bit_order::msb_first);
 
       CHECK_EQUAL(storage.size(), bit_stream.size_bytes());
 
@@ -1098,7 +1098,7 @@ namespace
 
       auto storage_span = etl::span<unsigned char, etl::dynamic_extent>(storage.data(), storage.size());
 
-      etl::bit_stream_reader bit_stream(storage_span, etl::endian::big);
+      etl::bit_stream_reader bit_stream(storage_span, etl::bit_order::msb_first);
 
       CHECK_EQUAL(storage.size(), bit_stream.size_bytes());
 
@@ -1142,7 +1142,7 @@ namespace
 
       auto storage_span = etl::span<char, 11U>(storage.data(), storage.size());
 
-      etl::bit_stream_reader bit_stream(storage_span, etl::endian::big);
+      etl::bit_stream_reader bit_stream(storage_span, etl::bit_order::msb_first);
 
       CHECK_EQUAL(storage.size(), bit_stream.size_bytes());
 
@@ -1187,7 +1187,7 @@ namespace
 
       auto storage_span = etl::span<unsigned char, 11U>(storage.data(), storage.size());
 
-      etl::bit_stream_reader bit_stream(storage_span, etl::endian::big);
+      etl::bit_stream_reader bit_stream(storage_span, etl::bit_order::msb_first);
 
       CHECK_EQUAL(storage.size(), bit_stream.size_bytes());
 
@@ -1231,7 +1231,7 @@ namespace
 
       auto storage_span = etl::span<const char, etl::dynamic_extent>(storage.data(), storage.size());
 
-      etl::bit_stream_reader bit_stream(storage_span, etl::endian::big);
+      etl::bit_stream_reader bit_stream(storage_span, etl::bit_order::msb_first);
 
       CHECK_EQUAL(storage.size(), bit_stream.size_bytes());
 
@@ -1276,7 +1276,7 @@ namespace
 
       auto storage_span = etl::span<const unsigned char, etl::dynamic_extent>(storage.data(), storage.size());
 
-      etl::bit_stream_reader bit_stream(storage_span, etl::endian::big);
+      etl::bit_stream_reader bit_stream(storage_span, etl::bit_order::msb_first);
 
       CHECK_EQUAL(storage.size(), bit_stream.size_bytes());
 
@@ -1320,7 +1320,7 @@ namespace
 
       auto storage_span = etl::span<const char, 11U>(storage.data(), storage.size());
 
-      etl::bit_stream_reader bit_stream(storage_span, etl::endian::big);
+      etl::bit_stream_reader bit_stream(storage_span, etl::bit_order::msb_first);
 
       CHECK_EQUAL(storage.size(), bit_stream.size_bytes());
 
@@ -1365,7 +1365,7 @@ namespace
 
       auto storage_span = etl::span<const unsigned char, 11U>(storage.data(), storage.size());
 
-      etl::bit_stream_reader bit_stream(storage_span, etl::endian::big);
+      etl::bit_stream_reader bit_stream(storage_span, etl::bit_order::msb_first);
 
       CHECK_EQUAL(storage.size(), bit_stream.size_bytes());
 
@@ -1407,7 +1407,7 @@ namespace
       std::array<char, 11U> storage = {char(0x6A), char(0x46), char(0x8A), char(0xF3), char(0x7B), char(0xDB),
                                        char(0x97), char(0x53), char(0x19), char(0xE1), char(0x28)};
 
-      etl::bit_stream_reader bit_stream(storage.data(), storage.size(), etl::endian::big);
+      etl::bit_stream_reader bit_stream(storage.data(), storage.size(), etl::bit_order::msb_first);
 
       CHECK_EQUAL(storage.size(), bit_stream.size_bytes());
 
@@ -1442,7 +1442,7 @@ namespace
       std::array<char, 12U> storage = {char(0xEC), char(0xBA), char(0xDE), char(0x68), char(0xAF), char(0xD2),
                                        char(0xC5), char(0xC8), char(0x65), char(0xD3), char(0xDF), char(0x80)};
 
-      etl::bit_stream_reader bit_stream(storage.data(), storage.size(), etl::endian::big);
+      etl::bit_stream_reader bit_stream(storage.data(), storage.size(), etl::bit_order::msb_first);
 
       CHECK_EQUAL(storage.size(), bit_stream.size_bytes());
 
@@ -1470,7 +1470,7 @@ namespace
       std::array<char, 12U> storage = {char(0xEC), char(0xBA), char(0xDE), char(0x68), char(0xAF), char(0xD2),
                                        char(0xC5), char(0xC8), char(0x65), char(0xD3), char(0xDF), char(0x80)};
 
-      etl::bit_stream_reader bit_stream(storage.data(), storage.size(), etl::endian::big);
+      etl::bit_stream_reader bit_stream(storage.data(), storage.size(), etl::bit_order::msb_first);
 
       CHECK_EQUAL(storage.size(), bit_stream.size_bytes());
 

--- a/test/test_bit_stream_reader_little_endian.cpp
+++ b/test/test_bit_stream_reader_little_endian.cpp
@@ -100,7 +100,7 @@ namespace
     {
       char storage = 0x5AU;
 
-      etl::bit_stream_reader bit_stream(&storage, 1, etl::endian::little);
+      etl::bit_stream_reader bit_stream(&storage, 1, etl::bit_order::lsb_first);
 
       CHECK_EQUAL(1U, bit_stream.size_bytes());
 
@@ -157,7 +157,7 @@ namespace
     {
       char storage = 0x5AU;
 
-      etl::bit_stream_reader bit_stream(&storage, 1, etl::endian::little);
+      etl::bit_stream_reader bit_stream(&storage, 1, etl::bit_order::lsb_first);
 
       CHECK_EQUAL(1U, bit_stream.size_bytes());
 
@@ -215,7 +215,7 @@ namespace
       std::array<char, 4U>   storage  = {char(0x80), char(0x5A), char(0xA5), char(0xFF)};
       std::array<int8_t, 4U> expected = {int8_t(0x01), int8_t(0x5A), int8_t(0xA5), int8_t(0xFF)};
 
-      etl::bit_stream_reader bit_stream(storage.data(), storage.size(), etl::endian::little);
+      etl::bit_stream_reader bit_stream(storage.data(), storage.size(), etl::bit_order::lsb_first);
 
       CHECK_EQUAL(storage.size(), bit_stream.size_bytes());
 
@@ -253,7 +253,7 @@ namespace
       std::array<char, 4U>   storage  = {char(0x80), char(0x5A), char(0xA5), char(0xFF)};
       std::array<int8_t, 4U> expected = {int8_t(0x01), int8_t(0x5A), int8_t(0xA5), int8_t(0xFF)};
 
-      etl::bit_stream_reader bit_stream(storage.data(), storage.size(), etl::endian::little);
+      etl::bit_stream_reader bit_stream(storage.data(), storage.size(), etl::bit_order::lsb_first);
 
       CHECK_EQUAL(storage.size(), bit_stream.size_bytes());
 
@@ -291,7 +291,7 @@ namespace
       std::array<char, 4U>   storage  = {char(0x80), char(0x5A), char(0xA5), char(0xFF)};
       std::array<int8_t, 4U> expected = {int8_t(0x01), int8_t(0x5A), int8_t(0xA5), int8_t(0xFF)};
 
-      etl::bit_stream_reader bit_stream(storage.data(), storage.size(), etl::endian::little);
+      etl::bit_stream_reader bit_stream(storage.data(), storage.size(), etl::bit_order::lsb_first);
 
       CHECK_EQUAL(storage.size(), bit_stream.size_bytes());
 
@@ -313,7 +313,7 @@ namespace
       std::array<char, 3U>   storage  = {char(0x85), char(0x69), char(0xF0)};
       std::array<int8_t, 4U> expected = {int8_t(0x01), int8_t(0xF5), int8_t(0x05), int8_t(0xFF)};
 
-      etl::bit_stream_reader bit_stream(storage.data(), storage.size(), etl::endian::little);
+      etl::bit_stream_reader bit_stream(storage.data(), storage.size(), etl::bit_order::lsb_first);
 
       CHECK_EQUAL(storage.size(), bit_stream.size_bytes());
 
@@ -351,7 +351,7 @@ namespace
       std::array<char, 3U>   storage  = {char(0x85), char(0x69), char(0xF0)};
       std::array<int8_t, 4U> expected = {int8_t(0x01), int8_t(0xF5), int8_t(0x05), int8_t(0xFF)};
 
-      etl::bit_stream_reader bit_stream(storage.data(), storage.size(), etl::endian::little);
+      etl::bit_stream_reader bit_stream(storage.data(), storage.size(), etl::bit_order::lsb_first);
 
       CHECK_EQUAL(storage.size(), bit_stream.size_bytes());
 
@@ -389,7 +389,7 @@ namespace
       std::array<char, 4U>   storage  = {char(0x85), char(0x69), char(0xF0)};
       std::array<int8_t, 4U> expected = {int8_t(0x01), int8_t(0xF5), int8_t(0x05), int8_t(0xFF)};
 
-      etl::bit_stream_reader bit_stream(storage.data(), storage.size(), etl::endian::little);
+      etl::bit_stream_reader bit_stream(storage.data(), storage.size(), etl::bit_order::lsb_first);
 
       CHECK_EQUAL(storage.size(), bit_stream.size_bytes());
 
@@ -414,7 +414,7 @@ namespace
       std::array<char, 4U>    storage  = {char(0x80), char(0x5A), char(0xA5), char(0xFF)};
       std::array<uint8_t, 4U> expected = {uint8_t(0x01), uint8_t(0x5A), uint8_t(0xA5), uint8_t(0xFF)};
 
-      etl::bit_stream_reader bit_stream(storage.data(), storage.size(), etl::endian::little);
+      etl::bit_stream_reader bit_stream(storage.data(), storage.size(), etl::bit_order::lsb_first);
 
       CHECK_EQUAL(storage.size(), bit_stream.size_bytes());
 
@@ -452,7 +452,7 @@ namespace
       std::array<char, 3U>   storage  = {char(0x85), char(0x69), char(0xF0)};
       std::array<int8_t, 4U> expected = {uint8_t(0x01), uint8_t(0x15), uint8_t(0x05), uint8_t(0x1F)};
 
-      etl::bit_stream_reader bit_stream(storage.data(), storage.size(), etl::endian::little);
+      etl::bit_stream_reader bit_stream(storage.data(), storage.size(), etl::bit_order::lsb_first);
 
       CHECK_EQUAL(storage.size(), bit_stream.size_bytes());
 
@@ -490,7 +490,7 @@ namespace
       std::array<char, 3U>   storage  = {char(0x85), char(0x69), char(0xF0)};
       std::array<int8_t, 4U> expected = {uint8_t(0x01), uint8_t(0x15), uint8_t(0x05), uint8_t(0x1F)};
 
-      etl::bit_stream_reader bit_stream(storage.data(), storage.size(), etl::endian::little);
+      etl::bit_stream_reader bit_stream(storage.data(), storage.size(), etl::bit_order::lsb_first);
 
       CHECK_EQUAL(storage.size(), bit_stream.size_bytes());
 
@@ -526,7 +526,7 @@ namespace
       std::array<char, 8U>    storage  = {char(0x80), char(0x00), char(0xA5), char(0x5A), char(0x5A), char(0xA5), char(0xFF), char(0xFF)};
       std::array<int16_t, 4U> expected = {int16_t(0x0001), int16_t(0x5AA5), int16_t(0xA55A), int16_t(0xFFFF)};
 
-      etl::bit_stream_reader bit_stream(storage.data(), storage.size(), etl::endian::little);
+      etl::bit_stream_reader bit_stream(storage.data(), storage.size(), etl::bit_order::lsb_first);
 
       CHECK_EQUAL(storage.size(), bit_stream.size_bytes());
 
@@ -564,7 +564,7 @@ namespace
       std::array<char, 5U>    storage  = {char(0x80), char(0x16), char(0xAA), char(0x57), char(0xFF)};
       std::array<int16_t, 4U> expected = {int16_t(0x0001), int16_t(0x015A), int16_t(0xFEA5), int16_t(0xFFFF)};
 
-      etl::bit_stream_reader bit_stream(storage.data(), storage.size(), etl::endian::little);
+      etl::bit_stream_reader bit_stream(storage.data(), storage.size(), etl::bit_order::lsb_first);
 
       CHECK_EQUAL(storage.size(), bit_stream.size_bytes());
 
@@ -602,7 +602,7 @@ namespace
       std::array<char, 8U>     storage  = {char(0x80), char(0x00), char(0xA5), char(0x5A), char(0x5A), char(0xA5), char(0xFF), char(0xFF)};
       std::array<uint16_t, 4U> expected = {uint16_t(0x0001), uint16_t(0x5AA5), uint16_t(0xA55A), uint16_t(0xFFFF)};
 
-      etl::bit_stream_reader bit_stream(storage.data(), storage.size(), etl::endian::little);
+      etl::bit_stream_reader bit_stream(storage.data(), storage.size(), etl::bit_order::lsb_first);
 
       CHECK_EQUAL(storage.size(), bit_stream.size_bytes());
 
@@ -640,7 +640,7 @@ namespace
       std::array<char, 5U>     storage  = {char(0x80), char(0x16), char(0xAA), char(0x57), char(0xFF)};
       std::array<uint16_t, 4U> expected = {uint16_t(0x0001), uint16_t(0x015A), uint16_t(0x02A5), uint16_t(0x03FF)};
 
-      etl::bit_stream_reader bit_stream(storage.data(), storage.size(), etl::endian::little);
+      etl::bit_stream_reader bit_stream(storage.data(), storage.size(), etl::bit_order::lsb_first);
 
       CHECK_EQUAL(storage.size(), bit_stream.size_bytes());
 
@@ -679,7 +679,7 @@ namespace
                                           char(0xA5), char(0x5A), char(0x5A), char(0xA5), char(0xFF), char(0xFF), char(0xFF), char(0xFF)};
       std::array<int32_t, 4U> expected = {int32_t(0x00000001), int32_t(0x5AA5A55A), int32_t(0xA55A5AA5), int32_t(0xFFFFFFFF)};
 
-      etl::bit_stream_reader bit_stream(storage.data(), storage.size(), etl::endian::little);
+      etl::bit_stream_reader bit_stream(storage.data(), storage.size(), etl::bit_order::lsb_first);
 
       CHECK_EQUAL(storage.size(), bit_stream.size_bytes());
 
@@ -718,7 +718,7 @@ namespace
                                           char(0x55), char(0xAA), char(0x7F), char(0xFF), char(0xFF)};
       std::array<int32_t, 4U> expected = {int32_t(0x00000001), int32_t(0x001AA55A), int32_t(0xFFE55AA5), int32_t(0xFFFFFFFF)};
 
-      etl::bit_stream_reader bit_stream(storage.data(), storage.size(), etl::endian::little);
+      etl::bit_stream_reader bit_stream(storage.data(), storage.size(), etl::bit_order::lsb_first);
 
       CHECK_EQUAL(storage.size(), bit_stream.size_bytes());
 
@@ -757,7 +757,7 @@ namespace
                                           char(0xA5), char(0x5A), char(0x5A), char(0xA5), char(0xFF), char(0xFF), char(0xFF), char(0xFF)};
       std::array<int32_t, 4U> expected = {int32_t(0x00000001), int32_t(0x5AA5A55A), int32_t(0xA55A5AA5), int32_t(0xFFFFFFFF)};
 
-      etl::bit_stream_reader bit_stream(storage.data(), storage.size(), etl::endian::little);
+      etl::bit_stream_reader bit_stream(storage.data(), storage.size(), etl::bit_order::lsb_first);
 
       CHECK_EQUAL(storage.size(), bit_stream.size_bytes());
 
@@ -796,7 +796,7 @@ namespace
                                           char(0x55), char(0xAA), char(0x7F), char(0xFF), char(0xFF)};
       std::array<int32_t, 4U> expected = {uint32_t(0x00000001), uint32_t(0x001AA55A), uint32_t(0x00255AA5), uint32_t(0x003FFFFF)};
 
-      etl::bit_stream_reader bit_stream(storage.data(), storage.size(), etl::endian::little);
+      etl::bit_stream_reader bit_stream(storage.data(), storage.size(), etl::bit_order::lsb_first);
 
       CHECK_EQUAL(storage.size(), bit_stream.size_bytes());
 
@@ -838,7 +838,7 @@ namespace
       std::array<int64_t, 4U> expected = {int64_t(0x0000000000000001LL), int64_t(0x5AA5A55AA55A5AA5LL), int64_t(0xA55A5AA55AA5A55ALL),
                                           int64_t(0xFFFFFFFFFFFFFFFFLL)};
 
-      etl::bit_stream_reader bit_stream(storage.data(), storage.size(), etl::endian::little);
+      etl::bit_stream_reader bit_stream(storage.data(), storage.size(), etl::bit_order::lsb_first);
 
       CHECK_EQUAL(storage.size(), bit_stream.size_bytes());
 
@@ -879,7 +879,7 @@ namespace
       std::array<int64_t, 4U> expected = {int64_t(0x0000000000000001LL), int64_t(0x0000255AA55AA55ALL), int64_t(0xFFFFDAA55AA55AA5LL),
                                           int64_t(0xFFFFFFFFFFFFFFFFLL)};
 
-      etl::bit_stream_reader bit_stream(storage.data(), storage.size(), etl::endian::little);
+      etl::bit_stream_reader bit_stream(storage.data(), storage.size(), etl::bit_order::lsb_first);
 
       CHECK_EQUAL(storage.size(), bit_stream.size_bytes());
 
@@ -921,7 +921,7 @@ namespace
       std::array<uint64_t, 4U> expected = {uint64_t(0x0000000000000001ULL), uint64_t(0x5AA5A55AA55A5AA5ULL), uint64_t(0xA55A5AA55AA5A55AULL),
                                            uint64_t(0xFFFFFFFFFFFFFFFFULL)};
 
-      etl::bit_stream_reader bit_stream(storage.data(), storage.size(), etl::endian::little);
+      etl::bit_stream_reader bit_stream(storage.data(), storage.size(), etl::bit_order::lsb_first);
 
       CHECK_EQUAL(storage.size(), bit_stream.size_bytes());
 
@@ -962,7 +962,7 @@ namespace
       std::array<uint64_t, 4U> expected = {uint64_t(0x0000000000000001ULL), uint64_t(0x0000255AA55AA55AULL), uint64_t(0x00005AA55AA55AA5ULL),
                                            uint64_t(0x00007FFFFFFFFFFFULL)};
 
-      etl::bit_stream_reader bit_stream(storage.data(), storage.size(), etl::endian::little);
+      etl::bit_stream_reader bit_stream(storage.data(), storage.size(), etl::bit_order::lsb_first);
 
       CHECK_EQUAL(storage.size(), bit_stream.size_bytes());
 
@@ -1007,7 +1007,7 @@ namespace
       std::array<char, 14U> storage = {char(0x5A), char(0x2C), char(0x48), char(0xF7), char(0xB3), char(0xD5), char(0x91),
                                        char(0x19), char(0x5D), char(0x3B), char(0x7F), char(0x1E), char(0x6A), char(0xA5)};
 
-      etl::bit_stream_reader bit_stream(storage.data(), storage.size(), etl::endian::little);
+      etl::bit_stream_reader bit_stream(storage.data(), storage.size(), etl::bit_order::lsb_first);
 
       CHECK_EQUAL(storage.size(), bit_stream.size_bytes());
 
@@ -1049,7 +1049,7 @@ namespace
       std::array<char, 11U> storage = {char(0x58), char(0xB1), char(0x3E), char(0xF6), char(0x7A), char(0x86),
                                        char(0x57), char(0x4E), char(0xC3), char(0xCE), char(0x90)};
 
-      etl::bit_stream_reader bit_stream(storage.data(), storage.size(), etl::endian::little);
+      etl::bit_stream_reader bit_stream(storage.data(), storage.size(), etl::bit_order::lsb_first);
 
       CHECK_EQUAL(storage.size(), bit_stream.size_bytes());
 
@@ -1091,7 +1091,7 @@ namespace
       std::array<char, 11U> storage = {char(0x58), char(0xB1), char(0x3E), char(0xF6), char(0x7A), char(0x86),
                                        char(0x57), char(0x4E), char(0xC3), char(0xCE), char(0x90)};
 
-      etl::bit_stream_reader bit_stream(storage.data(), storage.size(), etl::endian::little);
+      etl::bit_stream_reader bit_stream(storage.data(), storage.size(), etl::bit_order::lsb_first);
 
       CHECK_EQUAL(storage.size(), bit_stream.size_bytes());
 
@@ -1126,7 +1126,7 @@ namespace
       std::array<char, 12U> storage = {char(0x74), char(0xDE), char(0xA2), char(0xCF), char(0x6A), char(0xFB),
                                        char(0xA3), char(0x5E), char(0x5D), char(0x30), char(0x9F), char(0x80)};
 
-      etl::bit_stream_reader bit_stream(storage.data(), storage.size(), etl::endian::little);
+      etl::bit_stream_reader bit_stream(storage.data(), storage.size(), etl::bit_order::lsb_first);
 
       CHECK_EQUAL(storage.size(), bit_stream.size_bytes());
 
@@ -1154,7 +1154,7 @@ namespace
       std::array<char, 12U> storage = {char(0x74), char(0xDE), char(0xA2), char(0xCF), char(0x6A), char(0xFB),
                                        char(0xA3), char(0x5E), char(0x5D), char(0x30), char(0x9F), char(0x80)};
 
-      etl::bit_stream_reader bit_stream(storage.data(), storage.size(), etl::endian::little);
+      etl::bit_stream_reader bit_stream(storage.data(), storage.size(), etl::bit_order::lsb_first);
 
       CHECK_EQUAL(storage.size(), bit_stream.size_bytes());
 

--- a/test/test_bit_stream_writer_big_endian.cpp
+++ b/test/test_bit_stream_writer_big_endian.cpp
@@ -119,7 +119,7 @@ namespace
     {
       std::array<char, 256> storage;
 
-      etl::bit_stream_writer bit_stream(storage.data(), storage.size(), etl::endian::big);
+      etl::bit_stream_writer bit_stream(storage.data(), storage.size(), etl::bit_order::msb_first);
 
       CHECK_EQUAL(storage.size(), bit_stream.available(CHAR_BIT));
       CHECK_EQUAL(storage.size(), bit_stream.available<CHAR_BIT>());
@@ -140,7 +140,7 @@ namespace
       unsigned char storage  = 0;
       unsigned char expected = 0x5AU;
 
-      etl::bit_stream_writer bit_stream(&storage, 1U, etl::endian::big);
+      etl::bit_stream_writer bit_stream(&storage, 1U, etl::bit_order::msb_first);
 
       CHECK(bit_stream.write(false));
       CHECK_EQUAL(1U, bit_stream.used_data().size());
@@ -176,7 +176,7 @@ namespace
       std::array<char, 256U> expected;
       std::iota(expected.begin(), expected.end(), 0);
 
-      etl::bit_stream_writer bit_stream(storage.data(), storage.size(), etl::endian::big);
+      etl::bit_stream_writer bit_stream(storage.data(), storage.size(), etl::bit_order::msb_first);
 
       for (size_t i = 0UL; i < 256UL; ++i)
       {
@@ -204,7 +204,7 @@ namespace
       std::array<char, 256> expected;
       std::iota(expected.begin(), expected.end(), 0);
 
-      etl::bit_stream_writer bit_stream(storage.data(), storage.size(), etl::endian::big);
+      etl::bit_stream_writer bit_stream(storage.data(), storage.size(), etl::bit_order::msb_first);
 
       for (size_t i = 0UL; i < 256UL; ++i)
       {
@@ -233,7 +233,7 @@ namespace
 
       CHECK(expected.size() == storage.size());
 
-      etl::bit_stream_writer bit_stream(storage.data(), storage.size(), etl::endian::big);
+      etl::bit_stream_writer bit_stream(storage.data(), storage.size(), etl::bit_order::msb_first);
 
       CHECK(bit_stream.write(int16_t(0x0001)));
       CHECK_EQUAL(sizeof(int16_t) * 1, bit_stream.used_data().size());
@@ -265,7 +265,7 @@ namespace
 
       CHECK(expected.size() == storage.size());
 
-      etl::bit_stream_writer bit_stream(storage.data(), storage.size(), etl::endian::big);
+      etl::bit_stream_writer bit_stream(storage.data(), storage.size(), etl::bit_order::msb_first);
 
       CHECK(bit_stream.write(uint16_t(0x0001)));
       CHECK_EQUAL(sizeof(uint16_t) * 1, bit_stream.used_data().size());
@@ -298,7 +298,7 @@ namespace
 
       CHECK(expected.size() == storage.size());
 
-      etl::bit_stream_writer bit_stream(storage.data(), storage.size(), etl::endian::big);
+      etl::bit_stream_writer bit_stream(storage.data(), storage.size(), etl::bit_order::msb_first);
 
       CHECK(bit_stream.write(int32_t(0x00000001)));
       CHECK_EQUAL(sizeof(int32_t) * 1, bit_stream.used_data().size());
@@ -331,7 +331,7 @@ namespace
 
       CHECK(expected.size() == storage.size());
 
-      etl::bit_stream_writer bit_stream(storage.data(), storage.size(), etl::endian::big);
+      etl::bit_stream_writer bit_stream(storage.data(), storage.size(), etl::bit_order::msb_first);
 
       CHECK(bit_stream.write(uint32_t(0x00000001)));
       CHECK_EQUAL(sizeof(uint32_t) * 1, bit_stream.used_data().size());
@@ -365,7 +365,7 @@ namespace
 
       CHECK(expected.size() == storage.size());
 
-      etl::bit_stream_writer bit_stream(storage.data(), storage.size(), etl::endian::big);
+      etl::bit_stream_writer bit_stream(storage.data(), storage.size(), etl::bit_order::msb_first);
 
       CHECK(bit_stream.write(int64_t(0x0000000000000001LL)));
       CHECK_EQUAL(sizeof(int64_t) * 1, bit_stream.used_data().size());
@@ -399,7 +399,7 @@ namespace
 
       CHECK(expected.size() == storage.size());
 
-      etl::bit_stream_writer bit_stream(storage.data(), storage.size(), etl::endian::big);
+      etl::bit_stream_writer bit_stream(storage.data(), storage.size(), etl::bit_order::msb_first);
 
       CHECK(bit_stream.write(uint64_t(0x0000000000000001LL)));
       CHECK_EQUAL(sizeof(uint64_t) * 1, bit_stream.used_data().size());
@@ -429,7 +429,7 @@ namespace
       std::array<int8_t, 4>              write_data = {int8_t(0x01), int8_t(0xF5), int8_t(0x05), int8_t(0xFF)}; // 1, -11, 10, -1
       std::array<char, 4>                expected   = {char(0x0D), char(0x4B), char(0xF0), char(0x00)};         // 1, -11, 10, -1
 
-      etl::bit_stream_writer bit_stream(storage.data(), storage.size(), etl::endian::big);
+      etl::bit_stream_writer bit_stream(storage.data(), storage.size(), etl::bit_order::msb_first);
 
       // Insert into the stream
       CHECK(bit_stream.write(write_data[0], 5));
@@ -455,7 +455,7 @@ namespace
       std::array<char, 4 * sizeof(int16_t)> expected   = {char(0x00), char(0x55), char(0xAA), char(0x97),
                                                           char(0xFF), char(0x00), char(0x00), char(0x00)};
 
-      etl::bit_stream_writer bit_stream(storage.data(), storage.size(), etl::endian::big);
+      etl::bit_stream_writer bit_stream(storage.data(), storage.size(), etl::bit_order::msb_first);
 
       // Insert into the stream
       CHECK(bit_stream.write(write_data[0], 10));
@@ -484,7 +484,7 @@ namespace
                                                          char(0x56), char(0xA9), char(0x7F), char(0xFF), char(0xFF), char(0x00),
                                                          char(0x00), char(0x00), char(0x00), char(0x00)};
 
-      etl::bit_stream_writer bit_stream(storage.data(), storage.size(), etl::endian::big);
+      etl::bit_stream_writer bit_stream(storage.data(), storage.size(), etl::bit_order::msb_first);
 
       // Insert into the stream
       CHECK(bit_stream.write(write_data[0], 22));
@@ -521,7 +521,7 @@ namespace
                                                           char(0xD5), char(0x2A), char(0xD5), char(0x2A), char(0xD5), char(0x2F),
                                                           char(0xFF), char(0xFF), char(0xFF), char(0xFF), char(0xFF), char(0xF0)};
 
-      etl::bit_stream_writer bit_stream(storage.data(), storage.size(), etl::endian::big);
+      etl::bit_stream_writer bit_stream(storage.data(), storage.size(), etl::bit_order::msb_first);
 
       // Insert into the stream
       bit_stream.write(write_data[0], 47);
@@ -571,7 +571,7 @@ namespace
                                                          char(0xD5), char(0x2A), char(0xD5), char(0x2A), char(0xD5), char(0x2F),
                                                          char(0xFF), char(0xFF), char(0xFF), char(0xFF), char(0xFF), char(0xF0)};
 
-      etl::bit_stream_writer bit_stream(storage.data(), storage.size(), etl::endian::big);
+      etl::bit_stream_writer bit_stream(storage.data(), storage.size(), etl::bit_order::msb_first);
 
       // Insert into the stream
       bit_stream.write(write_data[0], 47);
@@ -624,7 +624,7 @@ namespace
       std::array<char, 14> expected = {char(0x5A), char(0x12), char(0x34), char(0x89), char(0xAB), char(0xCD), char(0xEF),
                                        char(0xFE), char(0xDC), char(0xBA), char(0x98), char(0x56), char(0x78), char(0xA5)};
 
-      etl::bit_stream_writer bit_stream(storage.data(), storage.size(), etl::endian::big);
+      etl::bit_stream_writer bit_stream(storage.data(), storage.size(), etl::bit_order::msb_first);
 
       // Insert into the stream.
       bit_stream.write(c1);
@@ -670,7 +670,7 @@ namespace
       std::array<char, 14> expected = {char(0x6A), char(0x46), char(0x8A), char(0xF3), char(0x7B), char(0xDB),
                                        char(0x97), char(0x53), char(0x19), char(0xE1), char(0x28)};
 
-      etl::bit_stream_writer bit_stream(storage.data(), storage.size(), etl::endian::big);
+      etl::bit_stream_writer bit_stream(storage.data(), storage.size(), etl::bit_order::msb_first);
 
       // Insert into the stream.
       bit_stream.write(c1, 6);
@@ -718,7 +718,7 @@ namespace
 
       auto callback = etl::bit_stream_writer::callback_type::create< Accumulator, &Accumulator::Add>(accumulator);
 
-      etl::bit_stream_writer bit_stream(storage.data(), storage.size(), etl::endian::big, callback);
+      etl::bit_stream_writer bit_stream(storage.data(), storage.size(), etl::bit_order::msb_first, callback);
 
       // Insert into the stream.
       bit_stream.write(c1, 6);
@@ -754,7 +754,7 @@ namespace
       std::array<char, 12U> expected{char(0xEC), char(0xBA), char(0xDE), char(0x68), char(0xAF), char(0xD2),
                                      char(0xC5), char(0xC8), char(0x65), char(0xD3), char(0xDF), char(0x80)};
 
-      etl::bit_stream_writer bit_stream(storage.data(), storage.size(), etl::endian::big);
+      etl::bit_stream_writer bit_stream(storage.data(), storage.size(), etl::bit_order::msb_first);
 
       Object object1 = {-1234, 123456789, 250};
       Object object2 = {5678, -987654321, 126};
@@ -781,7 +781,7 @@ namespace
     {
       std::array<char, 2U> storage;
 
-      etl::bit_stream_writer bit_stream(storage.data(), storage.size(), etl::endian::big);
+      etl::bit_stream_writer bit_stream(storage.data(), storage.size(), etl::bit_order::msb_first);
 
       CHECK_EQUAL(bit_stream.empty(), true);
       CHECK_EQUAL(bit_stream.full(), false);
@@ -795,6 +795,181 @@ namespace
 
       CHECK_EQUAL(bit_stream.empty(), false);
       CHECK_EQUAL(bit_stream.full(), true);
+    }
+  }
+
+  //*************************************************************************
+  /// Tests for the separately configurable byte order (endianness).
+  /// bit_order  controls MSB/LSB-first bit ordering.
+  /// byte_order controls big/little-endian byte ordering.
+  //*************************************************************************
+  SUITE(test_bit_stream_byte_order)
+  {
+    //*************************************************************************
+    /// bit_order = big (MSB first), byte_order = little.
+    /// The value's bytes are reversed but the bit order is unchanged.
+    //*************************************************************************
+    TEST(test_write_uint16_t_little_byte_order)
+    {
+      std::array<char, sizeof(uint16_t)> storage;
+      storage.fill(0);
+      std::array<char, sizeof(uint16_t)> expected = {char(0x34), char(0x12)};
+
+      etl::bit_stream_writer bit_stream(storage.data(), storage.size(), etl::bit_order::msb_first, etl::bit_stream_writer::callback_type(),
+                                        etl::endian::little);
+
+      CHECK(bit_stream.write(uint16_t(0x1234)));
+
+      for (size_t i = 0UL; i < storage.size(); ++i)
+      {
+        CHECK_EQUAL(int(expected[i]), int(storage[i]));
+      }
+    }
+
+    //*************************************************************************
+    TEST(test_write_uint32_t_little_byte_order)
+    {
+      std::array<char, sizeof(uint32_t)> storage;
+      storage.fill(0);
+      std::array<char, sizeof(uint32_t)> expected = {char(0x78), char(0x56), char(0x34), char(0x12)};
+
+      etl::bit_stream_writer bit_stream(storage.data(), storage.size(), etl::bit_order::msb_first, etl::bit_stream_writer::callback_type(),
+                                        etl::endian::little);
+
+      CHECK(bit_stream.write(uint32_t(0x12345678)));
+
+      for (size_t i = 0UL; i < storage.size(); ++i)
+      {
+        CHECK_EQUAL(int(expected[i]), int(storage[i]));
+      }
+    }
+
+    //*************************************************************************
+    /// byte_order = big must match the default (no byte swap).
+    //*************************************************************************
+    TEST(test_write_uint16_t_big_byte_order_matches_default)
+    {
+      std::array<char, sizeof(uint16_t)> storage;
+      storage.fill(0);
+      std::array<char, sizeof(uint16_t)> expected = {char(0x12), char(0x34)};
+
+      etl::bit_stream_writer bit_stream(storage.data(), storage.size(), etl::bit_order::msb_first, etl::bit_stream_writer::callback_type(),
+                                        etl::endian::big);
+
+      CHECK(bit_stream.write(uint16_t(0x1234)));
+
+      for (size_t i = 0UL; i < storage.size(); ++i)
+      {
+        CHECK_EQUAL(int(expected[i]), int(storage[i]));
+      }
+    }
+
+    //*************************************************************************
+    /// The reader must undo the byte order applied by the writer.
+    //*************************************************************************
+    TEST(test_read_uint32_t_little_byte_order)
+    {
+      std::array<char, sizeof(uint32_t)> storage = {char(0x78), char(0x56), char(0x34), char(0x12)};
+
+      etl::bit_stream_reader bit_stream(storage.data(), storage.size(), etl::bit_order::msb_first, etl::endian::little);
+
+      etl::optional<uint32_t> result = bit_stream.read<uint32_t>();
+      CHECK(result.has_value());
+      CHECK_EQUAL(uint32_t(0x12345678), result.value());
+    }
+
+    //*************************************************************************
+    /// Round-trip writer -> reader for every combination of bit order and
+    /// byte order, for an unsigned type.
+    //*************************************************************************
+    TEST(test_round_trip_all_orders_uint16_t)
+    {
+      const etl::bit_order           bit_orders[2]  = {etl::bit_order::msb_first, etl::bit_order::lsb_first};
+      const etl::endian              byte_orders[2] = {etl::endian::big, etl::endian::little};
+      const std::array<uint16_t, 8U> values         = {uint16_t(0x0000), uint16_t(0x0001), uint16_t(0x1234), uint16_t(0x5AA5),
+                                                       uint16_t(0xA55A), uint16_t(0x00FF), uint16_t(0xFF00), uint16_t(0xFFFF)};
+
+      for (size_t b = 0UL; b < 2UL; ++b)
+      {
+        for (size_t y = 0UL; y < 2UL; ++y)
+        {
+          for (size_t v = 0UL; v < values.size(); ++v)
+          {
+            std::array<char, sizeof(uint16_t)> storage;
+            storage.fill(0);
+
+            etl::bit_stream_writer writer(storage.data(), storage.size(), bit_orders[b], etl::bit_stream_writer::callback_type(), byte_orders[y]);
+            CHECK(writer.write(values[v]));
+
+            etl::bit_stream_reader  reader(storage.data(), storage.size(), bit_orders[b], byte_orders[y]);
+            etl::optional<uint16_t> result = reader.read<uint16_t>();
+            CHECK(result.has_value());
+            CHECK_EQUAL(values[v], result.value());
+          }
+        }
+      }
+    }
+
+    //*************************************************************************
+    /// Round-trip writer -> reader for every combination of bit order and
+    /// byte order, for a signed type.
+    //*************************************************************************
+    TEST(test_round_trip_all_orders_int32_t)
+    {
+      const etl::bit_order          bit_orders[2]  = {etl::bit_order::msb_first, etl::bit_order::lsb_first};
+      const etl::endian             byte_orders[2] = {etl::endian::big, etl::endian::little};
+      const std::array<int32_t, 6U> values         = {int32_t(0x00000000), int32_t(0x00000001), int32_t(0x12345678),
+                                                      int32_t(-1234),      int32_t(-1),         int32_t(0x7FFFFFFF)};
+
+      for (size_t b = 0UL; b < 2UL; ++b)
+      {
+        for (size_t y = 0UL; y < 2UL; ++y)
+        {
+          for (size_t v = 0UL; v < values.size(); ++v)
+          {
+            std::array<char, sizeof(int32_t)> storage;
+            storage.fill(0);
+
+            etl::bit_stream_writer writer(storage.data(), storage.size(), bit_orders[b], etl::bit_stream_writer::callback_type(), byte_orders[y]);
+            CHECK(writer.write(values[v]));
+
+            etl::bit_stream_reader reader(storage.data(), storage.size(), bit_orders[b], byte_orders[y]);
+            etl::optional<int32_t> result = reader.read<int32_t>();
+            CHECK(result.has_value());
+            CHECK_EQUAL(values[v], result.value());
+          }
+        }
+      }
+    }
+
+    //*************************************************************************
+    /// Byte order is only meaningful for full-width values, so it has no
+    /// effect on a sub-width field. The data must still round-trip.
+    //*************************************************************************
+    TEST(test_byte_order_ignored_for_sub_width_write)
+    {
+      std::array<char, sizeof(uint16_t)> storage_big;
+      std::array<char, sizeof(uint16_t)> storage_little;
+      storage_big.fill(0);
+      storage_little.fill(0);
+
+      etl::bit_stream_writer writer_big(storage_big.data(), storage_big.size(), etl::bit_order::msb_first, etl::bit_stream_writer::callback_type(),
+                                        etl::endian::big);
+      etl::bit_stream_writer writer_little(storage_little.data(), storage_little.size(), etl::bit_order::msb_first,
+                                           etl::bit_stream_writer::callback_type(), etl::endian::little);
+
+      CHECK(writer_big.write(uint16_t(0x0ABC), 12));
+      CHECK(writer_little.write(uint16_t(0x0ABC), 12));
+
+      for (size_t i = 0UL; i < storage_big.size(); ++i)
+      {
+        CHECK_EQUAL(int(storage_big[i]), int(storage_little[i]));
+      }
+
+      etl::bit_stream_reader  reader(storage_little.data(), storage_little.size(), etl::bit_order::msb_first, etl::endian::little);
+      etl::optional<uint16_t> result = reader.read<uint16_t>(12);
+      CHECK(result.has_value());
+      CHECK_EQUAL(uint16_t(0x0ABC), result.value());
     }
   }
 } // namespace

--- a/test/test_bit_stream_writer_little_endian.cpp
+++ b/test/test_bit_stream_writer_little_endian.cpp
@@ -119,7 +119,7 @@ namespace
     {
       std::array<char, 256> storage;
 
-      etl::bit_stream_writer bit_stream(storage.data(), storage.size(), etl::endian::little);
+      etl::bit_stream_writer bit_stream(storage.data(), storage.size(), etl::bit_order::lsb_first);
 
       CHECK_EQUAL(storage.size(), bit_stream.available(CHAR_BIT));
       CHECK_EQUAL(storage.size(), bit_stream.available<CHAR_BIT>());
@@ -140,7 +140,7 @@ namespace
       unsigned char storage  = 0;
       unsigned char expected = 0x5AU;
 
-      etl::bit_stream_writer bit_stream(&storage, 1U, etl::endian::little);
+      etl::bit_stream_writer bit_stream(&storage, 1U, etl::bit_order::lsb_first);
 
       CHECK(bit_stream.write(false));
       CHECK_EQUAL(1U, bit_stream.used_data().size());
@@ -176,7 +176,7 @@ namespace
       std::array<char, 256U> expected;
       std::iota(expected.begin(), expected.end(), 0);
 
-      etl::bit_stream_writer bit_stream(storage.data(), storage.size(), etl::endian::little);
+      etl::bit_stream_writer bit_stream(storage.data(), storage.size(), etl::bit_order::lsb_first);
 
       for (size_t i = 0UL; i < 256UL; ++i)
       {
@@ -204,7 +204,7 @@ namespace
       std::array<char, 256> expected;
       std::iota(expected.begin(), expected.end(), 0);
 
-      etl::bit_stream_writer bit_stream(storage.data(), storage.size(), etl::endian::little);
+      etl::bit_stream_writer bit_stream(storage.data(), storage.size(), etl::bit_order::lsb_first);
 
       for (size_t i = 0UL; i < 256UL; ++i)
       {
@@ -233,7 +233,7 @@ namespace
 
       CHECK(expected.size() == storage.size());
 
-      etl::bit_stream_writer bit_stream(storage.data(), storage.size(), etl::endian::little);
+      etl::bit_stream_writer bit_stream(storage.data(), storage.size(), etl::bit_order::lsb_first);
 
       CHECK(bit_stream.write(int16_t(0x0001)));
       CHECK_EQUAL(sizeof(int16_t) * 1, bit_stream.used_data().size());
@@ -265,7 +265,7 @@ namespace
 
       CHECK(expected.size() == storage.size());
 
-      etl::bit_stream_writer bit_stream(storage.data(), storage.size(), etl::endian::little);
+      etl::bit_stream_writer bit_stream(storage.data(), storage.size(), etl::bit_order::lsb_first);
 
       CHECK(bit_stream.write(uint16_t(0x0001)));
       CHECK_EQUAL(sizeof(uint16_t) * 1, bit_stream.used_data().size());
@@ -298,7 +298,7 @@ namespace
 
       CHECK(expected.size() == storage.size());
 
-      etl::bit_stream_writer bit_stream(storage.data(), storage.size(), etl::endian::little);
+      etl::bit_stream_writer bit_stream(storage.data(), storage.size(), etl::bit_order::lsb_first);
 
       CHECK(bit_stream.write(int32_t(0x00000001)));
       CHECK_EQUAL(sizeof(int32_t) * 1, bit_stream.used_data().size());
@@ -331,7 +331,7 @@ namespace
 
       CHECK(expected.size() == storage.size());
 
-      etl::bit_stream_writer bit_stream(storage.data(), storage.size(), etl::endian::little);
+      etl::bit_stream_writer bit_stream(storage.data(), storage.size(), etl::bit_order::lsb_first);
 
       CHECK(bit_stream.write(uint32_t(0x00000001)));
       CHECK_EQUAL(sizeof(uint32_t) * 1, bit_stream.used_data().size());
@@ -365,7 +365,7 @@ namespace
 
       CHECK(expected.size() == storage.size());
 
-      etl::bit_stream_writer bit_stream(storage.data(), storage.size(), etl::endian::little);
+      etl::bit_stream_writer bit_stream(storage.data(), storage.size(), etl::bit_order::lsb_first);
 
       CHECK(bit_stream.write(int64_t(0x0000000000000001LL)));
       CHECK_EQUAL(sizeof(int64_t) * 1, bit_stream.used_data().size());
@@ -399,7 +399,7 @@ namespace
 
       CHECK(expected.size() == storage.size());
 
-      etl::bit_stream_writer bit_stream(storage.data(), storage.size(), etl::endian::little);
+      etl::bit_stream_writer bit_stream(storage.data(), storage.size(), etl::bit_order::lsb_first);
 
       CHECK(bit_stream.write(uint64_t(0x0000000000000001LL)));
       CHECK_EQUAL(sizeof(uint64_t) * 1, bit_stream.used_data().size());
@@ -429,7 +429,7 @@ namespace
       std::array<int8_t, 4>              write_data = {int8_t(0x01), int8_t(0xF5), int8_t(0x05), int8_t(0xFF)}; // 1, -11, 10, -1
       std::array<char, 4>                expected   = {char(0x85), char(0x69), char(0xF0), char(0x00)};         // 1, -11, 10, -1
 
-      etl::bit_stream_writer bit_stream(storage.data(), storage.size(), etl::endian::little);
+      etl::bit_stream_writer bit_stream(storage.data(), storage.size(), etl::bit_order::lsb_first);
 
       // Insert into the stream
       CHECK(bit_stream.write(write_data[0], 5));
@@ -454,7 +454,7 @@ namespace
       std::array<uint8_t, 4>             write_data = {uint8_t(0x01), uint8_t(0xF5), uint8_t(0x05), uint8_t(0xFF)}; // 1, -11, 10, -1
       std::array<char, 4>                expected   = {char(0x85), char(0x69), char(0xF0), char(0x00)};             // 1, -11, 10, -1
 
-      etl::bit_stream_writer bit_stream(storage.data(), storage.size(), etl::endian::little);
+      etl::bit_stream_writer bit_stream(storage.data(), storage.size(), etl::bit_order::lsb_first);
 
       // Insert into the stream
       CHECK(bit_stream.write(write_data[0], 5));
@@ -480,7 +480,7 @@ namespace
       std::array<char, 4 * sizeof(int16_t)> expected   = {char(0x80), char(0x16), char(0xAA), char(0x57),
                                                           char(0xFF), char(0x00), char(0x00), char(0x00)};
 
-      etl::bit_stream_writer bit_stream(storage.data(), storage.size(), etl::endian::little);
+      etl::bit_stream_writer bit_stream(storage.data(), storage.size(), etl::bit_order::lsb_first);
 
       // Insert into the stream
       CHECK(bit_stream.write(write_data[0], 10));
@@ -508,7 +508,7 @@ namespace
       std::array<char, 4 * sizeof(uint16_t)> expected   = {char(0x80), char(0x16), char(0xAA), char(0x57),
                                                            char(0xFF), char(0x00), char(0x00), char(0x00)};
 
-      etl::bit_stream_writer bit_stream(storage.data(), storage.size(), etl::endian::little);
+      etl::bit_stream_writer bit_stream(storage.data(), storage.size(), etl::bit_order::lsb_first);
 
       // Insert into the stream
       CHECK(bit_stream.write(write_data[0], 10));
@@ -537,7 +537,7 @@ namespace
                                                          char(0x55), char(0xAA), char(0x7F), char(0xFF), char(0xFF), char(0x00),
                                                          char(0x00), char(0x00), char(0x00), char(0x00)};
 
-      etl::bit_stream_writer bit_stream(storage.data(), storage.size(), etl::endian::little);
+      etl::bit_stream_writer bit_stream(storage.data(), storage.size(), etl::bit_order::lsb_first);
 
       // Insert into the stream
       CHECK(bit_stream.write(write_data[0], 22));
@@ -572,7 +572,7 @@ namespace
                                                          char(0x55), char(0xAA), char(0x7F), char(0xFF), char(0xFF), char(0x00),
                                                          char(0x00), char(0x00), char(0x00), char(0x00)};
 
-      etl::bit_stream_writer bit_stream(storage.data(), storage.size(), etl::endian::little);
+      etl::bit_stream_writer bit_stream(storage.data(), storage.size(), etl::bit_order::lsb_first);
 
       // Insert into the stream
       CHECK(bit_stream.write(write_data[0], 22));
@@ -609,7 +609,7 @@ namespace
                                                           char(0x95), char(0x6A), char(0x95), char(0x6A), char(0x95), char(0x6F),
                                                           char(0xFF), char(0xFF), char(0xFF), char(0xFF), char(0xFF), char(0xF0)};
 
-      etl::bit_stream_writer bit_stream(storage.data(), storage.size(), etl::endian::little);
+      etl::bit_stream_writer bit_stream(storage.data(), storage.size(), etl::bit_order::lsb_first);
 
       // Insert into the stream
       bit_stream.write(write_data[0], 47);
@@ -659,7 +659,7 @@ namespace
                                                          char(0x95), char(0x6A), char(0x95), char(0x6A), char(0x95), char(0x6F),
                                                          char(0xFF), char(0xFF), char(0xFF), char(0xFF), char(0xFF), char(0xF0)};
 
-      etl::bit_stream_writer bit_stream(storage.data(), storage.size(), etl::endian::little);
+      etl::bit_stream_writer bit_stream(storage.data(), storage.size(), etl::bit_order::lsb_first);
 
       // Insert into the stream
       bit_stream.write(write_data[0], 47);
@@ -712,7 +712,7 @@ namespace
       std::array<char, 14> expected = {char(0x5A), char(0x2C), char(0x48), char(0xF7), char(0xB3), char(0xD5), char(0x91),
                                        char(0x19), char(0x5D), char(0x3B), char(0x7F), char(0x1E), char(0x6A), char(0xA5)};
 
-      etl::bit_stream_writer bit_stream(storage.data(), storage.size(), etl::endian::little);
+      etl::bit_stream_writer bit_stream(storage.data(), storage.size(), etl::bit_order::lsb_first);
 
       // Insert into the stream.
       bit_stream.write(c1);
@@ -758,7 +758,7 @@ namespace
       std::array<char, 14> expected = {char(0x58), char(0xB1), char(0x3E), char(0xF6), char(0x7A), char(0x86),
                                        char(0x57), char(0x4E), char(0xC3), char(0xCE), char(0x90)};
 
-      etl::bit_stream_writer bit_stream(storage.data(), storage.size(), etl::endian::little);
+      etl::bit_stream_writer bit_stream(storage.data(), storage.size(), etl::bit_order::lsb_first);
 
       // Insert into the stream.
       bit_stream.write(c1, 6);
@@ -805,7 +805,7 @@ namespace
 
       auto callback = etl::bit_stream_writer::callback_type::create< Accumulator, &Accumulator::Add>(accumulator);
 
-      etl::bit_stream_writer bit_stream(storage.data(), storage.size(), etl::endian::little, callback);
+      etl::bit_stream_writer bit_stream(storage.data(), storage.size(), etl::bit_order::lsb_first, callback);
 
       // Insert into the stream.
       bit_stream.write(c1, 6);
@@ -841,7 +841,7 @@ namespace
       std::array<char, 12U> expected{char(0x74), char(0xDE), char(0xA2), char(0xCF), char(0x6A), char(0xFB),
                                      char(0xA3), char(0x5E), char(0x5D), char(0x30), char(0x9F), char(0x80)};
 
-      etl::bit_stream_writer bit_stream(storage.data(), storage.size(), etl::endian::little);
+      etl::bit_stream_writer bit_stream(storage.data(), storage.size(), etl::bit_order::lsb_first);
 
       Object object1 = {-1234, 123456789, 250};
       Object object2 = {5678, -987654321, 126};
@@ -868,7 +868,7 @@ namespace
     {
       std::array<char, 2U> storage;
 
-      etl::bit_stream_writer bit_stream(storage.data(), storage.size(), etl::endian::little);
+      etl::bit_stream_writer bit_stream(storage.data(), storage.size(), etl::bit_order::lsb_first);
 
       CHECK_EQUAL(bit_stream.empty(), true);
       CHECK_EQUAL(bit_stream.full(), false);


### PR DESCRIPTION
No const variant is implemented for the operator[]. Trying to use it on a const reference fails: https://godbolt.org/z/YjGone9oj