### PR TITLE
Fix FreeRTOS.h/semphr.h include paths for ESP-IDF (fixes #1439)

### DIFF
--- a/include/etl/mutex/mutex_freertos.h
+++ b/include/etl/mutex/mutex_freertos.h
@@ -31,8 +31,26 @@ SOFTWARE.
 
 #include "../platform.h"
 
-#include "FreeRTOS.h"
-#include <semphr.h>
+#if defined(__has_include) // Compiler supports __has_include
+
+  #if __has_include(<FreeRTOS.h>) && __has_include(<semphr.h>) // Standard FreeRTOS include layout
+    #include <FreeRTOS.h>
+    #include <semphr.h>
+
+  #elif __has_include(<freertos/FreeRTOS.h>) && __has_include(<freertos/semphr.h>) // ESP-IDF style include layout
+    #include <freertos/FreeRTOS.h>
+    #include <freertos/semphr.h>
+
+  #else // Neither include layout found
+    #error "FreeRTOS.h and semphr.h not found. Please include path to FreeRTOS in your project settings"
+  #endif
+
+#else
+
+  #include <FreeRTOS.h>
+  #include <semphr.h>
+
+#endif
 
 namespace etl
 {


### PR DESCRIPTION
## Problem

`mutex_freertos.h` unconditionally includes the vanilla FreeRTOS header layout (`FreeRTOS.h` and `semphr.h` at the include root). On ESP-IDF and therefore Arduino-ESP32 too, since it's built on top of ESP-IDF these headers are nested one level deeper under `freertos/`. The flat path doesn't exist there, so any ESP32 target with `ETL_TARGET_OS_FREERTOS` defined fails to compile.

## Fix

Use `__has_include` to try the standard path first, fall back to the ESP-IDF nested path, and fail with a clear `#error` if neither is found

## Others

Also resolves a pre-existing include-style inconsistency in this file: the old code mixed "FreeRTOS.h" (quotes) with <semphr.h> (angle brackets). All includes now uniformly use angle brackets.

Confirmed via a full-repo search that `mutex_freertos.h` is the only file in `etl` that includes a real FreeRTOS header, self-contained fix, nothing else to update.
