### PR TITLE
Fix implicit conversion in binary rotations

### DIFF
--- a/include/etl/binary.h
+++ b/include/etl/binary.h
@@ -123,7 +123,7 @@ namespace etl
 
     ETL_CONSTANT size_t SHIFT = etl::integral_limits<typename etl::make_unsigned<T>::type>::bits - 1U;
 
-    return (value << 1U) | (value >> SHIFT);
+    return static_cast<T>((value << 1U) | (value >> SHIFT));
 #endif
   }
 
@@ -149,7 +149,7 @@ namespace etl
     }
     else
     {
-      return (value << distance) | (value >> SHIFT);
+      return static_cast<T>((value << distance) | (value >> SHIFT));
     }
 #endif
   }
@@ -168,7 +168,7 @@ namespace etl
 
     ETL_CONSTANT size_t SHIFT = etl::integral_limits<typename etl::make_unsigned<T>::type>::bits - 1U;
 
-    return (value >> 1U) | (value << SHIFT);
+    return static_cast<T>((value >> 1U) | (value << SHIFT));
 #endif
   }
 
@@ -194,7 +194,7 @@ namespace etl
     }
     else
     {
-      return (value >> distance) | (value << SHIFT);
+      return static_cast<T>((value >> distance) | (value << SHIFT));
     }
 #endif
   }


### PR DESCRIPTION
Explicitly cast rotated values to their input type before returning.
This prevents UBSan implicit conversion failures when etl::rotl and
etl::rotr operate on narrow unsigned types.

```bash
include/etl/binary.h:152:14: runtime error: implicit conversion from type 'int' of value 259 
(32-bit, signed) to type 'unsigned char' changed the value to 3 (8-bit, unsigned)
    #0 etl::rotate_left<unsigned char>(unsigned char, unsigned long)
       etl/include/etl/binary.h:152:14
    #1 etl::rotl<unsigned char>(unsigned char, int)
       etl/include/etl/bit.h:193:14
    #2 main rotate_narrowing_test.cpp:10:11
```
Test with:
```bash
clang++ -std=c++11 \
        -g -fno-omit-frame-pointer \
        -fsanitize=undefined,implicit-conversion \
        -fno-sanitize-recover=all \
        -Iinclude file/rotate_narrowing_test.cpp \
        -o test
```