### PR TITLE
fix(devcontainer): resolve missing packages in bullseye image

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -36,13 +36,12 @@ RUN set -eux \
     && apt-get -y install --no-install-recommends \
         python3-full \
         python3-pip \
-        python3-cogapp \
         git \
         wget \
         cmake \
         clang-format \
-        clang-format-18 \
         lcov \
+    && python3 -m pip install --no-cache-dir cogapp \
     && rm -rf /var/lib/apt/lists/*
 
 RUN set -eux; \


### PR DESCRIPTION
This PR fixes devcontainer provisioning on Debian Bullseye by removing unavailable apt packages and installing `cogapp` in a distro-independent way.

**What changed**
* Updated Dockerfile to:
  * Remove `python3-cogapp` from `apt-get install` (not available on Bullseye)
  * Remove `clang-format-18` from `apt-get install` (not available on Bullseye)
  * Keep `clang-format` installation via apt
  * Add `python3 -m pip install --no-cache-dir cogapp`

**Why**
The previous package list referenced Bullseye-unavailable packages, causing `clang:18` to `clang:21` devcontainer setup failures. Installing cogapp via pip avoids distro package availability issues.

**Impact**
* Devcontainer builds succeed on Bullseye.
* Existing tool/version verification behavior is preserved.