### PR TITLE
Add referenced clamped values with shared ranges

### DIFF
--- a/docs/utilities/clamped-value.md
+++ b/docs/utilities/clamped-value.md
@@ -10,26 +10,27 @@ title: "clamped_value"
 Provides a value constrained between a minimum and maximum value. Values are
 clamped using `etl::clamp`. The type supports compile-time bounds to minimise
 storage and runtime bounds when the range must be changed. Integral types are
-supported in all language modes. Floating-point types are supported in C++20
-when `ETL_HAS_FLOATING_POINT_CLAMPED_VALUE` is `1`. By default, the macro is
-enabled when `__cpp_nontype_template_args` is at least `201911L`.
+supported in all language modes. Floating-point types with runtime bounds are
+supported in C++11 and later when `ETL_HAS_FLOATING_POINT_CLAMPED_VALUE` is
+`1`. Floating-point compile-time bounds require C++20 support for
+floating-point non-type template arguments.
 
 ## Availability
 
 `ETL_HAS_FLOATING_POINT_CLAMPED_VALUE` is always defined by this header as
-either `0` or `1`. It defaults to `1` only when C++20 is enabled and the
-compiler supports floating-point non-type template arguments. A platform
-profile or build may define the macro before including the header to override
-automatic detection.
+either `0` or `1`. It defaults to `1` in C++11 and later. The related
+`ETL_HAS_COMPILE_TIME_FLOATING_POINT_CLAMPED_VALUE` macro defaults to `1` only
+when C++20 is enabled and the compiler supports floating-point non-type
+template arguments. A platform profile or build may define either macro before
+including the header to override automatic detection.
 
-When the macro is `0`, `T` must be an integral type. When it is `1`, `float`,
-`double`, and `long double` may also be used.
+When `ETL_HAS_FLOATING_POINT_CLAMPED_VALUE` is `0`, `T` must be an integral
+type. When it is `1`, `float`, `double`, and `long double` may also be used with
+runtime bounds.
 
 ```cpp
-template <typename T,
-          T Min = T(),
-          T Max = T(),
-          bool RuntimeSpecialisation = ((Min == T()) && (Max == T()))>
+// C++11 and later
+template <typename T, T... Limits>
 class clamped_value;
 ```
 
@@ -39,8 +40,11 @@ etl::clamped_value<int, 2, 7> value_ct; // Fixed range [2, 7].
 etl::clamped_value<int> value_rt(2, 7, 5); // Runtime range and initial value.
 
 #if ETL_HAS_FLOATING_POINT_CLAMPED_VALUE
+etl::clamped_value<double> float_rt(-1.5, 2.5, 0.5);
+#endif
+
+#if ETL_HAS_COMPILE_TIME_FLOATING_POINT_CLAMPED_VALUE
 etl::clamped_value<float, -1.5f, 2.5f> float_ct(0.5f);
-etl::clamped_value<double>              float_rt(-1.5, 2.5, 0.5);
 #endif
 ```
 
@@ -67,13 +71,10 @@ clamped_value<int> value(min, max, initial);
 Creates a runtime clamped value. The two-argument form initializes the value
 to `min`; the three-argument form clamps `initial` to the range.
 
-`min` must not be greater than `max`. As with `cyclic_value`, zero-initialized
-`Min` and `Max` select the runtime-bound specialization; use a non-zero
-compile-time bound when a fixed compile-time range is needed. NaN bounds and
-initial values are rejected. Infinite bounds and values are permitted.
-
-Because zero-initialized `Min` and `Max` select runtime bounds, a fixed
-compile-time range `[0, 0]` cannot be represented by this dispatch scheme.
+`min` must not be greater than `max`. Omitting the template bounds selects the
+runtime-bound specialization. Supplying `Min` and `Max` selects fixed
+compile-time bounds. NaN bounds and initial values are rejected. Infinite
+bounds and values are permitted.
 
 ## Modifiers
 

--- a/docs/utilities/clamped-value.md
+++ b/docs/utilities/clamped-value.md
@@ -26,7 +26,8 @@ including the header to override automatic detection.
 
 When `ETL_HAS_FLOATING_POINT_CLAMPED_VALUE` is `0`, `T` must be an integral
 type. When it is `1`, `float`, `double`, and `long double` may also be used with
-runtime bounds.
+runtime bounds. `clamped_value_range<T>` and `referenced_clamped_value<T>` are
+available in C++11 and later.
 
 ```cpp
 // C++11 and later
@@ -48,12 +49,29 @@ etl::clamped_value<float, -1.5f, 2.5f> float_ct(0.5f);
 #endif
 ```
 
+In C++11 and later, multiple values can share one immutable runtime range:
+
+```cpp
+const etl::clamped_value_range<float> range(-1.5f, 2.5f);
+
+etl::referenced_clamped_value<float> value1(range, 0.5f);
+etl::referenced_clamped_value<float> value2(range, 1.5f);
+```
+
+`referenced_clamped_value<T>` stores an
+`etl::reference_wrapper<const clamped_value_range<T>>`. The range must outlive
+every value that refers to it. Construction from a temporary range is deleted.
+Copying or swapping a referenced value also copies or swaps its range reference.
+
 ## Types
 
 `difference_type` is the signed counterpart of `T` for integral values. For
 floating-point values, `difference_type` is `T`, allowing fractional steps.
 `limits_type` and `difference_limits_type` provide the corresponding
 `etl::numeric_limits` specializations.
+
+`referenced_clamped_value<T>` also defines `range_type` as
+`clamped_value_range<T>`.
 
 ## Constructors
 
@@ -76,6 +94,23 @@ runtime-bound specialization. Supplying `Min` and `Max` selects fixed
 compile-time bounds. NaN bounds and initial values are rejected. Infinite
 bounds and values are permitted.
 
+### Referenced ranges
+
+```cpp
+clamped_value_range<T> range(min, max);
+referenced_clamped_value<T> value(range);
+referenced_clamped_value<T> value(range, initial);
+```
+
+The one-argument value constructor initializes to `range.min()`. The
+two-argument form clamps `initial` to the shared range. A range is immutable
+after construction, so every referring value observes stable bounds. A
+default-constructed range uses the full representable range of `T`.
+
+`referenced_clamped_value<T>` is non-owning. The referenced range must outlive
+the value and any copies of it. The constructors taking `range_type&&` are
+deleted to prevent direct construction from a temporary range.
+
 ## Modifiers
 
 ```cpp
@@ -92,6 +127,10 @@ the value directly to a bound. For integral values, `advance` uses the signed
 counterpart of `T` as its step type. For floating-point values, the step type
 is `T` and may be fractional. Steps saturate in constant time at the minimum
 or maximum rather than wrapping. NaN steps are rejected.
+
+`referenced_clamped_value<T>` supports `set(T)`, `to_min()`, `to_max()`, and
+`advance(difference_type)`. It does not provide `set(min, max)` because its
+range is immutable and shared.
 
 Positive steps move toward `max`; negative steps move toward `min`. Infinite
 steps saturate at a finite bound. Infinite values and bounds remain valid.
@@ -122,6 +161,14 @@ ETL_NODISCARD T max() const noexcept;
 Gets the current value and its bounds. Both compile-time and runtime
 specializations provide these accessors as const-qualified member functions.
 
+`referenced_clamped_value<T>` additionally provides:
+
+```cpp
+ETL_NODISCARD const range_type& range() const noexcept;
+```
+
+This returns the exact `clamped_value_range<T>` object referenced by the value.
+
 ## Operators
 
 ```cpp
@@ -143,6 +190,8 @@ floating-point values, assignment and compound-assignment reject NaN.
 Prefix increment and decrement return a reference to the updated object.
 Postfix increment and decrement return a copy of the value before it was
 updated. All four operations move by one and saturate at the applicable bound.
+`referenced_clamped_value<T>` provides the same conversion, assignment,
+increment, decrement, and compound-assignment operators.
 
 ## Operations
 
@@ -152,6 +201,10 @@ ETL_CONSTEXPR14 void swap(clamped_value& lhs, clamped_value& rhs);
 ```
 
 Swaps clamped values. Runtime values also swap their bounds.
+
+Swapping two `referenced_clamped_value<T>` objects swaps both their current
+values and range references. Copy construction and copy assignment preserve
+the source's range identity; they do not copy the range itself.
 
 Equality, inequality, and relational comparisons are provided. Comparisons
 against arithmetic values use the implicit conversion to `T`. Equality
@@ -169,3 +222,124 @@ assignments, and steps also trigger an ETL assertion. Depending on the ETL
 error-handler configuration, an assertion may throw `etl::exception`, invoke a
 configured handler, or terminate. Operations that validate input are only
 `noexcept` when exceptions are disabled.
+
+The same validation applies when constructing `clamped_value_range<T>` and
+when assigning or advancing a `referenced_clamped_value<T>`.
+
+## Shared Referenced Ranges
+
+`clamped_value_range<T>` and `referenced_clamped_value<T>` are available in
+C++11 and later. They let independent values share immutable runtime bounds.
+
+### `clamped_value_range<T>`
+
+```cpp
+template <typename T>
+class clamped_value_range;
+```
+
+#### Constructors
+
+```cpp
+clamped_value_range();
+clamped_value_range(T min, T max);
+```
+
+The default constructor uses the full representable range of `T`. The
+two-argument constructor stores immutable bounds and rejects reversed or NaN
+bounds.
+
+#### Accessors
+
+```cpp
+ETL_NODISCARD T min() const noexcept;
+ETL_NODISCARD T max() const noexcept;
+```
+
+### `referenced_clamped_value<T>`
+
+```cpp
+template <typename T>
+class referenced_clamped_value;
+```
+
+The class stores a current value and an
+`etl::reference_wrapper<const clamped_value_range<T>>`. It does not own the
+range, which must outlive the value and all copies of it.
+
+Member types are `range_type`, `difference_type`, `limits_type`, and
+`difference_limits_type`, with the same numeric meanings as `clamped_value<T>`.
+
+#### Constructors
+
+```cpp
+explicit referenced_clamped_value(const range_type& range);
+referenced_clamped_value(const range_type& range, T initial);
+referenced_clamped_value(const referenced_clamped_value& other);
+
+referenced_clamped_value(range_type&&) = delete;
+referenced_clamped_value(range_type&&, T) = delete;
+```
+
+The one-argument constructor initializes to `range.min()`. The two-argument
+constructor clamps `initial`. Temporary ranges are rejected to prevent an
+immediately dangling reference. Copy construction preserves the source value
+and range identity.
+
+#### Modifiers
+
+```cpp
+void set(T value);
+void to_min() noexcept;
+void to_max() noexcept;
+void advance(difference_type n);
+```
+
+These operations mirror `clamped_value<T>`. There is no `set(min, max)` because
+the referenced range is immutable and shared.
+
+#### Accessors
+
+```cpp
+ETL_NODISCARD T get() const noexcept;
+ETL_NODISCARD T min() const noexcept;
+ETL_NODISCARD T max() const noexcept;
+ETL_NODISCARD const range_type& range() const noexcept;
+ETL_NODISCARD operator T() const noexcept;
+```
+
+`range()` returns the exact range object held by reference.
+
+#### Operators
+
+```cpp
+referenced_clamped_value& operator=(const referenced_clamped_value& other) & noexcept;
+referenced_clamped_value& operator=(T value) &;
+referenced_clamped_value& operator++() & noexcept;
+referenced_clamped_value operator++(int) noexcept;
+referenced_clamped_value& operator--() & noexcept;
+referenced_clamped_value operator--(int) noexcept;
+referenced_clamped_value& operator+=(difference_type n) &;
+referenced_clamped_value& operator-=(difference_type n) &;
+```
+
+Copy assignment copies both the current value and range reference. Arithmetic
+and value assignment clamp to the referenced bounds. Comparisons compare only
+current values, not range identity or bounds.
+
+#### Swap
+
+```cpp
+void swap(referenced_clamped_value& other) noexcept;
+void swap(referenced_clamped_value& lhs,
+          referenced_clamped_value& rhs) noexcept;
+```
+
+Swap exchanges both current values and range references, keeping each value
+associated with its original bounds.
+
+#### Errors
+
+Invalid or NaN range bounds trigger an ETL assertion. NaN initial values,
+assignments, and steps are also rejected. Infinite values follow the same
+behavior as `clamped_value<T>`.

--- a/include/etl/clamped_value.h
+++ b/include/etl/clamped_value.h
@@ -43,21 +43,32 @@ SOFTWARE.
 
 ///\def ETL_HAS_FLOATING_POINT_CLAMPED_VALUE
 /// Set to `1` when clamped_value supports floating-point types.
-/// Floating-point support requires C++20 non-type template arguments.
+/// Runtime floating-point support requires C++11 variadic templates.
 /// The macro may be defined by the build or platform profile to override
 /// automatic detection.
 #if !defined(ETL_HAS_FLOATING_POINT_CLAMPED_VALUE)
-  #if ETL_USING_CPP20 && defined(__cpp_nontype_template_args) && (__cpp_nontype_template_args >= 201911L)
+  #if ETL_USING_CPP11
     #define ETL_HAS_FLOATING_POINT_CLAMPED_VALUE 1
   #else
     #define ETL_HAS_FLOATING_POINT_CLAMPED_VALUE 0
   #endif
 #endif
 
+///\def ETL_HAS_COMPILE_TIME_FLOATING_POINT_CLAMPED_VALUE
+/// Set to `1` when clamped_value supports floating-point compile-time bounds.
+#if !defined(ETL_HAS_COMPILE_TIME_FLOATING_POINT_CLAMPED_VALUE)
+  #if ETL_HAS_FLOATING_POINT_CLAMPED_VALUE && ETL_USING_CPP20 && defined(__cpp_nontype_template_args) && (__cpp_nontype_template_args >= 201911L)
+    #define ETL_HAS_COMPILE_TIME_FLOATING_POINT_CLAMPED_VALUE 1
+  #else
+    #define ETL_HAS_COMPILE_TIME_FLOATING_POINT_CLAMPED_VALUE 0
+  #endif
+#endif
+
 ///\defgroup clamped_value clamped_value
 /// Provides a value that is clamped between two limits.
 /// Integral types are supported in all language modes. Floating-point types
-/// are supported when ETL_HAS_FLOATING_POINT_CLAMPED_VALUE is `1`.
+/// with runtime bounds are supported when
+/// ETL_HAS_FLOATING_POINT_CLAMPED_VALUE is `1`.
 /// \ingroup utilities
 
 namespace etl
@@ -235,22 +246,32 @@ namespace etl
   } // namespace private_clamped_value
   /// \endcond
 
-#include "private/diagnostic_float_equal_push.h"
+#if ETL_USING_CPP11
+  template <typename T, T... Limits>
+  class clamped_value;
+#else // ETL_NOT_USING_CPP11
+  #include "private/diagnostic_float_equal_push.h"
   template <typename T, T Min = T(), T Max = T(), bool RuntimeSpecialisation = ((Min == T()) && (Max == T()))>
   class clamped_value;
-#include "private/diagnostic_pop.h"
+  #include "private/diagnostic_pop.h"
+#endif
 
   //***************************************************************************
   /// Provides a value that is clamped between two compile-time limits.
   /// Supports incrementing, decrementing and arbitrary advance.
   ///@tparam T   An integral type, or a floating-point type when
-  ///            ETL_HAS_FLOATING_POINT_CLAMPED_VALUE is `1`.
+  ///            ETL_HAS_COMPILE_TIME_FLOATING_POINT_CLAMPED_VALUE is `1`.
   ///@tparam Min The minimum value of the range.
   ///@tparam Max The maximum value of the range.
   ///\ingroup clamped_value
   //***************************************************************************
+#if ETL_USING_CPP11
+  template <typename T, T Min, T Max>
+  class clamped_value<T, Min, Max>
+#else // ETL_NOT_USING_CPP11
   template <typename T, T Min, T Max>
   class clamped_value<T, Min, Max, false>
+#endif
   {
   public:
 
@@ -582,8 +603,13 @@ namespace etl
   ///@tparam Max Ignored for this specialisation.
   ///\ingroup clamped_value
   //***************************************************************************
+#if ETL_USING_CPP11
+  template <typename T>
+  class clamped_value<T>
+#else // ETL_NOT_USING_CPP11
   template <typename T, T Min, T Max>
   class clamped_value<T, Min, Max, true>
+#endif
   {
   public:
 

--- a/include/etl/clamped_value.h
+++ b/include/etl/clamped_value.h
@@ -35,6 +35,7 @@ SOFTWARE.
 #include "absolute.h"
 #include "algorithm.h"
 #include "error_handler.h"
+#include "functional.h"
 #include "limits.h"
 #include "math.h"
 #include "static_assert.h"
@@ -978,6 +979,400 @@ namespace etl
     T min_value;
     T max_value;
   };
+
+#if ETL_USING_CPP11
+  //***************************************************************************
+  /// An immutable pair of runtime limits that may be shared by multiple
+  /// referenced_clamped_value objects.
+  ///@tparam T An integral type, or a floating-point type when
+  ///           ETL_HAS_FLOATING_POINT_CLAMPED_VALUE is `1`.
+  ///\ingroup clamped_value
+  //***************************************************************************
+  template <typename T>
+  class clamped_value_range
+  {
+  public:
+
+    typedef typename private_clamped_value::traits<T>::limits_type limits_type;
+
+    //*************************************************************************
+    /// Constructs the full representable range of T.
+    //*************************************************************************
+    ETL_CONSTEXPR14 clamped_value_range()
+      : min_value(limits_type::lowest())
+      , max_value(limits_type::max())
+    {
+    }
+
+    //*************************************************************************
+    /// Constructs a range with the supplied limits.
+    /// Reversed bounds and NaN bounds are rejected.
+    ///\param min_ The minimum value.
+    ///\param max_ The maximum value.
+    //*************************************************************************
+    ETL_CONSTEXPR14 clamped_value_range(T min_, T max_)
+      : min_value(min_)
+      , max_value(max_)
+    {
+      private_clamped_value::validate(min_);
+      private_clamped_value::validate(max_);
+      ETL_ASSERT(min_ <= max_, ETL_ERROR_GENERIC("clamped_value_range: invalid range"));
+    }
+
+    //*************************************************************************
+    /// Gets the minimum value.
+    //*************************************************************************
+    ETL_NODISCARD ETL_CONSTEXPR T min() const ETL_NOEXCEPT
+    {
+      return min_value;
+    }
+
+    //*************************************************************************
+    /// Gets the maximum value.
+    //*************************************************************************
+    ETL_NODISCARD ETL_CONSTEXPR T max() const ETL_NOEXCEPT
+    {
+      return max_value;
+    }
+
+  private:
+
+    const T min_value;
+    const T max_value;
+  };
+
+  //***************************************************************************
+  /// Provides a value clamped to a shared immutable runtime range.
+  /// The referenced range must outlive this object.
+  ///@tparam T An integral type, or a floating-point type when
+  ///           ETL_HAS_FLOATING_POINT_CLAMPED_VALUE is `1`.
+  ///\ingroup clamped_value
+  //***************************************************************************
+  template <typename T>
+  class referenced_clamped_value
+  {
+  public:
+
+    /// The referenced range type.
+    typedef clamped_value_range<T> range_type;
+
+    /// The type used to advance or subtract from the stored value.
+    typedef typename private_clamped_value::traits<T>::difference_type difference_type;
+
+    /// Numeric limits for the stored value type.
+    typedef typename private_clamped_value::traits<T>::limits_type limits_type;
+
+    /// Numeric limits for difference_type.
+    typedef typename private_clamped_value::traits<T>::difference_limits_type difference_limits_type;
+
+    //*************************************************************************
+    /// Constructs a value initialized to the minimum of the referenced range.
+    ///\param range_ The range to reference. It must outlive this object.
+    //*************************************************************************
+    explicit referenced_clamped_value(const range_type& range_)
+      : value(range_.min())
+      , value_range(etl::cref(range_))
+    {
+    }
+
+    //*************************************************************************
+    /// Constructs a value clamped to the referenced range.
+    ///\param range_ The range to reference. It must outlive this object.
+    ///\param initial The initial value.
+    //*************************************************************************
+    referenced_clamped_value(const range_type& range_, T initial)
+      : value(private_clamped_value::validated_clamp(initial, range_.min(), range_.max()))
+      , value_range(etl::cref(range_))
+    {
+    }
+
+    //*************************************************************************
+    /// Prevents construction with a temporary range.
+    //*************************************************************************
+    referenced_clamped_value(range_type&&)    = delete;
+    referenced_clamped_value(range_type&&, T) = delete;
+
+    //*************************************************************************
+    /// Copies the value and its range reference.
+    ///\param other The value to copy.
+    //*************************************************************************
+    referenced_clamped_value(const referenced_clamped_value& other) ETL_NOEXCEPT
+      : value(other.value)
+      , value_range(other.value_range)
+    {
+    }
+
+    //*************************************************************************
+    /// Copy assignment. Copies the value and its range reference.
+    ///\param other The value and range reference to copy.
+    ///\return A reference to this value.
+    //*************************************************************************
+    referenced_clamped_value& operator=(const referenced_clamped_value& other) ETL_LVALUE_REF_QUALIFIER ETL_NOEXCEPT
+    {
+      if (this != &other)
+      {
+        value       = other.value;
+        value_range = other.value_range;
+      }
+
+      return *this;
+    }
+
+    //*************************************************************************
+    /// Sets the value and clamps it to the referenced range.
+    ///\param value_ The value to assign.
+    //*************************************************************************
+    void set(T value_)
+    {
+      value = private_clamped_value::validated_clamp(value_, min(), max());
+    }
+
+    //*************************************************************************
+    /// Resets the value to the minimum of the referenced range.
+    //*************************************************************************
+    void to_min() ETL_NOEXCEPT
+    {
+      value = min();
+    }
+
+    //*************************************************************************
+    /// Resets the value to the maximum of the referenced range.
+    //*************************************************************************
+    void to_max() ETL_NOEXCEPT
+    {
+      value = max();
+    }
+
+    //*************************************************************************
+    /// Advances the value and saturates it at the referenced bounds.
+    ///\param n The difference to add.
+    //*************************************************************************
+    void advance(difference_type n)
+    {
+      private_clamped_value::validate(n);
+      value = private_clamped_value::advance(value, min(), max(), n);
+    }
+
+    //*************************************************************************
+    /// Converts to the underlying value type.
+    ///\return The current value.
+    //*************************************************************************
+    ETL_NODISCARD operator T() const ETL_NOEXCEPT
+    {
+      return value;
+    }
+
+    //*************************************************************************
+    /// Advances by one and saturates at the maximum.
+    ///\return A reference to this value.
+    //*************************************************************************
+    referenced_clamped_value& operator++() ETL_LVALUE_REF_QUALIFIER ETL_NOEXCEPT
+    {
+      value = private_clamped_value::advance(value, min(), max(), difference_type(1));
+      return *this;
+    }
+
+    //*************************************************************************
+    /// Advances by one and returns the previous value.
+    ///\return The value before incrementing.
+    //*************************************************************************
+    referenced_clamped_value operator++(int) ETL_NOEXCEPT
+    {
+      referenced_clamped_value temp(*this);
+      ++(*this);
+      return temp;
+    }
+
+    //*************************************************************************
+    /// Subtracts one and saturates at the minimum.
+    ///\return A reference to this value.
+    //*************************************************************************
+    referenced_clamped_value& operator--() ETL_LVALUE_REF_QUALIFIER ETL_NOEXCEPT
+    {
+      value = private_clamped_value::advance(value, min(), max(), difference_type(-1));
+      return *this;
+    }
+
+    //*************************************************************************
+    /// Subtracts one and returns the previous value.
+    ///\return The value before decrementing.
+    //*************************************************************************
+    referenced_clamped_value operator--(int) ETL_NOEXCEPT
+    {
+      referenced_clamped_value temp(*this);
+      --(*this);
+      return temp;
+    }
+
+    //*************************************************************************
+    /// Assigns a value and clamps it to the referenced range.
+    ///\param value_ The value to assign.
+    ///\return A reference to this value.
+    //*************************************************************************
+    referenced_clamped_value& operator=(T value_) ETL_LVALUE_REF_QUALIFIER
+    {
+      set(value_);
+      return *this;
+    }
+
+    //*************************************************************************
+    /// Adds a difference and clamps to the referenced range.
+    ///\param n The difference to add.
+    ///\return A reference to this value.
+    //*************************************************************************
+    referenced_clamped_value& operator+=(difference_type n) ETL_LVALUE_REF_QUALIFIER
+    {
+      advance(n);
+      return *this;
+    }
+
+    //*************************************************************************
+    /// Subtracts a difference and clamps to the referenced range.
+    ///\param n The difference to subtract.
+    ///\return A reference to this value.
+    //*************************************************************************
+    referenced_clamped_value& operator-=(difference_type n) ETL_LVALUE_REF_QUALIFIER
+    {
+      private_clamped_value::validate(n);
+      value = private_clamped_value::subtract(value, min(), max(), n);
+      return *this;
+    }
+
+    //*************************************************************************
+    /// Gets the current value.
+    ///\return The current value.
+    //*************************************************************************
+    ETL_NODISCARD
+    T get() const ETL_NOEXCEPT
+    {
+      return value;
+    }
+
+    //*************************************************************************
+    /// Gets the minimum of the referenced range.
+    ///\return The minimum value.
+    //*************************************************************************
+    ETL_NODISCARD
+    T min() const ETL_NOEXCEPT
+    {
+      return value_range.get().min();
+    }
+
+    //*************************************************************************
+    /// Gets the maximum of the referenced range.
+    ///\return The maximum value.
+    //*************************************************************************
+    ETL_NODISCARD
+    T max() const ETL_NOEXCEPT
+    {
+      return value_range.get().max();
+    }
+
+    //*************************************************************************
+    /// Gets the referenced range.
+    ///\return The referenced range.
+    //*************************************************************************
+    ETL_NODISCARD
+    const range_type& range() const ETL_NOEXCEPT
+    {
+      return value_range.get();
+    }
+
+    //*************************************************************************
+    /// Swaps the values and range references.
+    ///\param other The value to swap with.
+    //*************************************************************************
+    void swap(referenced_clamped_value& other) ETL_NOEXCEPT
+    {
+      using ETL_OR_STD::swap;
+      swap(value, other.value);
+      swap(value_range, other.value_range);
+    }
+
+    //*************************************************************************
+    /// Swaps the values and range references.
+    ///\param lhs The first value.
+    ///\param rhs The second value.
+    //*************************************************************************
+    friend void swap(referenced_clamped_value& lhs, referenced_clamped_value& rhs) ETL_NOEXCEPT
+    {
+      lhs.swap(rhs);
+    }
+
+    //*************************************************************************
+    /// Compares current values for equality.
+    ///\param lhs The left-hand value.
+    ///\param rhs The right-hand value.
+    ///\return `true` if the current values are equal.
+    //*************************************************************************
+    friend bool operator==(const referenced_clamped_value& lhs, const referenced_clamped_value& rhs) ETL_NOEXCEPT
+    {
+  #include "private/diagnostic_float_equal_push.h"
+      return lhs.value == rhs.value;
+  #include "private/diagnostic_pop.h"
+    }
+
+    //*************************************************************************
+    /// Compares current values for inequality.
+    ///\param lhs The left-hand value.
+    ///\param rhs The right-hand value.
+    ///\return `true` if the current values differ.
+    //*************************************************************************
+    friend bool operator!=(const referenced_clamped_value& lhs, const referenced_clamped_value& rhs) ETL_NOEXCEPT
+    {
+      return !(lhs == rhs);
+    }
+
+    //*************************************************************************
+    /// Compares current values using less-than.
+    ///\param lhs The left-hand value.
+    ///\param rhs The right-hand value.
+    ///\return `true` if lhs is less than rhs.
+    //*************************************************************************
+    friend bool operator<(const referenced_clamped_value& lhs, const referenced_clamped_value& rhs) ETL_NOEXCEPT
+    {
+      return lhs.value < rhs.value;
+    }
+
+    //*************************************************************************
+    /// Compares current values using less-than-or-equal.
+    ///\param lhs The left-hand value.
+    ///\param rhs The right-hand value.
+    ///\return `true` if lhs is less than or equal to rhs.
+    //*************************************************************************
+    friend bool operator<=(const referenced_clamped_value& lhs, const referenced_clamped_value& rhs) ETL_NOEXCEPT
+    {
+      return !(rhs < lhs);
+    }
+
+    //*************************************************************************
+    /// Compares current values using greater-than.
+    ///\param lhs The left-hand value.
+    ///\param rhs The right-hand value.
+    ///\return `true` if lhs is greater than rhs.
+    //*************************************************************************
+    friend bool operator>(const referenced_clamped_value& lhs, const referenced_clamped_value& rhs) ETL_NOEXCEPT
+    {
+      return rhs < lhs;
+    }
+
+    //*************************************************************************
+    /// Compares current values using greater-than-or-equal.
+    ///\param lhs The left-hand value.
+    ///\param rhs The right-hand value.
+    ///\return `true` if lhs is greater than or equal to rhs.
+    //*************************************************************************
+    friend bool operator>=(const referenced_clamped_value& lhs, const referenced_clamped_value& rhs) ETL_NOEXCEPT
+    {
+      return !(lhs < rhs);
+    }
+
+  private:
+
+    T                                        value;
+    etl::reference_wrapper<const range_type> value_range;
+  };
+#endif
 } // namespace etl
 
 #endif

--- a/test/syntax_check/clamped_value.h.t.cpp
+++ b/test/syntax_check/clamped_value.h.t.cpp
@@ -31,6 +31,9 @@ SOFTWARE.
 #include <etl/clamped_value.h>
 
 #if ETL_HAS_FLOATING_POINT_CLAMPED_VALUE
+etl::clamped_value<double> clamped_double_run_time;
+#endif
+
+#if ETL_HAS_COMPILE_TIME_FLOATING_POINT_CLAMPED_VALUE
 etl::clamped_value<float, -1.0f, 1.0f> clamped_float_compile_time;
-etl::clamped_value<double>             clamped_double_run_time;
 #endif

--- a/test/syntax_check/clamped_value.h.t.cpp
+++ b/test/syntax_check/clamped_value.h.t.cpp
@@ -37,3 +37,13 @@ etl::clamped_value<double> clamped_double_run_time;
 #if ETL_HAS_COMPILE_TIME_FLOATING_POINT_CLAMPED_VALUE
 etl::clamped_value<float, -1.0f, 1.0f> clamped_float_compile_time;
 #endif
+
+#if ETL_USING_CPP11
+const etl::clamped_value_range<int> referenced_clamped_range(0, 10);
+etl::referenced_clamped_value<int>  referenced_clamped_int(referenced_clamped_range);
+
+  #if ETL_HAS_FLOATING_POINT_CLAMPED_VALUE
+const etl::clamped_value_range<float> referenced_clamped_float_range(-1.0f, 1.0f);
+etl::referenced_clamped_value<float>  referenced_clamped_float(referenced_clamped_float_range);
+  #endif
+#endif

--- a/test/test_clamped_value.cpp
+++ b/test/test_clamped_value.cpp
@@ -531,5 +531,157 @@ namespace
     }
   #endif
 #endif
+
+#if ETL_USING_CPP11
+    //*************************************************************************
+    TEST(test_referenced_clamped_value_uses_shared_range)
+    {
+      const etl::clamped_value_range<int> range(2, 7);
+      etl::referenced_clamped_value<int>  value1(range, 1);
+      etl::referenced_clamped_value<int>  value2(range, 8);
+
+      CHECK_EQUAL(2, value1.get());
+      CHECK_EQUAL(7, value2.get());
+      CHECK_EQUAL(2, value1.min());
+      CHECK_EQUAL(7, value1.max());
+      CHECK_EQUAL(&range, &value1.range());
+      CHECK_EQUAL(&range, &value2.range());
+    }
+
+    //*************************************************************************
+    TEST(test_referenced_clamped_value_arithmetic_saturates)
+    {
+      const etl::clamped_value_range<int> range(-2, 3);
+      etl::referenced_clamped_value<int>  value(range, 0);
+
+      value += 2;
+      CHECK_EQUAL(2, value.get());
+      ++value;
+      ++value;
+      CHECK_EQUAL(3, value.get());
+      value -= 4;
+      CHECK_EQUAL(-1, value.get());
+      --value;
+      --value;
+      CHECK_EQUAL(-2, value.get());
+    }
+
+    //*************************************************************************
+    TEST(test_referenced_clamped_value_modifiers_and_postfix_operators)
+    {
+      const etl::clamped_value_range<int> range(2, 7);
+      etl::referenced_clamped_value<int>  value(range);
+
+      CHECK_EQUAL(2, value.get());
+      value.set(4);
+      CHECK_EQUAL(4, value.get());
+
+      etl::referenced_clamped_value<int> previous = value++;
+      CHECK_EQUAL(4, previous.get());
+      CHECK_EQUAL(5, value.get());
+
+      previous = value--;
+      CHECK_EQUAL(5, previous.get());
+      CHECK_EQUAL(4, value.get());
+
+      value.to_max();
+      CHECK_EQUAL(7, value.get());
+      value.to_min();
+      CHECK_EQUAL(2, value.get());
+
+      value = 100;
+      CHECK_EQUAL(7, value.get());
+    }
+
+    //*************************************************************************
+    TEST(test_referenced_clamped_value_default_range_and_comparisons)
+    {
+      const etl::clamped_value_range<int> default_range;
+      const etl::clamped_value_range<int> range(0, 10);
+      etl::referenced_clamped_value<int>  value1(range, 3);
+      etl::referenced_clamped_value<int>  value2(range, 4);
+      const int                           converted = value1;
+
+      CHECK_EQUAL(etl::numeric_limits<int>::lowest(), default_range.min());
+      CHECK_EQUAL(etl::numeric_limits<int>::max(), default_range.max());
+      CHECK_EQUAL(3, converted);
+      CHECK(value1 == value1);
+      CHECK(value1 != value2);
+      CHECK(value1 < value2);
+      CHECK(value1 <= value2);
+      CHECK(value2 > value1);
+      CHECK(value2 >= value1);
+      CHECK(value1 < 4);
+      CHECK(3 == value1);
+    }
+
+    //*************************************************************************
+    TEST(test_referenced_clamped_value_copy_assignment_and_swap_ranges)
+    {
+      const etl::clamped_value_range<int> range1(0, 10);
+      const etl::clamped_value_range<int> range2(20, 30);
+      etl::referenced_clamped_value<int>  value1(range1, 4);
+      etl::referenced_clamped_value<int>  value2(range2, 24);
+
+      etl::referenced_clamped_value<int> copy(value1);
+      CHECK_EQUAL(&range1, &copy.range());
+      CHECK_EQUAL(4, copy.get());
+
+      copy = value2;
+      CHECK_EQUAL(&range2, &copy.range());
+      CHECK_EQUAL(24, copy.get());
+
+      swap(value1, value2);
+      CHECK_EQUAL(&range2, &value1.range());
+      CHECK_EQUAL(24, value1.get());
+      CHECK_EQUAL(&range1, &value2.range());
+      CHECK_EQUAL(4, value2.get());
+    }
+
+    //*************************************************************************
+    TEST(test_referenced_clamped_value_rejects_invalid_range)
+    {
+      CHECK_THROW((etl::clamped_value_range<int>(7, 2)), etl::exception);
+    }
+
+    //*************************************************************************
+    TEST(test_referenced_clamped_value_rejects_temporary_range)
+    {
+      typedef etl::clamped_value_range<int>      range_type;
+      typedef etl::referenced_clamped_value<int> value_type;
+
+      CHECK_FALSE((etl::is_constructible<value_type, range_type&&>::value));
+      CHECK_FALSE((etl::is_constructible<value_type, range_type&&, int>::value));
+    }
+
+  #if ETL_HAS_FLOATING_POINT_CLAMPED_VALUE
+    //*************************************************************************
+    TEST(test_referenced_floating_clamped_value)
+    {
+      const etl::clamped_value_range<float> range(-1.5F, 2.5F);
+      etl::referenced_clamped_value<float>  value(range, 0.5F);
+
+      value += 1.25F;
+      CHECK_CLOSE(1.75F, value.get(), 0.0001F);
+      value.advance(10.0F);
+      CHECK_CLOSE(2.5F, value.get(), 0.0001F);
+    }
+
+    //*************************************************************************
+    TEST(test_referenced_floating_clamped_value_rejects_nan)
+    {
+      const float nan = etl::numeric_limits<float>::quiet_NaN();
+
+      CHECK_THROW((etl::clamped_value_range<float>(nan, 1.0F)), etl::exception);
+
+      const etl::clamped_value_range<float> range(-1.0F, 1.0F);
+      CHECK_THROW((etl::referenced_clamped_value<float>(range, nan)), etl::exception);
+
+      etl::referenced_clamped_value<float> value(range, 0.0F);
+      CHECK_THROW(value = nan, etl::exception);
+      CHECK_THROW(value.advance(nan), etl::exception);
+    }
+  #endif
+#endif
   }
 } // namespace

--- a/test/test_clamped_value.cpp
+++ b/test/test_clamped_value.cpp
@@ -61,6 +61,17 @@ namespace
       CHECK_EQUAL(7, value.max());
     }
 
+#if ETL_USING_CPP11
+    //*************************************************************************
+    TEST(test_compile_time_zero_range)
+    {
+      etl::clamped_value<int, 0, 0> value(1);
+      CHECK_EQUAL(0, value.get());
+      CHECK_EQUAL(0, value.min());
+      CHECK_EQUAL(0, value.max());
+    }
+#endif
+
     //*************************************************************************
     TEST(test_run_time_initialisation)
     {
@@ -364,7 +375,7 @@ namespace
       CHECK_THROW(value.set(7, 2), etl::exception);
     }
 
-#if ETL_HAS_FLOATING_POINT_CLAMPED_VALUE
+#if ETL_HAS_COMPILE_TIME_FLOATING_POINT_CLAMPED_VALUE
     //*************************************************************************
     TEST(test_compile_time_floating_clamps_and_advances)
     {
@@ -381,7 +392,9 @@ namespace
       value.advance(10.0f);
       CHECK_CLOSE(2.5f, value.get(), 0.0001f);
     }
+#endif
 
+#if ETL_HAS_FLOATING_POINT_CLAMPED_VALUE
     //*************************************************************************
     TEST(test_runtime_floating_clamps_and_advances)
     {
@@ -396,45 +409,52 @@ namespace
       value.advance(-10.0);
       CHECK_CLOSE(-1.5, value.get(), 0.0001);
     }
+#endif
 
+#if ETL_HAS_COMPILE_TIME_FLOATING_POINT_CLAMPED_VALUE
     //*************************************************************************
-    TEST(test_floating_increment_and_decrement_saturate_at_fractional_bounds)
+    TEST(test_compile_time_floating_increment_saturates_at_fractional_bound)
     {
       etl::clamped_value<float, -0.5f, 0.5f> compile_time(0.25f);
-      etl::clamped_value<float>              run_time(-0.5f, 0.5f, -0.25f);
 
       ++compile_time;
-      --run_time;
 
       CHECK_CLOSE(0.5f, compile_time.get(), 0.0001f);
-      CHECK_CLOSE(-0.5f, run_time.get(), 0.0001f);
+    }
+#endif
+
+#if ETL_HAS_FLOATING_POINT_CLAMPED_VALUE
+    //*************************************************************************
+    TEST(test_runtime_floating_decrement_saturates_at_fractional_bound)
+    {
+      etl::clamped_value<float> value(-0.5f, 0.5f, -0.25f);
+
+      --value;
+
+      CHECK_CLOSE(-0.5f, value.get(), 0.0001f);
     }
 
     //*************************************************************************
-    TEST(test_floating_comparison_and_swap)
+    TEST(test_runtime_floating_comparison_and_swap)
     {
-      etl::clamped_value<double, -2.0, 2.0> compile_time1(-0.5);
-      etl::clamped_value<double, -2.0, 2.0> compile_time2(1.5);
-      etl::clamped_value<double>            run_time1(-3.0, 3.0, -1.0);
-      etl::clamped_value<double>            run_time2(4.0, 8.0, 6.0);
+      etl::clamped_value<double> value1(-3.0, 3.0, -1.0);
+      etl::clamped_value<double> value2(4.0, 8.0, 6.0);
 
-      CHECK(compile_time1 < compile_time2);
-      CHECK(compile_time1 < 1.0);
-      swap(compile_time1, compile_time2);
-      swap(run_time1, run_time2);
+      CHECK(value1 < value2);
+      CHECK(value1 < 1.0);
+      swap(value1, value2);
 
-      CHECK_CLOSE(1.5, compile_time1.get(), 0.0001);
-      CHECK_CLOSE(6.0, run_time1.get(), 0.0001);
-      CHECK_CLOSE(4.0, run_time1.min(), 0.0001);
-      CHECK_CLOSE(-1.0, run_time2.get(), 0.0001);
+      CHECK_CLOSE(6.0, value1.get(), 0.0001);
+      CHECK_CLOSE(4.0, value1.min(), 0.0001);
+      CHECK_CLOSE(-1.0, value2.get(), 0.0001);
     }
 
     //*************************************************************************
-    TEST(test_floating_infinity_saturates)
+    TEST(test_runtime_floating_infinity_saturates)
     {
-      const double                          infinity = etl::numeric_limits<double>::infinity();
-      etl::clamped_value<double, -2.0, 2.0> value(0.0);
-      etl::clamped_value<double>            infinite_range(-infinity, infinity, 0.0);
+      const double               infinity = etl::numeric_limits<double>::infinity();
+      etl::clamped_value<double> value(-2.0, 2.0, 0.0);
+      etl::clamped_value<double> infinite_range(-infinity, infinity, 0.0);
 
       value += infinity;
       CHECK_CLOSE(2.0, value.get(), 0.0001);
@@ -501,7 +521,7 @@ namespace
       CHECK(true);
     }
 
-  #if ETL_HAS_FLOATING_POINT_CLAMPED_VALUE
+  #if ETL_HAS_COMPILE_TIME_FLOATING_POINT_CLAMPED_VALUE
     //*************************************************************************
     TEST(test_floating_clamped_value_constexpr)
     {


### PR DESCRIPTION
## Summary

- add immutable `clamped_value_range<T>` bounds that can be shared by multiple values
- add non-owning `referenced_clamped_value<T>` with the runtime clamped-value operations
- reject temporary ranges to reduce dangling-reference risk
- document ownership, lifetime, constructors, accessors, modifiers, operators, comparisons, and errors

## Testing

- full unit test suite: 13,781 tests passed
- Clang syntax checks: C++03, C++11, C++14, C++17, and C++20
- strict GCC compilation: C++11 and C++20
- no-STL header compilation: C++11 and C++23
- clang-format and whitespace checks

Depends on ETLCPP/etl#1595.
References issue https://github.com/ETLCPP/etl/issues/1596