### PR TITLE
Allow easier construction of const_(multi_)map

### DIFF
--- a/include/etl/const_map.h
+++ b/include/etl/const_map.h
@@ -508,7 +508,8 @@ namespace etl
 
     //*************************************************************************
     ///\brief Construct a const_map from a variadic list of elements.
-    /// Static asserts if the elements are not of type <code>value_type</code>.
+    /// Static asserts if the elements are not constructible into
+    /// <code>value_type</code>.
     /// Static asserts if the number of elements is greater than the capacity of
     /// the const_map.
     //*************************************************************************
@@ -517,7 +518,8 @@ namespace etl
       : iconst_map<TKey, TMapped, TKeyCompare>(element_list, sizeof...(elements), Size)
       , element_list{etl::forward<TElements>(elements)...}
     {
-      static_assert((etl::are_all_same<value_type, etl::decay_t<TElements>...>::value), "All elements must be value_type");
+      static_assert((etl::conjunction<etl::is_constructible<value_type, etl::decay_t<TElements>>...>::value),
+                    "All elements must be constructible into value_type");
       static_assert(sizeof...(elements) <= Size, "Number of elements exceeds capacity");
     }
 

--- a/include/etl/const_multimap.h
+++ b/include/etl/const_multimap.h
@@ -458,7 +458,8 @@ namespace etl
     //*************************************************************************
     ///\brief Construct a const_map from a variadic list of elements.
     /// Static asserts if the element type is not constructible.
-    /// Static asserts if the elements are not of type <code>value_type</code>.
+    /// Static asserts if the elements are not constructible into
+    /// <code>value_type</code>.
     /// Static asserts if the number of elements is greater than the capacity of
     /// the const_map.
     //*************************************************************************
@@ -467,7 +468,8 @@ namespace etl
       : iconst_multimap<TKey, TMapped, TKeyCompare>(element_list, sizeof...(elements), Size)
       , element_list{etl::forward<TElements>(elements)...}
     {
-      static_assert((etl::are_all_same<value_type, etl::decay_t<TElements>...>::value), "All elements must be value_type");
+      static_assert((etl::conjunction<etl::is_constructible<value_type, etl::decay_t<TElements>>...>::value),
+                    "All elements must be constructible into value_type");
       static_assert(sizeof...(elements) <= Size, "Number of elements exceeds capacity");
     }
 

--- a/test/test_const_map.cpp
+++ b/test/test_const_map.cpp
@@ -257,6 +257,27 @@ namespace
       CHECK_TRUE(data.max_size() == Max_Size);
       CHECK_FALSE(data.begin() == data.end());
     }
+
+    //*************************************************************************
+    TEST(test_cpp17_deduced_constructor_of_plain_pair)
+    {
+      static const etl::const_map   data{ETL_OR_STD::pair{Key('A'), 0}, ETL_OR_STD::pair{Key('B'), 1}, ETL_OR_STD::pair{Key('C'), 2},
+                                       ETL_OR_STD::pair{Key('D'), 3}, ETL_OR_STD::pair{Key('E'), 4}, ETL_OR_STD::pair{Key('F'), 5},
+                                       ETL_OR_STD::pair{Key('G'), 6}, ETL_OR_STD::pair{Key('H'), 7}, ETL_OR_STD::pair{Key('I'), 8},
+                                       ETL_OR_STD::pair{Key('J'), 9}};
+      etl::const_map<Key, int, 10U> check{ETL_OR_STD::pair{Key('A'), 0}, ETL_OR_STD::pair{Key('B'), 1}, ETL_OR_STD::pair{Key('C'), 2},
+                                          ETL_OR_STD::pair{Key('D'), 3}, ETL_OR_STD::pair{Key('E'), 4}, ETL_OR_STD::pair{Key('F'), 5},
+                                          ETL_OR_STD::pair{Key('G'), 6}, ETL_OR_STD::pair{Key('H'), 7}, ETL_OR_STD::pair{Key('I'), 8},
+                                          ETL_OR_STD::pair{Key('J'), 9}};
+
+      CHECK_TRUE(data.is_valid());
+      CHECK_TRUE(data.size() == Max_Size);
+      CHECK_FALSE(data.empty());
+      CHECK_TRUE(data.full());
+      CHECK_TRUE(data.capacity() == Max_Size);
+      CHECK_TRUE(data.max_size() == Max_Size);
+      CHECK_FALSE(data.begin() == data.end());
+    }
 #endif
 
     //*************************************************************************

--- a/test/test_const_multimap.cpp
+++ b/test/test_const_multimap.cpp
@@ -226,6 +226,28 @@ namespace
       CHECK_TRUE(data.max_size() == Max_Size);
       CHECK_FALSE(data.begin() == data.end());
     }
+
+    //*************************************************************************
+    TEST(test_cpp17_deduced_constructor_of_plain_pair)
+    {
+      static const etl::const_multimap data{ETL_OR_STD::pair{Key('A'), 0}, ETL_OR_STD::pair{Key('B'), 1}, ETL_OR_STD::pair{Key('C'), 2},
+                                            ETL_OR_STD::pair{Key('D'), 3}, ETL_OR_STD::pair{Key('E'), 4}, ETL_OR_STD::pair{Key('F'), 5},
+                                            ETL_OR_STD::pair{Key('G'), 6}, ETL_OR_STD::pair{Key('G'), 7}, ETL_OR_STD::pair{Key('G'), 8},
+                                            ETL_OR_STD::pair{Key('J'), 9}};
+
+      etl::const_multimap<Key, int, 10U> check{ETL_OR_STD::pair{Key('A'), 0}, ETL_OR_STD::pair{Key('B'), 1}, ETL_OR_STD::pair{Key('C'), 2},
+                                               ETL_OR_STD::pair{Key('D'), 3}, ETL_OR_STD::pair{Key('E'), 4}, ETL_OR_STD::pair{Key('F'), 5},
+                                               ETL_OR_STD::pair{Key('G'), 6}, ETL_OR_STD::pair{Key('H'), 7}, ETL_OR_STD::pair{Key('I'), 8},
+                                               ETL_OR_STD::pair{Key('J'), 9}};
+
+      CHECK_TRUE(data.is_valid());
+      CHECK_TRUE(data.size() == Max_Size);
+      CHECK_FALSE(data.empty());
+      CHECK_TRUE(data.full());
+      CHECK_TRUE(data.capacity() == Max_Size);
+      CHECK_TRUE(data.max_size() == Max_Size);
+      CHECK_FALSE(data.begin() == data.end());
+    }
 #endif
 
     //*************************************************************************


### PR DESCRIPTION
When forcing to feed into value_types it has to be an ETL_OR_STD::pair<const K, V>, but when you want to use CTAD on the pairs the const is missing and the assert triggers.