### PR TITLE
Exclude operator <=> from chrono when STL not available

### DIFF
--- a/include/etl/private/chrono/day.h
+++ b/include/etl/private/chrono/day.h
@@ -211,7 +211,7 @@ namespace etl
     //***********************************************************************
     /// Spaceship operator
     //***********************************************************************
-#if ETL_USING_CPP20
+#if ETL_USING_CPP20 && ETL_USING_STL
     [[nodiscard]]
     inline constexpr auto operator<=>(const etl::chrono::day& d1, const etl::chrono::day& d2) ETL_NOEXCEPT
     {

--- a/include/etl/private/chrono/duration.h
+++ b/include/etl/private/chrono/duration.h
@@ -482,7 +482,7 @@ namespace etl
   //***********************************************************************
   /// Spaceship operator
   //***********************************************************************
-#if ETL_USING_CPP20
+#if ETL_USING_CPP20 && ETL_USING_STL
   template <typename TRep1, typename TPeriod1, typename TRep2, typename TPeriod2>
   [[nodiscard]]
   constexpr auto operator<=>(const etl::chrono::duration<TRep1, TPeriod1>& lhs, const etl::chrono::duration<TRep2, TPeriod2>& rhs) ETL_NOEXCEPT

--- a/include/etl/private/chrono/month.h
+++ b/include/etl/private/chrono/month.h
@@ -224,7 +224,7 @@ namespace etl
     //***********************************************************************
     /// Spaceship operator
     //***********************************************************************
-#if ETL_USING_CPP20
+#if ETL_USING_CPP20 && ETL_USING_STL
     [[nodiscard]]
     inline constexpr auto operator<=>(const etl::chrono::month& d1, const etl::chrono::month& d2) ETL_NOEXCEPT
     {

--- a/include/etl/private/chrono/month_day.h
+++ b/include/etl/private/chrono/month_day.h
@@ -178,7 +178,7 @@ namespace etl
     //***********************************************************************
     /// Spaceship operator
     //***********************************************************************
-#if ETL_USING_CPP20
+#if ETL_USING_CPP20 && ETL_USING_STL
     [[nodiscard]]
     inline constexpr auto operator<=>(const etl::chrono::month_day& lhs, const etl::chrono::month_day& rhs) ETL_NOEXCEPT
     {
@@ -298,7 +298,7 @@ namespace etl
     //***********************************************************************
     /// Spaceship operator
     //***********************************************************************
-#if ETL_USING_CPP20
+#if ETL_USING_CPP20 && ETL_USING_STL
     [[nodiscard]]
     inline constexpr auto operator<=>(const etl::chrono::month_day_last& mdl1, const etl::chrono::month_day_last& mdl2) ETL_NOEXCEPT
     {

--- a/include/etl/private/chrono/time_point.h
+++ b/include/etl/private/chrono/time_point.h
@@ -353,7 +353,7 @@ namespace etl
   //***********************************************************************
   /// Spaceship operator
   //***********************************************************************
-#if ETL_USING_CPP20
+#if ETL_USING_CPP20 && ETL_USING_STL
   template <typename TClock, typename TDuration1, typename TDuration2>
   [[nodiscard]]
   constexpr auto operator<=>(const etl::chrono::time_point<TClock, TDuration1>& lhs, const etl::chrono::time_point<TClock, TDuration2>& rhs)

--- a/include/etl/private/chrono/year.h
+++ b/include/etl/private/chrono/year.h
@@ -240,7 +240,7 @@ namespace etl
     //***********************************************************************
     /// Spaceship operator
     //***********************************************************************
-#if ETL_USING_CPP20
+#if ETL_USING_CPP20 && ETL_USING_STL
     [[nodiscard]]
     inline constexpr auto operator<=>(const etl::chrono::year& y1, const etl::chrono::year& y2) ETL_NOEXCEPT
     {

--- a/include/etl/private/chrono/year_month.h
+++ b/include/etl/private/chrono/year_month.h
@@ -234,7 +234,7 @@ namespace etl
     //***********************************************************************
     /// Spaceship operator
     //***********************************************************************
-#if ETL_USING_CPP20
+#if ETL_USING_CPP20 && ETL_USING_STL
     [[nodiscard]]
     inline constexpr auto operator<=>(const etl::chrono::year_month& lhs, const etl::chrono::year_month& rhs) ETL_NOEXCEPT
     {

--- a/include/etl/private/chrono/year_month_day.h
+++ b/include/etl/private/chrono/year_month_day.h
@@ -426,7 +426,7 @@ namespace etl
     //***********************************************************************
     /// Spaceship operator
     //***********************************************************************
-#if ETL_USING_CPP20
+#if ETL_USING_CPP20 && ETL_USING_STL
     [[nodiscard]]
     inline constexpr auto operator<=>(const etl::chrono::year_month_day& lhs, const etl::chrono::year_month_day& rhs) ETL_NOEXCEPT
     {
@@ -722,7 +722,7 @@ namespace etl
     //***********************************************************************
     /// Spaceship operator
     //***********************************************************************
-#if ETL_USING_CPP20
+#if ETL_USING_CPP20 && ETL_USING_STL
     [[nodiscard]]
     inline constexpr auto operator<=>(const etl::chrono::year_month_day_last& lhs, const etl::chrono::year_month_day_last& rhs) ETL_NOEXCEPT
     {

--- a/test/test_chrono_day.cpp
+++ b/test/test_chrono_day.cpp
@@ -278,7 +278,7 @@ namespace
       CHECK_TRUE(day10 >= day10);
       CHECK_TRUE(day20 >= day10);
 
-#if ETL_USING_CPP20
+#if ETL_USING_CPP20 && ETL_USING_STL
       CHECK_TRUE((day10 <=> day10) == 0);
       CHECK_TRUE((day10 <=> day20) < 0);
       CHECK_TRUE((day20 <=> day10) > 0);

--- a/test/test_chrono_duration.cpp
+++ b/test/test_chrono_duration.cpp
@@ -1045,7 +1045,7 @@ namespace
       CHECK_EQUAL(1, s1.count()); // 10 seconds % (-3) seconds = 1 second
     }
 
-#if ETL_USING_CPP20
+#if ETL_USING_CPP20 && ETL_USING_STL
     //*************************************************************************
     TEST(test_duration_spaceship_operator)
     {

--- a/test/test_chrono_month.cpp
+++ b/test/test_chrono_month.cpp
@@ -303,7 +303,7 @@ namespace
       CHECK_TRUE(month1 >= month1);
       CHECK_TRUE(month2 >= month1);
 
-#if ETL_USING_CPP20
+#if ETL_USING_CPP20 && ETL_USING_STL
       CHECK_TRUE((month1 <=> month1) == 0);
       CHECK_TRUE((month1 <=> month2) < 0);
       CHECK_TRUE((month2 <=> month1) > 0);

--- a/test/test_chrono_month_day.cpp
+++ b/test/test_chrono_month_day.cpp
@@ -89,7 +89,7 @@ namespace
       CHECK_FALSE(md.ok()); // Invalid month_day
     }
 
-#if ETL_USING_CPP20
+#if ETL_USING_CPP20 && ETL_USING_STL
     //*************************************************************************
     TEST(test_month_day_spaceship_operator)
     {

--- a/test/test_chrono_time_point.cpp
+++ b/test/test_chrono_time_point.cpp
@@ -365,7 +365,7 @@ namespace
       CHECK_FALSE(tp10d >= tp20h);
       CHECK_FALSE(tp10h >= tp20d);
 
-#if ETL_USING_CPP20
+#if ETL_USING_CPP20 && ETL_USING_STL
       CHECK_TRUE((tp10h <=> tp10h) == 0);
       CHECK_TRUE((tp10h <=> tp20h) < 0);
       CHECK_TRUE((tp20h <=> tp10h) > 0);

--- a/test/test_chrono_year.cpp
+++ b/test/test_chrono_year.cpp
@@ -284,7 +284,7 @@ namespace
       CHECK_FALSE(year10 == year20);
       CHECK_TRUE(year10 != year20);
 
-#if ETL_USING_CPP20
+#if ETL_USING_CPP20 && ETL_USING_STL
       CHECK_TRUE((year10 <=> year10) == 0);
       CHECK_TRUE((year10 <=> year20) < 0);
       CHECK_TRUE((year20 <=> year10) > 0);

--- a/test/test_chrono_year_month.cpp
+++ b/test/test_chrono_year_month.cpp
@@ -89,7 +89,7 @@ namespace
       CHECK_FALSE(ym.ok()); // Invalid year_month
     }
 
-#if ETL_USING_CPP20
+#if ETL_USING_CPP20 && ETL_USING_STL
     //*************************************************************************
     TEST(test_year_month_spaceship_operator)
     {

--- a/test/test_chrono_year_month_day.cpp
+++ b/test/test_chrono_year_month_day.cpp
@@ -98,7 +98,7 @@ namespace
       CHECK_FALSE(ymd.ok()); // Invalid year_month_day
     }
 
-#if ETL_USING_CPP20
+#if ETL_USING_CPP20 && ETL_USING_STL
     //*************************************************************************
     TEST(test_year_month_day_spaceship_operator)
     {


### PR DESCRIPTION
[#1601](https://github.com/ETLCPP/etl/issues/1601)
