### PR TITLE
CI: cancel superseded workflow runs

### DIFF
--- a/.github/workflows/bazel-gcc-c++23-no-stl.yml
+++ b/.github/workflows/bazel-gcc-c++23-no-stl.yml
@@ -30,6 +30,10 @@ on:
       - 'subprojects/**'
       - '.devcontainer/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
 
   build-bazel-gcc-cpp23-no-stl:

--- a/.github/workflows/clang-c++11.yml
+++ b/.github/workflows/clang-c++11.yml
@@ -30,6 +30,10 @@ on:
       - 'subprojects/**'
       - '.devcontainer/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
 
   build-clang-cpp11-linux-stl:

--- a/.github/workflows/clang-c++14.yml
+++ b/.github/workflows/clang-c++14.yml
@@ -30,6 +30,10 @@ on:
       - 'subprojects/**'
       - '.devcontainer/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
 
   build-clang-cpp14-linux-stl:

--- a/.github/workflows/clang-c++17.yml
+++ b/.github/workflows/clang-c++17.yml
@@ -30,6 +30,10 @@ on:
       - 'subprojects/**'
       - '.devcontainer/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
 
   build-clang-cpp17-linux-stl:

--- a/.github/workflows/clang-c++20.yml
+++ b/.github/workflows/clang-c++20.yml
@@ -30,6 +30,10 @@ on:
       - 'subprojects/**'
       - '.devcontainer/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
 
   build-clang-cpp20-linux-stl-libcxx:

--- a/.github/workflows/clang-c++23.yml
+++ b/.github/workflows/clang-c++23.yml
@@ -30,6 +30,10 @@ on:
       - 'subprojects/**'
       - '.devcontainer/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
 
   build-clang-cpp23-linux-stl-libcxx:

--- a/.github/workflows/clang-c++26.yml
+++ b/.github/workflows/clang-c++26.yml
@@ -30,6 +30,10 @@ on:
       - 'subprojects/**'
       - '.devcontainer/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
 
   build-clang-cpp26-linux-stl-libcxx:

--- a/.github/workflows/clang-format.yaml
+++ b/.github/workflows/clang-format.yaml
@@ -7,6 +7,10 @@ on:
     branches: [ master, development, pull-request/* ]
     types: [opened, synchronize, reopened]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   clang-format:
     name: clang-format

--- a/.github/workflows/clang-format_update.yaml
+++ b/.github/workflows/clang-format_update.yaml
@@ -3,6 +3,10 @@ name: clang-format-update
 on:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   clang-format:
     runs-on: ubuntu-24.04

--- a/.github/workflows/clang-syntax-checks.yml
+++ b/.github/workflows/clang-syntax-checks.yml
@@ -30,6 +30,10 @@ on:
       - 'subprojects/**'
       - '.devcontainer/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-clang-cpp03-linux-STL:
     name: Syntax Check - Clang C++03 Linux STL

--- a/.github/workflows/clang-tidy.yaml
+++ b/.github/workflows/clang-tidy.yaml
@@ -31,6 +31,10 @@ on:
       - 'subprojects/**'
       - '.devcontainer/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   clang-tidy:
     name: clang-tidy

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -31,9 +31,8 @@ on:
       - 'subprojects/**'
       - '.devcontainer/**'
 
-# Allow only one concurrent deployment to GitHub Pages
 concurrency:
-  group: coverage-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 # Grant GITHUB_TOKEN the minimum permissions needed at the workflow level

--- a/.github/workflows/deploy-etl-documentation.yml
+++ b/.github/workflows/deploy-etl-documentation.yml
@@ -6,7 +6,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   deploy:

--- a/.github/workflows/deploy-etl-documentation.yml
+++ b/.github/workflows/deploy-etl-documentation.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches: [ master ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/gcc-c++11.yml
+++ b/.github/workflows/gcc-c++11.yml
@@ -30,6 +30,10 @@ on:
       - 'subprojects/**'
       - '.devcontainer/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   
   build-gcc-cpp11-linux-stl:

--- a/.github/workflows/gcc-c++14.yml
+++ b/.github/workflows/gcc-c++14.yml
@@ -30,6 +30,10 @@ on:
       - 'subprojects/**'
       - '.devcontainer/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
 
   build-gcc-cpp14-linux-stl:

--- a/.github/workflows/gcc-c++17.yml
+++ b/.github/workflows/gcc-c++17.yml
@@ -30,6 +30,10 @@ on:
       - 'subprojects/**'
       - '.devcontainer/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
 
   build-gcc-cpp17-linux-stl:

--- a/.github/workflows/gcc-c++20.yml
+++ b/.github/workflows/gcc-c++20.yml
@@ -30,6 +30,10 @@ on:
       - 'subprojects/**'
       - '.devcontainer/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
 
   build-gcc-cpp20-linux-stl:

--- a/.github/workflows/gcc-c++23-armhf.yml
+++ b/.github/workflows/gcc-c++23-armhf.yml
@@ -30,6 +30,10 @@ on:
       - 'subprojects/**'
       - '.devcontainer/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
 
   build-gcc-cpp23-linux-no-stl-armhf:

--- a/.github/workflows/gcc-c++23-i386.yml
+++ b/.github/workflows/gcc-c++23-i386.yml
@@ -30,6 +30,10 @@ on:
       - 'subprojects/**'
       - '.devcontainer/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
 
   build-gcc-cpp23-linux-no-stl-i386:

--- a/.github/workflows/gcc-c++23-powerpc.yml
+++ b/.github/workflows/gcc-c++23-powerpc.yml
@@ -30,6 +30,10 @@ on:
       - 'subprojects/**'
       - '.devcontainer/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
 
   build-gcc-cpp23-linux-no-stl-powerpc:

--- a/.github/workflows/gcc-c++23-riscv64.yml
+++ b/.github/workflows/gcc-c++23-riscv64.yml
@@ -30,6 +30,10 @@ on:
       - 'subprojects/**'
       - '.devcontainer/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
 
   build-gcc-cpp23-linux-no-stl-riscv64:

--- a/.github/workflows/gcc-c++23-s390x.yml
+++ b/.github/workflows/gcc-c++23-s390x.yml
@@ -30,6 +30,10 @@ on:
       - 'subprojects/**'
       - '.devcontainer/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
 
   build-gcc-cpp23-linux-no-stl-s390x:

--- a/.github/workflows/gcc-c++23.yml
+++ b/.github/workflows/gcc-c++23.yml
@@ -30,6 +30,10 @@ on:
       - 'subprojects/**'
       - '.devcontainer/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
 
   build-gcc-cpp23-linux-stl:

--- a/.github/workflows/gcc-c++26.yml
+++ b/.github/workflows/gcc-c++26.yml
@@ -30,6 +30,10 @@ on:
       - 'subprojects/**'
       - '.devcontainer/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
 
   build-gcc-cpp26-linux-stl:

--- a/.github/workflows/gcc-syntax-checks.yml
+++ b/.github/workflows/gcc-syntax-checks.yml
@@ -30,6 +30,10 @@ on:
       - 'subprojects/**'
       - '.devcontainer/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-gcc-cpp03-linux-STL:
     name: Syntax Check - GCC C++03 Linux STL

--- a/.github/workflows/generator.yml
+++ b/.github/workflows/generator.yml
@@ -6,6 +6,10 @@ on:
     branches: [ master, pull-request/* ]
     types: [opened, synchronize, reopened]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   generator-run:
     name: Header Generator

--- a/.github/workflows/meson-gcc-c++23-no-stl.yml
+++ b/.github/workflows/meson-gcc-c++23-no-stl.yml
@@ -30,6 +30,10 @@ on:
       - 'subprojects/**'
       - '.devcontainer/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
 
   build-meson-gcc-cpp23-no-stl:

--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -30,6 +30,10 @@ on:
       - 'subprojects/**'
       - '.devcontainer/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-windows-msvc-stl:
     name: Windows - STL

--- a/.github/workflows/platformio-update.yml
+++ b/.github/workflows/platformio-update.yml
@@ -4,6 +4,10 @@ on:
   release:
     types: [published]  # Trigger only when a GitHub release is published
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/docs/_index.md
+++ b/docs/_index.md
@@ -4,8 +4,6 @@ weight: 998
 type: hextra-home
 ---
 
-<meta name="algolia-site-verification"  content="00F8AEB171531498" />
-
 <div class="not-prose badges">
 
 <div>

--- a/docs/_index.md
+++ b/docs/_index.md
@@ -4,6 +4,8 @@ weight: 998
 type: hextra-home
 ---
 
+<meta name="algolia-site-verification"  content="00F8AEB171531498" />
+
 <div class="not-prose badges">
 
 <div>


### PR DESCRIPTION
## Summary
Solves issue https://github.com/ETLCPP/etl/issues/1536

This pull request updates the GitHub Actions workflows to standardize and improve concurrency handling across all CI/CD pipelines. The main change is the consistent addition of a `concurrency` group configuration to prevent duplicate or overlapping workflow runs for the same branch or pull request, ensuring that only the latest run is in progress.

**Workflow concurrency improvements:**

* Added a `concurrency` section to all workflow YAML files, using the pattern `group: ${{ github.workflow }}-${{ github.ref }}` and `cancel-in-progress: true` to ensure that only one workflow run per branch or PR is active at a time. This change was applied to all build, test, formatting, linting, and deployment workflows. [[1]](diffhunk://#diff-e66824e285dc210dc5be3806b93eaf0d4d0845009804553b79c75ec6656ffac1R9-R12) [[2]](diffhunk://#diff-05507b87e7666310e6c56f9938b534d9c0cee58f49cf67fcc030114acc94cc62R9-R12) [[3]](diffhunk://#diff-31b976bd8a89cea53f17f50c519fd6328a73ebc644d20c60d3213b2bc7709701R9-R12) [[4]](diffhunk://#diff-cb3567e06e7830113f5af7d246348153bf4e8f4d5bc22a2e5be23ba52ac04b65R9-R12) [[5]](diffhunk://#diff-9fa6f63b9ad7e0be352f306b4133792a82dc3c6b3c2ff567984978a4659efd5bR9-R12) [[6]](diffhunk://#diff-659e7e7acf8173dd3b3acdd95dbb1435dcb73d54f6a88a0a8e763eccec050022R9-R12) [[7]](diffhunk://#diff-8a39a5edf6214b3250eed93814e9e17170153cdff1b09b9b5e536adbe369cfc7R9-R12) [[8]](diffhunk://#diff-72c9a31b248dab7bb0250c33f85e992db805d96aae0e82f6b815092b65850e37R10-R13) [[9]](diffhunk://#diff-698c4336bfc5f14b539b45b29a9210b47b6f73c87fd01acec95e62140ea67ef4R6-R9) [[10]](diffhunk://#diff-630fca813af159ca3fcf17effe10beadcbdb24f2cb7dbf57495a9ef409296517R9-R12) [[11]](diffhunk://#diff-cfd2469451c077b103cc59c348cd5d7db7bcdc8eceb2b0f57956ff0d4c5af0f9R10-R13) [[12]](diffhunk://#diff-a2115d277b5ca5a2f09a999e53440839cf332b94da177f3d1766334555b0f7c6L10-R11) [[13]](diffhunk://#diff-56c77401627e6a7a56a71ef62247044abf37c8b7cd760c291932a44ddf25afd7R7-R10) [[14]](diffhunk://#diff-21d90cd8921fcda2af19a30c4ebc3a8032c9baef5eb05545cc34eeef64660cc5R9-R12) [[15]](diffhunk://#diff-7631b840da34b02d2f0bd36bb0041e9a6917d3aa1e6b73ce74ab1f59557395ecR9-R12) [[16]](diffhunk://#diff-d0acd0410dc0f60fbd4757a93a0b52782fe01c3a23d8129a73219a80b3be885dR9-R12) [[17]](diffhunk://#diff-fc0aa3fdc85cc7a3429b026d83516945bf29a95a2cb786471f83aa55a03ac4a7R9-R12) [[18]](diffhunk://#diff-3f76ab854ff710c8feb7c25c3b3833d4256c6d6d179420b6755fb97184466fc8R9-R12) [[19]](diffhunk://#diff-7125bd2f31f8ef94ccfe0713627b3d2d43ece1406cb34d4c6730eb5c69973662R9-R12) [[20]](diffhunk://#diff-2639f00d0153392bcd265a834a2da77bb763a5c0a2ba67090fd8ea185764348bR9-R12)

**Consistency and minor cleanup:**

* Updated the `concurrency` group naming in the `coverage.yml` workflow to match the new convention.
* Removed a stray blank line at the end of the test steps in `clang-c++20.yml` and `clang-c++23.yml` for minor cleanup. [[1]](diffhunk://#diff-9fa6f63b9ad7e0be352f306b4133792a82dc3c6b3c2ff567984978a4659efd5bL219) [[2]](diffhunk://#diff-659e7e7acf8173dd3b3acdd95dbb1435dcb73d54f6a88a0a8e763eccec050022L193)

These changes help prevent wasted CI resources and avoid confusion from multiple workflow runs for the same branch or PR.