### PR TITLE
Set default compare for iconst_map

### DIFF
--- a/include/etl/const_map.h
+++ b/include/etl/const_map.h
@@ -48,7 +48,7 @@ SOFTWARE.
 
 namespace etl
 {
-  template <typename TKey, typename TMapped, typename TKeyCompare>
+  template <typename TKey, typename TMapped, typename TKeyCompare = etl::less<TKey>>
   class iconst_map
   {
   public:

--- a/include/etl/const_set.h
+++ b/include/etl/const_set.h
@@ -48,7 +48,7 @@ SOFTWARE.
 
 namespace etl
 {
-  template <typename TKey, typename TKeyCompare>
+  template <typename TKey, typename TKeyCompare = etl::less<TKey>>
   class iconst_set
   {
   public:

--- a/test/test_const_map.cpp
+++ b/test/test_const_map.cpp
@@ -112,6 +112,9 @@ namespace
   using mapped_type    = Data::mapped_type;
   using const_iterator = Data::const_iterator;
 
+  static_assert(etl::is_same<etl::iconst_map<key_type, mapped_type>, etl::iconst_map<key_type, mapped_type, etl::less<key_type>>>::value,
+                "default compare is not less");
+
   SUITE(test_const_map)
   {
     //*************************************************************************

--- a/test/test_const_multimap.cpp
+++ b/test/test_const_multimap.cpp
@@ -111,6 +111,9 @@ namespace
   using mapped_type    = Data::mapped_type;
   using const_iterator = Data::const_iterator;
 
+  static_assert(etl::is_same<etl::iconst_multimap<key_type, mapped_type>, etl::iconst_multimap<key_type, mapped_type, etl::less<key_type>>>::value,
+                "default compare is not less");
+
   SUITE(test_const_multimap)
   {
     //*************************************************************************

--- a/test/test_const_multiset.cpp
+++ b/test/test_const_multiset.cpp
@@ -114,6 +114,9 @@ namespace
   using key_type       = Data::key_type;
   using const_iterator = Data::const_iterator;
 
+  static_assert(etl::is_same<etl::iconst_multiset<key_type>, etl::iconst_multiset<key_type, etl::less<key_type>>>::value,
+                "default compare is not less");
+
   SUITE(test_const_multiset)
   {
     //*************************************************************************

--- a/test/test_const_set.cpp
+++ b/test/test_const_set.cpp
@@ -112,6 +112,8 @@ namespace
   using key_type       = Data::key_type;
   using const_iterator = Data::const_iterator;
 
+  static_assert(etl::is_same<etl::iconst_set<key_type>, etl::iconst_set<key_type, etl::less<key_type>>>::value, "default compare is not less");
+
   SUITE(test_const_set)
   {
     //*************************************************************************

--- a/test/test_flat_map.cpp
+++ b/test/test_flat_map.cpp
@@ -211,6 +211,8 @@ namespace
   //  return os;
   //}
 
+  static_assert(etl::is_same<etl::iflat_map<int, D1>, etl::iflat_map<int, D1, etl::less<int>>>::value, "default compare is not less");
+
   SUITE(test_flat_map)
   {
     NDC N0  = NDC("A");

--- a/test/test_flat_multimap.cpp
+++ b/test/test_flat_multimap.cpp
@@ -239,6 +239,8 @@ namespace
     return true;
   }
 
+  static_assert(etl::is_same<etl::iflat_multimap<int, D1>, etl::iflat_multimap<int, D1, etl::less<int>>>::value, "default compare is not less");
+
   SUITE(test_flat_multimap)
   {
     //*************************************************************************

--- a/test/test_flat_multiset.cpp
+++ b/test/test_flat_multiset.cpp
@@ -241,6 +241,8 @@ namespace
 
     std::vector<int> int_data;
 
+    static_assert(etl::is_same<etl::iflat_multiset<int>, etl::iflat_multiset<int, etl::less<int>>>::value, "default compare is not less");
+
     //*************************************************************************
     struct SetupFixture
     {

--- a/test/test_flat_set.cpp
+++ b/test/test_flat_set.cpp
@@ -261,6 +261,8 @@ namespace
       return (lhs.value < rhs.k.value);
     }
 
+    static_assert(etl::is_same<etl::iflat_set<int>, etl::iflat_set<int, etl::less<int>>>::value, "default compare is not less");
+
     //*************************************************************************
     struct SetupFixture
     {


### PR DESCRIPTION
This is consistent with (i)flat_map, and allows to just write iconst_map<K, V>.