### PR TITLE
Adopt the Library Fundamentals TS `make_array` design for the sequence factories

### DIFF
--- a/docs/containers/arrays/array.md
+++ b/docs/containers/arrays/array.md
@@ -43,7 +43,10 @@ constexpr auto make_array(TValues&&... values) -> etl::array</*element-type*/, s
 ```
 
 The element type is `T` when supplied, otherwise the decayed common type of
-the arguments (the Library Fundamentals TS `make_array` design).
+the arguments (the Library Fundamentals TS `make_array` design). An empty
+array requires the element type to be supplied explicitly, e.g.
+`etl::make_array<int>()`; a call with neither an element type nor arguments
+is ill-formed, as there is nothing to deduce the element type from.
 
 ### Example
 ```cpp

--- a/docs/containers/arrays/array.md
+++ b/docs/containers/arrays/array.md
@@ -38,13 +38,20 @@ Defines data as an array of 'int', of length '10', containing the supplied data.
 **C++11 and above**
 
 ```cpp
-template <typename T, typename... TValues>
-constexpr auto make_array(TValues&&... values) -> etl::array<T, sizeof...(TValues)>
+template <typename T = void, typename... TValues>
+constexpr auto make_array(TValues&&... values) -> etl::array<etl::private_make::element_type_t<T, TValues...>, sizeof...(TValues)>
 ```
+
+The element type is `T` when supplied, otherwise the decayed common type of
+the arguments (the Library Fundamentals TS `make_array` design).
 
 ### Example
 ```cpp
-auto data = etl::make_array<int>(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
+// Deduced element type: etl::array<int, 10>.
+auto data = etl::make_array(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
+
+// Explicit element type: etl::array<char, 10>. Each argument is converted.
+auto chars = etl::make_array<char>(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
 ```
 
 ## Member types

--- a/docs/containers/arrays/array.md
+++ b/docs/containers/arrays/array.md
@@ -39,7 +39,7 @@ Defines data as an array of 'int', of length '10', containing the supplied data.
 
 ```cpp
 template <typename T = void, typename... TValues>
-constexpr auto make_array(TValues&&... values) -> etl::array<etl::private_make::element_type_t<T, TValues...>, sizeof...(TValues)>
+constexpr auto make_array(TValues&&... values) -> etl::array</*element-type*/, sizeof...(TValues)>
 ```
 
 The element type is `T` when supplied, otherwise the decayed common type of

--- a/docs/containers/lists/forward-list.md
+++ b/docs/containers/lists/forward-list.md
@@ -65,15 +65,20 @@ Defines data as an `forward_list` of int, of length 10, containing the supplied 
 ## Make template
 **C++11 and above**  
 ```cpp
-template <typename... T>
-constexpr auto make_forward_list(T&&... t) -> etl::forward_list<typename etl::common_type_t<T...>, sizeof...(T)>
+template <typename T = void, typename... TValues>
+constexpr auto make_forward_list(TValues&&... values) -> etl::forward_list<etl::private_make::element_type_t<T, TValues...>, sizeof...(TValues)>
 ```
 
-The element type is deduced as the common type of the arguments.
+The element type is `T` when supplied, otherwise the decayed common type of
+the arguments (the Library Fundamentals TS `make_array` design).
 
 ### Example
 ```cpp
+// Deduced element type: etl::forward_list<int, 10>.
 auto data = etl::make_forward_list(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
+
+// Explicit element type: etl::forward_list<char, 10>. Each argument is converted.
+auto chars = etl::make_forward_list<char>(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
 ```
 
 ## Member types

--- a/docs/containers/lists/forward-list.md
+++ b/docs/containers/lists/forward-list.md
@@ -66,7 +66,7 @@ Defines data as an `forward_list` of int, of length 10, containing the supplied 
 **C++11 and above**  
 ```cpp
 template <typename T = void, typename... TValues>
-constexpr auto make_forward_list(TValues&&... values) -> etl::forward_list<etl::private_make::element_type_t<T, TValues...>, sizeof...(TValues)>
+constexpr auto make_forward_list(TValues&&... values) -> etl::forward_list</*element-type*/, sizeof...(TValues)>
 ```
 
 The element type is `T` when supplied, otherwise the decayed common type of

--- a/docs/containers/lists/list.md
+++ b/docs/containers/lists/list.md
@@ -69,15 +69,20 @@ Defines data as an list of `int`, of length `10`, containing the supplied data.
 ## Make template
 **C++11 and above**  
 ```cpp
-template <typename... T>
-constexpr auto make_list(T&&... t) -> etl::list<typename etl::common_type_t<T...>, sizeof...(T)>
+template <typename T = void, typename... TValues>
+constexpr auto make_list(TValues&&... values) -> etl::list<etl::private_make::element_type_t<T, TValues...>, sizeof...(TValues)>
 ```
 
-The element type is deduced as the common type of the arguments.
+The element type is `T` when supplied, otherwise the decayed common type of
+the arguments (the Library Fundamentals TS `make_array` design).
 
 ### Example
 ```cpp
+// Deduced element type: etl::list<int, 10>.
 auto data = etl::make_list(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
+
+// Explicit element type: etl::list<char, 10>. Each argument is converted.
+auto chars = etl::make_list<char>(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
 ```
 
 ## Member types

--- a/docs/containers/lists/list.md
+++ b/docs/containers/lists/list.md
@@ -70,7 +70,7 @@ Defines data as an list of `int`, of length `10`, containing the supplied data.
 **C++11 and above**  
 ```cpp
 template <typename T = void, typename... TValues>
-constexpr auto make_list(TValues&&... values) -> etl::list<etl::private_make::element_type_t<T, TValues...>, sizeof...(TValues)>
+constexpr auto make_list(TValues&&... values) -> etl::list</*element-type*/, sizeof...(TValues)>
 ```
 
 The element type is `T` when supplied, otherwise the decayed common type of

--- a/docs/containers/queues & stacks/deque.md
+++ b/docs/containers/queues & stacks/deque.md
@@ -34,13 +34,20 @@ Defines data as an `deque` of `int`, of length `10`, containing the supplied dat
 ## Make template
 **C++11 and above**
 ```cpp
-template <typename T, typename... TValues>
-constexpr auto make_deque(TValues&&... values) -> etl::deque<T, sizeof...(TValues)>
+template <typename T = void, typename... TValues>
+constexpr auto make_deque(TValues&&... values) -> etl::deque<etl::private_make::element_type_t<T, TValues...>, sizeof...(TValues)>
 ```
+
+The element type is `T` when supplied, otherwise the decayed common type of
+the arguments (the Library Fundamentals TS `make_array` design).
 
 ### Example
 ```cpp
-auto data = etl::make_deque<int>(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
+// Deduced element type: etl::deque<int, 10>.
+auto data = etl::make_deque(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
+
+// Explicit element type: etl::deque<char, 10>. Each argument is converted.
+auto chars = etl::make_deque<char>(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
 ```
 
 ## Member types

--- a/docs/containers/queues & stacks/deque.md
+++ b/docs/containers/queues & stacks/deque.md
@@ -35,7 +35,7 @@ Defines data as an `deque` of `int`, of length `10`, containing the supplied dat
 **C++11 and above**
 ```cpp
 template <typename T = void, typename... TValues>
-constexpr auto make_deque(TValues&&... values) -> etl::deque<etl::private_make::element_type_t<T, TValues...>, sizeof...(TValues)>
+constexpr auto make_deque(TValues&&... values) -> etl::deque</*element-type*/, sizeof...(TValues)>
 ```
 
 The element type is `T` when supplied, otherwise the decayed common type of

--- a/docs/containers/vectors/indirect-vector.md
+++ b/docs/containers/vectors/indirect-vector.md
@@ -42,6 +42,26 @@ etl::indirect_vector data{ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
 ```
 Defines data as an `indirect_vector` of `int`, of length `10`, containing the supplied data.
 
+## Make template
+**C++11 and above**
+```cpp
+template <typename T = void, typename... TValues>
+constexpr auto make_indirect_vector(TValues&&... values)
+  -> etl::indirect_vector<etl::private_make::element_type_t<T, TValues...>, sizeof...(TValues)>
+```
+
+The element type is `T` when supplied, otherwise the decayed common type of
+the arguments (the Library Fundamentals TS `make_array` design).
+
+### Example
+```cpp
+// Deduced element type: etl::indirect_vector<int, 10>.
+auto data = etl::make_indirect_vector(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
+
+// Explicit element type: etl::indirect_vector<char, 10>. Each argument is converted.
+auto chars = etl::make_indirect_vector<char>(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
+```
+
 ## Member types
 
 ```cpp

--- a/docs/containers/vectors/indirect-vector.md
+++ b/docs/containers/vectors/indirect-vector.md
@@ -47,7 +47,7 @@ Defines data as an `indirect_vector` of `int`, of length `10`, containing the su
 ```cpp
 template <typename T = void, typename... TValues>
 constexpr auto make_indirect_vector(TValues&&... values)
-  -> etl::indirect_vector<etl::private_make::element_type_t<T, TValues...>, sizeof...(TValues)>
+  -> etl::indirect_vector</*element-type*/, sizeof...(TValues)>
 ```
 
 The element type is `T` when supplied, otherwise the decayed common type of

--- a/docs/containers/vectors/vector.md
+++ b/docs/containers/vectors/vector.md
@@ -54,6 +54,25 @@ etl::vector data{ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
 
 Defines data as an vector of int, of length 10, containing the supplied data.
 
+## Make template
+**C++11 and above**
+```cpp
+template <typename T = void, typename... TValues>
+constexpr auto make_vector(TValues&&... values) -> etl::vector<etl::private_make::element_type_t<T, TValues...>, sizeof...(TValues)>
+```
+
+The element type is `T` when supplied, otherwise the decayed common type of
+the arguments (the Library Fundamentals TS `make_array` design).
+
+### Example
+```cpp
+// Deduced element type: etl::vector<int, 10>.
+auto data = etl::make_vector(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
+
+// Explicit element type: etl::vector<char, 10>. Each argument is converted.
+auto chars = etl::make_vector<char>(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
+```
+
 ## Member types
 
 ```cpp

--- a/docs/containers/vectors/vector.md
+++ b/docs/containers/vectors/vector.md
@@ -58,7 +58,7 @@ Defines data as an vector of int, of length 10, containing the supplied data.
 **C++11 and above**
 ```cpp
 template <typename T = void, typename... TValues>
-constexpr auto make_vector(TValues&&... values) -> etl::vector<etl::private_make::element_type_t<T, TValues...>, sizeof...(TValues)>
+constexpr auto make_vector(TValues&&... values) -> etl::vector</*element-type*/, sizeof...(TValues)>
 ```
 
 The element type is `T` when supplied, otherwise the decayed common type of

--- a/include/etl/array.h
+++ b/include/etl/array.h
@@ -1053,16 +1053,17 @@ namespace etl
   /// Make
   //*************************************************************************
 #if ETL_HAS_INITIALIZER_LIST
-  template <typename T, typename... TValues>
-  constexpr auto make_array(TValues&&... values) ETL_NOEXCEPT -> etl::array<T, sizeof...(TValues)>
+  template <typename T = void, typename... TValues>
+  constexpr auto make_array(TValues&&... values) ETL_NOEXCEPT -> etl::array<etl::private_make::element_type_t<T, TValues...>, sizeof...(TValues)>
   {
-    // Forward each argument as its own deduced type, then convert explicitly to T.
-    // Forwarding as T (the old behaviour) made the call ill-formed for any const-qualified
-    // lvalue of type T: forward<T> requires a non-const T&, and a T&& cannot bind to a
-    // reference-related const lvalue. The explicit conversion also keeps narrowing
-    // initialisers (e.g. make_array<char>(0, 1)) working, which plain forwarding into the
-    // braced initialiser list would reject.
-    return {static_cast<T>(etl::forward<TValues>(values))...};
+    // Library Fundamentals TS make_array design: the element type is T when
+    // supplied explicitly, otherwise the decayed common type of the arguments.
+    // Each argument is forwarded as its own deduced type and converted
+    // explicitly, which accepts const-qualified lvalues (forwarding as the
+    // element type rejected them) and keeps narrowing initialisers such as
+    // make_array<char>(0, 1) working.
+    using TElement = etl::private_make::element_type_t<T, TValues...>;
+    return {static_cast<TElement>(etl::forward<TValues>(values))...};
   }
 #endif
 

--- a/include/etl/array.h
+++ b/include/etl/array.h
@@ -1054,16 +1054,16 @@ namespace etl
   //*************************************************************************
 #if ETL_HAS_INITIALIZER_LIST
   template <typename T = void, typename... TValues>
-  constexpr auto make_array(TValues&&... values) ETL_NOEXCEPT -> etl::array<etl::private_make::element_type_t<T, TValues...>, sizeof...(TValues)>
+  constexpr auto make_array(TValues&&... values) -> etl::array<etl::private_make::element_type_t<T, TValues...>, sizeof...(TValues)>
   {
     // Library Fundamentals TS make_array design: the element type is T when
     // supplied explicitly, otherwise the decayed common type of the arguments.
-    // Each argument is forwarded as its own deduced type and converted
-    // explicitly, which accepts const-qualified lvalues (forwarding as the
-    // element type rejected them) and keeps narrowing initialisers such as
-    // make_array<char>(0, 1) working.
+    // convert forwards arguments that already have the element type and
+    // converts the rest with static_cast, so const-qualified lvalues,
+    // narrowing initialisers such as make_array<char>(0, 1) and non-movable
+    // element types all work.
     using TElement = etl::private_make::element_type_t<T, TValues...>;
-    return {static_cast<TElement>(etl::forward<TValues>(values))...};
+    return {etl::private_make::convert<TElement>(etl::forward<TValues>(values))...};
   }
 #endif
 

--- a/include/etl/deque.h
+++ b/include/etl/deque.h
@@ -2532,16 +2532,17 @@ namespace etl
   /// Make
   //*************************************************************************
 #if ETL_USING_CPP11 && ETL_HAS_INITIALIZER_LIST
-  template <typename T, typename... TValues>
-  constexpr auto make_deque(TValues&&... values) -> etl::deque<T, sizeof...(TValues)>
+  template <typename T = void, typename... TValues>
+  constexpr auto make_deque(TValues&&... values) -> etl::deque<etl::private_make::element_type_t<T, TValues...>, sizeof...(TValues)>
   {
-    // Forward each argument as its own deduced type, then convert explicitly to T.
-    // Forwarding as T (the old behaviour) made the call ill-formed for any const-qualified
-    // lvalue of type T: forward<T> requires a non-const T&, and a T&& cannot bind to a
-    // reference-related const lvalue. The explicit conversion also keeps narrowing
-    // initialisers (e.g. make_deque<char>(0, 1)) working, which plain forwarding into the
-    // braced initialiser list would reject.
-    return {static_cast<T>(etl::forward<TValues>(values))...};
+    // Library Fundamentals TS make_array design: the element type is T when
+    // supplied explicitly, otherwise the decayed common type of the arguments.
+    // Each argument is forwarded as its own deduced type and converted
+    // explicitly, which accepts const-qualified lvalues (forwarding as the
+    // element type rejected them) and keeps narrowing initialisers such as
+    // make_deque<char>(0, 1) working.
+    using TElement = etl::private_make::element_type_t<T, TValues...>;
+    return {static_cast<TElement>(etl::forward<TValues>(values))...};
   }
 #endif
 

--- a/include/etl/deque.h
+++ b/include/etl/deque.h
@@ -2537,12 +2537,12 @@ namespace etl
   {
     // Library Fundamentals TS make_array design: the element type is T when
     // supplied explicitly, otherwise the decayed common type of the arguments.
-    // Each argument is forwarded as its own deduced type and converted
-    // explicitly, which accepts const-qualified lvalues (forwarding as the
-    // element type rejected them) and keeps narrowing initialisers such as
-    // make_deque<char>(0, 1) working.
+    // convert forwards arguments that already have the element type and
+    // converts the rest with static_cast, so const-qualified lvalues,
+    // narrowing initialisers such as make_deque<char>(0, 1) and non-movable
+    // element types all work.
     using TElement = etl::private_make::element_type_t<T, TValues...>;
-    return {static_cast<TElement>(etl::forward<TValues>(values))...};
+    return {etl::private_make::convert<TElement>(etl::forward<TValues>(values))...};
   }
 #endif
 

--- a/include/etl/forward_list.h
+++ b/include/etl/forward_list.h
@@ -1793,10 +1793,13 @@ namespace etl
   /// Make
   //*************************************************************************
 #if ETL_USING_CPP11 && ETL_HAS_INITIALIZER_LIST
-  template <typename... T>
-  constexpr auto make_forward_list(T&&... t) -> etl::forward_list<typename etl::common_type_t<T...>, sizeof...(T)>
+  template <typename T = void, typename... TValues>
+  constexpr auto make_forward_list(TValues&&... values) -> etl::forward_list<etl::private_make::element_type_t<T, TValues...>, sizeof...(TValues)>
   {
-    return {etl::forward<T>(t)...};
+    // Library Fundamentals TS make_array design: the element type is T when
+    // supplied explicitly, otherwise the decayed common type of the arguments.
+    using TElement = etl::private_make::element_type_t<T, TValues...>;
+    return {static_cast<TElement>(etl::forward<TValues>(values))...};
   }
 #endif
 

--- a/include/etl/forward_list.h
+++ b/include/etl/forward_list.h
@@ -1798,8 +1798,9 @@ namespace etl
   {
     // Library Fundamentals TS make_array design: the element type is T when
     // supplied explicitly, otherwise the decayed common type of the arguments.
+    // convert forwards same-type arguments and static_casts the rest.
     using TElement = etl::private_make::element_type_t<T, TValues...>;
-    return {static_cast<TElement>(etl::forward<TValues>(values))...};
+    return {etl::private_make::convert<TElement>(etl::forward<TValues>(values))...};
   }
 #endif
 

--- a/include/etl/indirect_vector.h
+++ b/include/etl/indirect_vector.h
@@ -1551,10 +1551,14 @@ namespace etl
   /// Make
   //*************************************************************************
 #if ETL_USING_CPP11 && ETL_HAS_INITIALIZER_LIST
-  template <typename... T>
-  constexpr auto make_indirect_vector(T&&... t) -> etl::indirect_vector<typename etl::common_type_t<T...>, sizeof...(T)>
+  template <typename T = void, typename... TValues>
+  constexpr auto
+    make_indirect_vector(TValues&&... values) -> etl::indirect_vector<etl::private_make::element_type_t<T, TValues...>, sizeof...(TValues)>
   {
-    return {etl::forward<T>(t)...};
+    // Library Fundamentals TS make_array design: the element type is T when
+    // supplied explicitly, otherwise the decayed common type of the arguments.
+    using TElement = etl::private_make::element_type_t<T, TValues...>;
+    return {static_cast<TElement>(etl::forward<TValues>(values))...};
   }
 #endif
 

--- a/include/etl/indirect_vector.h
+++ b/include/etl/indirect_vector.h
@@ -1557,8 +1557,9 @@ namespace etl
   {
     // Library Fundamentals TS make_array design: the element type is T when
     // supplied explicitly, otherwise the decayed common type of the arguments.
+    // convert forwards same-type arguments and static_casts the rest.
     using TElement = etl::private_make::element_type_t<T, TValues...>;
-    return {static_cast<TElement>(etl::forward<TValues>(values))...};
+    return {etl::private_make::convert<TElement>(etl::forward<TValues>(values))...};
   }
 #endif
 

--- a/include/etl/list.h
+++ b/include/etl/list.h
@@ -2218,10 +2218,13 @@ namespace etl
   /// Make
   //*************************************************************************
 #if ETL_USING_CPP11 && ETL_HAS_INITIALIZER_LIST
-  template <typename... T>
-  constexpr auto make_list(T&&... t) -> etl::list<typename etl::common_type_t<T...>, sizeof...(T)>
+  template <typename T = void, typename... TValues>
+  constexpr auto make_list(TValues&&... values) -> etl::list<etl::private_make::element_type_t<T, TValues...>, sizeof...(TValues)>
   {
-    return {etl::forward<T>(t)...};
+    // Library Fundamentals TS make_array design: the element type is T when
+    // supplied explicitly, otherwise the decayed common type of the arguments.
+    using TElement = etl::private_make::element_type_t<T, TValues...>;
+    return {static_cast<TElement>(etl::forward<TValues>(values))...};
   }
 #endif
 

--- a/include/etl/list.h
+++ b/include/etl/list.h
@@ -2223,8 +2223,9 @@ namespace etl
   {
     // Library Fundamentals TS make_array design: the element type is T when
     // supplied explicitly, otherwise the decayed common type of the arguments.
+    // convert forwards same-type arguments and static_casts the rest.
     using TElement = etl::private_make::element_type_t<T, TValues...>;
-    return {static_cast<TElement>(etl::forward<TValues>(values))...};
+    return {etl::private_make::convert<TElement>(etl::forward<TValues>(values))...};
   }
 #endif
 

--- a/include/etl/type_traits.h
+++ b/include/etl/type_traits.h
@@ -3753,13 +3753,14 @@ namespace etl
   using common_type_t = typename common_type<T...>::type;
 
   //***********************************
-  // Selects the element type for the make_xxx container factories, following
-  // the Library Fundamentals TS make_array design: TDesired if it was supplied
-  // explicitly, otherwise the decayed common type of the arguments. The
-  // specialisation keeps common_type uninstantiated when TDesired is supplied,
-  // so arguments with no common type are still accepted in that case.
+  // Implementation details of the make_xxx container factories.
   namespace private_make
   {
+    // Selects the element type, following the Library Fundamentals TS
+    // make_array design: TDesired if it was supplied explicitly, otherwise the
+    // common type of the arguments (common_type decays). The specialisation
+    // keeps common_type uninstantiated when TDesired is supplied, so arguments
+    // with no common type are still accepted in that case.
     template <typename TDesired, typename... TArgs>
     struct element_type
     {
@@ -3767,12 +3768,28 @@ namespace etl
     };
 
     template <typename... TArgs>
-    struct element_type<void, TArgs...> : etl::common_type<typename etl::decay<TArgs>::type...>
+    struct element_type<void, TArgs...> : etl::common_type<TArgs...>
     {
     };
 
     template <typename TDesired, typename... TArgs>
     using element_type_t = typename element_type<TDesired, TArgs...>::type;
+
+    // Converts a factory argument to the element type. An argument that
+    // already has the element type is forwarded unchanged; any other argument
+    // is converted with static_cast, which keeps narrowing initialisers such
+    // as make_array<char>(0, 1) working. Forwarding rather than casting in the
+    // same-type case avoids materialising a temporary, which before C++17
+    // requires an accessible copy or move constructor even though the copy is
+    // elided, and would reject copyable-but-non-movable element types.
+    template <typename TElement, typename TValue>
+    using convert_type_t = typename etl::conditional<etl::is_same<typename etl::decay<TValue>::type, TElement>::value, TValue&&, TElement>::type;
+
+    template <typename TElement, typename TValue>
+    constexpr convert_type_t<TElement, TValue> convert(TValue&& value)
+    {
+      return static_cast<convert_type_t<TElement, TValue>>(value);
+    }
   } // namespace private_make
 #endif
 

--- a/include/etl/type_traits.h
+++ b/include/etl/type_traits.h
@@ -3751,6 +3751,29 @@ namespace etl
 
   template <typename... T>
   using common_type_t = typename common_type<T...>::type;
+
+  //***********************************
+  // Selects the element type for the make_xxx container factories, following
+  // the Library Fundamentals TS make_array design: TDesired if it was supplied
+  // explicitly, otherwise the decayed common type of the arguments. The
+  // specialisation keeps common_type uninstantiated when TDesired is supplied,
+  // so arguments with no common type are still accepted in that case.
+  namespace private_make
+  {
+    template <typename TDesired, typename... TArgs>
+    struct element_type
+    {
+      using type = TDesired;
+    };
+
+    template <typename... TArgs>
+    struct element_type<void, TArgs...> : etl::common_type<typename etl::decay<TArgs>::type...>
+    {
+    };
+
+    template <typename TDesired, typename... TArgs>
+    using element_type_t = typename element_type<TDesired, TArgs...>::type;
+  } // namespace private_make
 #endif
 
   //***************************************************************************

--- a/include/etl/vector.h
+++ b/include/etl/vector.h
@@ -2004,8 +2004,9 @@ namespace etl
   {
     // Library Fundamentals TS make_array design: the element type is T when
     // supplied explicitly, otherwise the decayed common type of the arguments.
+    // convert forwards same-type arguments and static_casts the rest.
     using TElement = etl::private_make::element_type_t<T, TValues...>;
-    return {static_cast<TElement>(etl::forward<TValues>(values))...};
+    return {etl::private_make::convert<TElement>(etl::forward<TValues>(values))...};
   }
 #endif
 

--- a/include/etl/vector.h
+++ b/include/etl/vector.h
@@ -1999,10 +1999,13 @@ namespace etl
   /// Make
   //*************************************************************************
 #if ETL_USING_CPP11 && ETL_HAS_INITIALIZER_LIST
-  template <typename... T>
-  constexpr auto make_vector(T&&... t) -> etl::vector<typename etl::common_type_t<T...>, sizeof...(T)>
+  template <typename T = void, typename... TValues>
+  constexpr auto make_vector(TValues&&... values) -> etl::vector<etl::private_make::element_type_t<T, TValues...>, sizeof...(TValues)>
   {
-    return {etl::forward<T>(t)...};
+    // Library Fundamentals TS make_array design: the element type is T when
+    // supplied explicitly, otherwise the decayed common type of the arguments.
+    using TElement = etl::private_make::element_type_t<T, TValues...>;
+    return {static_cast<TElement>(etl::forward<TValues>(values))...};
   }
 #endif
 

--- a/test/test_array.cpp
+++ b/test/test_array.cpp
@@ -998,6 +998,25 @@ namespace
 #endif
 
     //*************************************************************************
+#if ETL_HAS_INITIALIZER_LIST
+    // With no explicit element type, the element type is deduced as the
+    // decayed common type of the arguments (Library Fundamentals TS
+    // make_array design).
+    TEST(test_make_array_deduced_element_type)
+    {
+      static const int static_const_lvalue = 1;
+
+      auto data = etl::make_array(static_const_lvalue, 2L, 3);
+
+      CHECK((std::is_same<etl::array<long, 3U>, decltype(data)>::value));
+
+      CHECK_EQUAL(1L, data[0]);
+      CHECK_EQUAL(2L, data[1]);
+      CHECK_EQUAL(3L, data[2]);
+    }
+#endif
+
+    //*************************************************************************
 #if ETL_HAS_INITIALIZER_LIST && ETL_USING_CPP14
     TEST(test_make_array_is_constexpr)
     {

--- a/test/test_array.cpp
+++ b/test/test_array.cpp
@@ -1017,6 +1017,38 @@ namespace
 #endif
 
     //*************************************************************************
+#if ETL_HAS_INITIALIZER_LIST
+    // Arguments that already have the element type are forwarded rather than
+    // cast. Casting created a prvalue that, before C++17, had to be
+    // materialised through the move constructor, so a copyable type with a
+    // deleted move constructor was rejected.
+    TEST(test_make_array_for_copyable_non_movable)
+    {
+      struct NonMovable
+      {
+        explicit NonMovable(int v_)
+          : v(v_)
+        {
+        }
+        NonMovable(const NonMovable&) = default;
+        NonMovable(NonMovable&&)      = delete;
+        int v;
+      };
+
+      NonMovable       mutable_lvalue(1);
+      const NonMovable const_lvalue(2);
+
+      auto data = etl::make_array<NonMovable>(mutable_lvalue, const_lvalue);
+
+      using Type = etl::remove_reference_t<decltype(data[0])>;
+      CHECK((std::is_same<NonMovable, Type>::value));
+
+      CHECK_EQUAL(1, data[0].v);
+      CHECK_EQUAL(2, data[1].v);
+    }
+#endif
+
+    //*************************************************************************
 #if ETL_HAS_INITIALIZER_LIST && ETL_USING_CPP14
     TEST(test_make_array_is_constexpr)
     {

--- a/test/test_array.cpp
+++ b/test/test_array.cpp
@@ -1018,6 +1018,22 @@ namespace
 
     //*************************************************************************
 #if ETL_HAS_INITIALIZER_LIST
+    // An empty array requires the element type to be supplied explicitly.
+    // etl::make_array() with no element type and no arguments is ill-formed,
+    // as in the Library Fundamentals TS: there is nothing to deduce the
+    // element type from.
+    TEST(test_make_array_empty)
+    {
+      auto data = etl::make_array<int>();
+
+      CHECK((std::is_same<etl::array<int, 0U>, decltype(data)>::value));
+      CHECK_TRUE(data.empty());
+      CHECK_EQUAL(0U, data.size());
+    }
+#endif
+
+    //*************************************************************************
+#if ETL_HAS_INITIALIZER_LIST
     // Arguments that already have the element type are forwarded rather than
     // cast. Casting created a prvalue that, before C++17, had to be
     // materialised through the move constructor, so a copyable type with a

--- a/test/test_deque.cpp
+++ b/test/test_deque.cpp
@@ -2347,6 +2347,25 @@ namespace
 #endif
 
     //*************************************************************************
+#if ETL_USING_CPP11 && ETL_HAS_INITIALIZER_LIST
+    // With no explicit element type, the element type is deduced as the
+    // decayed common type of the arguments (Library Fundamentals TS
+    // make_array design).
+    TEST(test_make_deque_deduced_element_type)
+    {
+      static const int static_const_lvalue = 1;
+
+      auto data = etl::make_deque(static_const_lvalue, 2L, 3);
+
+      CHECK((std::is_same<etl::deque<long, 3U>, decltype(data)>::value));
+
+      CHECK_EQUAL(1L, data[0]);
+      CHECK_EQUAL(2L, data[1]);
+      CHECK_EQUAL(3L, data[2]);
+    }
+#endif
+
+    //*************************************************************************
     TEST(test_fill)
     {
       DataNDC data(initial_data.begin(), initial_data.end());

--- a/test/test_forward_list.cpp
+++ b/test/test_forward_list.cpp
@@ -1557,6 +1557,30 @@ namespace
 #endif
 
     //*************************************************************************
+#if ETL_HAS_INITIALIZER_LIST
+    // An explicit element type selects the element type and converts every
+    // argument (Library Fundamentals TS make_array design), accepting
+    // const-qualified lvalues and narrowing initialisers.
+    TEST(test_make_forward_list_explicit_element_type)
+    {
+      static const char static_const_lvalue = 42;
+      const char        local_const_lvalue  = 43;
+      char              mutable_lvalue      = 44;
+
+      auto data = etl::make_forward_list<char>(static_const_lvalue, local_const_lvalue, mutable_lvalue, 45, 46);
+
+      CHECK((std::is_same<etl::forward_list<char, 5U>, decltype(data)>::value));
+
+      auto itr = data.begin();
+      CHECK_EQUAL(42, *itr++);
+      CHECK_EQUAL(43, *itr++);
+      CHECK_EQUAL(44, *itr++);
+      CHECK_EQUAL(45, *itr++);
+      CHECK_EQUAL(46, *itr++);
+    }
+#endif
+
+    //*************************************************************************
     TEST(test_forward_list_exception_types)
     {
       // Verify exception class hierarchy is correct

--- a/test/test_indirect_vector.cpp
+++ b/test/test_indirect_vector.cpp
@@ -1644,5 +1644,28 @@ namespace
       CHECK_EQUAL(44, data[2]);
     }
 #endif
+
+    //*************************************************************************
+#if ETL_USING_CPP11 && ETL_HAS_INITIALIZER_LIST
+    // An explicit element type selects the element type and converts every
+    // argument (Library Fundamentals TS make_array design), accepting
+    // const-qualified lvalues and narrowing initialisers.
+    TEST(test_make_indirect_vector_explicit_element_type)
+    {
+      static const char static_const_lvalue = 42;
+      const char        local_const_lvalue  = 43;
+      char              mutable_lvalue      = 44;
+
+      auto data = etl::make_indirect_vector<char>(static_const_lvalue, local_const_lvalue, mutable_lvalue, 45, 46);
+
+      CHECK((std::is_same<etl::indirect_vector<char, 5U>, decltype(data)>::value));
+
+      CHECK_EQUAL(42, data[0]);
+      CHECK_EQUAL(43, data[1]);
+      CHECK_EQUAL(44, data[2]);
+      CHECK_EQUAL(45, data[3]);
+      CHECK_EQUAL(46, data[4]);
+    }
+#endif
   }
 } // namespace

--- a/test/test_list.cpp
+++ b/test/test_list.cpp
@@ -2377,5 +2377,29 @@ namespace
       CHECK_EQUAL(3, data2.begin()->value);
     }
 #endif
+
+    //*************************************************************************
+#if ETL_HAS_INITIALIZER_LIST
+    // An explicit element type selects the element type and converts every
+    // argument (Library Fundamentals TS make_array design), accepting
+    // const-qualified lvalues and narrowing initialisers.
+    TEST(test_make_list_explicit_element_type)
+    {
+      static const char static_const_lvalue = 42;
+      const char        local_const_lvalue  = 43;
+      char              mutable_lvalue      = 44;
+
+      auto data = etl::make_list<char>(static_const_lvalue, local_const_lvalue, mutable_lvalue, 45, 46);
+
+      CHECK((std::is_same<etl::list<char, 5U>, decltype(data)>::value));
+
+      auto itr = data.begin();
+      CHECK_EQUAL(42, *itr++);
+      CHECK_EQUAL(43, *itr++);
+      CHECK_EQUAL(44, *itr++);
+      CHECK_EQUAL(45, *itr++);
+      CHECK_EQUAL(46, *itr++);
+    }
+#endif
   }
 } // namespace

--- a/test/test_vector.cpp
+++ b/test/test_vector.cpp
@@ -1531,8 +1531,12 @@ namespace
     {
       auto data = etl::make_vector<char>(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
 
+      // The explicit element type now selects the element type for all
+      // arguments (Library Fundamentals TS make_array design). Previously it
+      // pinned only the first argument's deduced type, and the element type
+      // was still the common type of the arguments - int for this call.
       using Type = typename std::remove_reference<decltype(data[0])>::type;
-      CHECK((std::is_same<int, Type>::value));
+      CHECK((std::is_same<char, Type>::value));
 
       CHECK_EQUAL(0, data[0]);
       CHECK_EQUAL(1, data[1]);
@@ -1587,6 +1591,29 @@ namespace
       CHECK_EQUAL(42, data[0]);
       CHECK_EQUAL(43, data[1]);
       CHECK_EQUAL(44, data[2]);
+    }
+#endif
+
+    //*************************************************************************
+#if ETL_HAS_INITIALIZER_LIST
+    // An explicit element type selects the element type and converts every
+    // argument (Library Fundamentals TS make_array design), accepting
+    // const-qualified lvalues and narrowing initialisers.
+    TEST(test_make_vector_explicit_element_type)
+    {
+      static const char static_const_lvalue = 42;
+      const char        local_const_lvalue  = 43;
+      char              mutable_lvalue      = 44;
+
+      auto data = etl::make_vector<char>(static_const_lvalue, local_const_lvalue, mutable_lvalue, 45, 46);
+
+      CHECK((std::is_same<etl::vector<char, 5U>, decltype(data)>::value));
+
+      CHECK_EQUAL(42, data[0]);
+      CHECK_EQUAL(43, data[1]);
+      CHECK_EQUAL(44, data[2]);
+      CHECK_EQUAL(45, data[3]);
+      CHECK_EQUAL(46, data[4]);
     }
 #endif
 


### PR DESCRIPTION
Followup for #1526.  Based on development, rather than master, because it depends upon #1526 and related MRs.

`make_array`, `make_deque`, `make_vector`, `make_list`, `make_forward_list` and `make_indirect_vector` now follow the Library Fundamentals TS s`td::experimental::make_array` design: a defaulted leading template parameter selects the element type explicitly, falling back to the decayed common type of the arguments when it is not supplied. A shared trait (`etl::private_make::element_type`) performs the selection lazily, so `common_type` is not instantiated when the element type is explicit.

This fixes the explicit-element-type calling style for the four common-type factories, where `make_vector<char>(lvalue)` never compiled: the explicit argument pinned the first pack parameter to `char`, making it a `char&&` that no lvalue can bind to. It also gives `make_array` and `make_deque` the deduced form (e.g. `make_array(1, 2L)` is `array<long, 2>`) for free. All arguments are converted with `static_cast`, as in the `make_array` const-lvalue fix, so const-qualified lvalues and narrowing initialisers work in both forms.

Intentional behaviour change: an explicit element type now converts every argument instead of pinning only the first. `make_vector<char>(0, 1, ...)` previously produced `vector<int>` - the explicit char affected only the first argument and the element type was still the common type
- and now produces `vector<char>`. *test_make_vector* documented the old behaviour and has been updated.

The keyed `set` and `map` factories are unchanged: their key/mapped types are separate mandatory template parameters ahead of a fully-deduced pack, so the explicit-type style already works, and retrofitting deduction there would interact with the defaulted comparator/hash parameters.

Adds explicit-element-type tests for the four common-type factories (`const`/non-`const` lvalues plus narrowing initialisers) and deduced-element-type tests for `make_array` and `make_deque`, and updates the four documented signatures.