### PR TITLE
Fix delegate clear through assignment

### DIFF
--- a/include/etl/private/delegate_cpp11.h
+++ b/include/etl/private/delegate_cpp11.h
@@ -690,6 +690,14 @@ namespace etl
       //***********************************************************************
       ETL_CONSTEXPR14 void clear() ETL_NOEXCEPT
       {
+        if (stub == function_ptr_stub)
+        {
+          ptr.fp = ETL_NULLPTR;
+        }
+        else
+        {
+          ptr.object = ETL_NULLPTR;
+        }
         stub = ETL_NULLPTR;
       }
 

--- a/test/test_delegate.cpp
+++ b/test/test_delegate.cpp
@@ -2167,6 +2167,20 @@ namespace
     #endif
     }
   #endif
+
+    TEST(test_delegate_clear_equals_default_constructed)
+    {
+      using delegate_type = etl::delegate<void(int, int)>;
+
+      delegate_type       delegate = {};
+      const delegate_type default_constructed;
+
+      CHECK(delegate == default_constructed);
+      delegate = delegate_type::create(free_int);
+      CHECK(delegate != default_constructed);
+      delegate = {};
+      CHECK(delegate == default_constructed);
+    }
   }
 } // namespace
 


### PR DESCRIPTION
Because the ptr was not nulled, it did not compare equal to a default constructed delegate anymore.